### PR TITLE
Fixed a number of compiler warnings

### DIFF
--- a/mchf-eclipse/drivers/ui/oscillator/ui_si570.c
+++ b/mchf-eclipse/drivers/ui/oscillator/ui_si570.c
@@ -71,7 +71,7 @@ static uchar ui_si570_verify_frequency(void)
 	//printf("write %02x %02x %02x %02x %02x %02x\n\r",os.regs[0],os.regs[1],os.regs[2],os.regs[3],os.regs[4],os.regs[5]);
 	//printf("read  %02x %02x %02x %02x %02x %02x\n\r",regs[0],regs[1],regs[2],regs[3],regs[4],regs[5]);
 
-	if(memcmp(regs,os.regs,6) != 0)
+	if(memcmp(regs,(uchar*)os.regs,6) != 0)
 		return 1;
 
 	return 0;
@@ -367,6 +367,7 @@ static uchar ui_si570_change_frequency(float new_freq, uchar test)
    	curr_div 	= (ushort)ceilf (fdco_min / new_freq);
   	//printf("%d-%d -> ",curr_div,divider_max);
 
+   	bool found = false;
    	while (curr_div <= divider_max)
 	{
     	for(i = 0; i < 6; i++)
@@ -381,104 +382,106 @@ static uchar ui_si570_change_frequency(float new_freq, uchar test)
         	{
          		n1 = (uchar)curr_n1;
 				if((n1 == 1) || ((n1 & 1) == 0))
-					goto found;
+					found = true;
+					break;
          	}
       	}
 
       	curr_div++;
    	}
 
-   	CriticalError(102);
-
-found:
-
-	//printf("(%d) %d %d\n\r",curr_div,n1,hsdiv);
-
- 	// New RFREQ calculation
-	os.rfreq = ((long double)new_freq * (long double)(n1 * hsdiv)) / os.fxtal;
-   	//printf("%d\n\r",(int)os.rfreq);
-
-   	// Debug print calc freq
-   	//printf("%d\n\r",(int)((os.fxtal*os.rfreq)/(n1*hsdiv)));
-
-#ifdef LOWER_PRECISION
-   	ratio = new_freq / fout0;
-   	ratio = ratio * (((float)n1)/((float)os.init_n1));
-   	ratio = ratio * (((float)hsdiv)/((float)os.init_hsdiv));
-   	final_rfreq_long = ratio * os.init_rfreq;
-#endif
-
-   	for(i = 0; i < 6; i++)
-   		os.regs[i] = 0;
-
-   	hsdiv = hsdiv - 4;
-   	os.regs[0] = (hsdiv << 5);
-
-   	if(n1 == 1)
-     	n1 = 0;
-   	else if((n1 & 1) == 0)
-      	n1 = n1 - 1;
-
-   	os.regs[0] = ui_si570_setbits(os.regs[0], 0xE0, (n1 >> 2));
-   	os.regs[1] = (n1 & 3) << 6;
-
-#ifdef LOWER_PRECISION
-   	os.regs[1] = os.regs[1] | (final_rfreq_long >> 30);
-   	os.regs[2] = final_rfreq_long >> 22;
-   	os.regs[3] = final_rfreq_long >> 14;
-   	os.regs[4] = final_rfreq_long >> 6;
-   	os.regs[5] = final_rfreq_long << 2;
-#endif
-
-#ifdef HIGHER_PRECISION
-   	whole = floorf(os.rfreq);
-   	frac_bits = floorf((os.rfreq - whole) * POW_2_28);
-
-   	for(i = 5; i >= 3; i--)
+   	if (!found)
+   		CriticalError(102);
+   	else
    	{
-   		os.regs[i] = frac_bits & 0xFF;
-   		frac_bits = frac_bits >> 8;
-   	}
 
-   	os.regs[2] = ui_si570_setbits(os.regs[2], 0xF0, (frac_bits & 0xF));
-   	os.regs[2] = ui_si570_setbits(os.regs[2], 0x0F, (whole & 0xF) << 4);
-   	os.regs[1] = ui_si570_setbits(os.regs[1], 0xC0, (whole >> 4) & 0x3F);
-#endif
+		//printf("(%d) %d %d\n\r",curr_div,n1,hsdiv);
 
