### PR TITLE
Devel df8 oe 0.0.219.26.x

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.h
+++ b/mchf-eclipse/drivers/audio/audio_driver.h
@@ -211,7 +211,7 @@ typedef struct SpectrumDisplay
 	ushort	wfall_line_update;	// used to set the number of lines per update on the waterfall
 	float	wfall_contrast;	// used to adjust the contrast of the waterfall display
 
-	ushort	waterfall_colours[NUMBER_WATERFALL_COLOURS];	// palette of colors for waterfall data
+	ushort	waterfall_colours[NUMBER_WATERFALL_COLOURS+1];	// palette of colors for waterfall data
 	float32_t	wfall_temp[FFT_IQ_BUFF_LEN/2];					// temporary holder for rescaling screen
 	ushort	waterfall[SPECTRUM_HEIGHT + WFALL_MEDIUM_ADDITIONAL +16][FFT_IQ_BUFF_LEN/2];	// circular buffer used for storing waterfall data - remember to increase this if the waterfall is made larger!
 

--- a/mchf-eclipse/drivers/ui/ui_driver.h
+++ b/mchf-eclipse/drivers/ui/ui_driver.h
@@ -630,6 +630,7 @@ void 	uiCodecMute(uchar val);
 void 	UiDriverSaveEepromValuesPowerDown(void);
 void	UiCheckForEEPROMLoadFreqModeDefaultRequest(void);
 void	UiCheckForPressedKey(void);
+void 	UiKeyBeep(void);
 //
 void 	UiCalcSubaudibleFreq(void);
 void 	UiLoadToneBurstMode(void);


### PR DESCRIPTION
Fixed a bug (array out of bounds error). This is detected by the compiler if -O3 is set and warnings are enabled.
Also a compiler warning due to missing function declaration.