-   	//printf("write %02x %02x %02x %02x %02x %02x\n\r",os.regs[0],os.regs[1],os.regs[2],os.regs[3],os.regs[4],os.regs[5]);
+		// New RFREQ calculation
+		os.rfreq = ((long double)new_freq * (long double)(n1 * hsdiv)) / os.fxtal;
+		//printf("%d\n\r",(int)os.rfreq);
 
-   	// check to see if this tuning will result in a "large" tuning step, without setting the frequency
-   	if(test)
-   		return(ui_si570_is_large_change());
+		// Debug print calc freq
+		//printf("%d\n\r",(int)((os.fxtal*os.rfreq)/(n1*hsdiv)));
 
-   	//
-	if(ui_si570_is_large_change())
-	{
-		res = ui_si570_large_frequency_change();
-	}
-	else
-	{
-		res = ui_si570_small_frequency_change();
+	#ifdef LOWER_PRECISION
+		ratio = new_freq / fout0;
+		ratio = ratio * (((float)n1)/((float)os.init_n1));
+		ratio = ratio * (((float)hsdiv)/((float)os.init_hsdiv));
+		final_rfreq_long = ratio * os.init_rfreq;
+	#endif
 
-		// Maybe large change was needed, let's try it
-		if(res)	{
+		for(i = 0; i < 6; i++)
+			os.regs[i] = 0;
+
+		hsdiv = hsdiv - 4;
+		os.regs[0] = (hsdiv << 5);
+
+		if(n1 == 1)
+			n1 = 0;
+		else if((n1 & 1) == 0)
+			n1 = n1 - 1;
+
+		os.regs[0] = ui_si570_setbits(os.regs[0], 0xE0, (n1 >> 2));
+		os.regs[1] = (n1 & 3) << 6;
+
+	#ifdef LOWER_PRECISION
+		os.regs[1] = os.regs[1] | (final_rfreq_long >> 30);
+		os.regs[2] = final_rfreq_long >> 22;
+		os.regs[3] = final_rfreq_long >> 14;
+		os.regs[4] = final_rfreq_long >> 6;
+		os.regs[5] = final_rfreq_long << 2;
+	#endif
+
+	#ifdef HIGHER_PRECISION
+		whole = floorf(os.rfreq);
+		frac_bits = floorf((os.rfreq - whole) * POW_2_28);
+
+		for(i = 5; i >= 3; i--)
+		{
+			os.regs[i] = frac_bits & 0xFF;
+			frac_bits = frac_bits >> 8;
+		}
+
+		os.regs[2] = ui_si570_setbits(os.regs[2], 0xF0, (frac_bits & 0xF));
+		os.regs[2] = ui_si570_setbits(os.regs[2], 0x0F, (whole & 0xF) << 4);
+		os.regs[1] = ui_si570_setbits(os.regs[1], 0xC0, (whole >> 4) & 0x3F);
+	#endif
+
+		//printf("write %02x %02x %02x %02x %02x %02x\n\r",os.regs[0],os.regs[1],os.regs[2],os.regs[3],os.regs[4],os.regs[5]);
+
+		// check to see if this tuning will result in a "large" tuning step, without setting the frequency
+		if(test)
+			return(ui_si570_is_large_change());
+
+		//
+		if(ui_si570_is_large_change())
+		{
 			res = ui_si570_large_frequency_change();
 		}
-	}
+		else
+		{
+			res = ui_si570_small_frequency_change();
 
-	if(res)
-		return res;
+			// Maybe large change was needed, let's try it
+			if(res)	{
+				res = ui_si570_large_frequency_change();
+			}
+		}
 
-	// Verify second time - we might be transmitting, so
-	// it is absolutely unacceptable to be on startup
-	// SI570 frequency if any I2C error or chip reset occurs!
-	res = ui_si570_verify_frequency();
-	if(res == 0)
-		os.rfreq_old = os.rfreq;
+		if(res)
+			return res;
 
-	//if(res)
-	//	printf("---- error ----\n\r");
+		// Verify second time - we might be transmitting, so
+		// it is absolutely unacceptable to be on startup
+		// SI570 frequency if any I2C error or chip reset occurs!
+		res = ui_si570_verify_frequency();
+		if(res == 0)
+			os.rfreq_old = os.rfreq;
 
+		//if(res)
+		//	printf("---- error ----\n\r");
+		}
 	return res;
 }
 

--- a/mchf-eclipse/hardware/mchf_hw_i2c.c
+++ b/mchf-eclipse/hardware/mchf_hw_i2c.c
@@ -65,6 +65,7 @@ static uint32_t WaitLineIdle(void)
 		if (!(TimeOut--))
 			return 1;
 	}
+	return 0;
 }
 
 //*----------------------------------------------------------------------------
@@ -217,7 +218,7 @@ uchar mchf_hw_i2c_WriteRegister(uchar I2CAddr,uchar RegisterAddr, uchar Register
 	return 0;
 }
 
-uchar mchf_hw_i2c_WriteBlock(uchar I2CAddr,uchar RegisterAddr, uchar *data, ulong size)
+uchar mchf_hw_i2c_WriteBlock(uchar I2CAddr,uchar RegisterAddr, volatile uchar *data, ulong size)
 {
 	ulong i;
 
@@ -415,7 +416,7 @@ uchar mchf_hw_i2c_WriteBlock(uchar I2CAddr,uchar RegisterAddr, uchar *data, ulon
 //* Output Parameters   :
 //* Functions called    :
 //*----------------------------------------------------------------------------
-uchar mchf_hw_i2c_ReadRegister(uchar I2CAddr,uchar RegisterAddr, uchar *RegisterValue)
+uchar mchf_hw_i2c_ReadRegister(uchar I2CAddr,uchar RegisterAddr, volatile uchar *RegisterValue)
 {
 	//printf("i2c read\n\r");
 

--- a/mchf-eclipse/hardware/mchf_hw_i2c.h
+++ b/mchf-eclipse/hardware/mchf_hw_i2c.h
@@ -18,8 +18,8 @@ void 	mchf_hw_i2c_init(void);
 void 	mchf_hw_i2c_reset(void);
 
 uchar 	mchf_hw_i2c_WriteRegister(uchar I2CAddr,uchar RegisterAddr, uchar RegisterValue);
-uchar 	mchf_hw_i2c_WriteBlock(uchar I2CAddr,uchar RegisterAddr, uchar *data,ulong size);
-uchar 	mchf_hw_i2c_ReadRegister (uchar I2CAddr,uchar RegisterAddr, uchar *RegisterValue);
+uchar 	mchf_hw_i2c_WriteBlock(uchar I2CAddr,uchar RegisterAddr,volatile uchar *data,ulong size);
+uchar 	mchf_hw_i2c_ReadRegister (uchar I2CAddr,uchar RegisterAddr, volatile uchar *RegisterValue);
 uchar 	mchf_hw_i2c_ReadData(uchar I2CAddr,uchar RegisterAddr, uchar *data, ulong size);
 
 #endif

--- a/mchf-eclipse/hardware/mchf_hw_i2c2.c
+++ b/mchf-eclipse/hardware/mchf_hw_i2c2.c
@@ -437,9 +437,11 @@ return Data;
 }
 
 
+/*
 uint8_t Read_24Cxxseq(uint32_t start, uint8_t *buffer, uint16_t length, uint8_t Mem_Type)
 {
 }
+*/
 
 uint8_t Write_24Cxxseq(uint32_t address, uint8_t *buffer, uint16_t length, uint8_t Mem_Type)
 {


### PR DESCRIPTION
- Missing returns and potential uninitialized use of variables by adding proper return statements, declarations or defaults
- Changed some code to use break and if instead of goto to prevent  uninitialized use of variable n1
- Added some volatile keywords and casts to make compiler (and user) happy.