### PR TITLE
Fixed issue in copying values to/from eeprom (array-out-of-bounds)

### DIFF
--- a/mchf-eclipse/Makefile
+++ b/mchf-eclipse/Makefile
@@ -19,7 +19,7 @@ GCC_LIB_VERSION = 4.8
 
 # compilation options
 CFLAGS  = -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -mthumb -ffunction-sections -O0 \
- -DARM_MATH_CM4 -DSTM32F407VG -DSTM32F4XX -DUSE_STDPERIPH_DRIVER
+ -DARM_MATH_CM4 -DSTM32F407VG -DSTM32F4XX -DUSE_STDPERIPH_DRIVER -Wall $(EXTRACFLAGS)
 LDFLAGS := -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -mthumb
 LIBS := -Llibs -larm_cortexM4lf_math -L$(PREFIX)/arm-none-eabi/lib/armv7e-m/fpu \
  -L$(PREFIX)/lib/gcc/arm-none-eabi/$(GCC_LIB_VERSION)/armv7e-m/fpu -lm -lg -lc -lgcc
@@ -128,9 +128,15 @@ stdio/printf.c
 
 INC_DIRS = $(foreach d, $(SUBDIRS), -I$d)
 
-CC = ${PREFIX}/bin/arm-none-eabi-gcc
-OC = ${PREFIX}/bin/arm-none-eabi-objcopy
-
+ifdef SystemRoot
+	CC = arm-none-eabi-gcc
+	OC = arm-none-eabi-objcopy
+	OS = arm-none-eabi-size
+else
+	CC = ${PREFIX}/bin/arm-none-eabi-gcc
+	OC = ${PREFIX}/bin/arm-none-eabi-objcopy
+	OS = ${PREFIX}/bin/arm-none-eabi-size
+endif
 ifdef SystemRoot # case WINxx:
    RM = del /Q
    FixPath = $(subst /,\,$1)
@@ -156,6 +162,7 @@ $(LPRJ).elf: $(OBJS) $(SRC)
 	$(CC) $(LDFLAGS) -Tarm-gcc-link.ld -Xlinker --gc-sections -Llibs -Wl,-Map,${LPRJ}.map -o${LPRJ}.elf $(OBJS) $(LIBS)
 
 $(PRJ).bin: $(LPRJ).elf
+	$(OS) $<
 	$(OC) -v -O binary $< $(PRJ).bin
 
 # cleaning rule

--- a/mchf-eclipse/cmsis_boot/startup/startup_stm32f4xx.c
+++ b/mchf-eclipse/cmsis_boot/startup/startup_stm32f4xx.c
@@ -19,7 +19,6 @@
   ******************************************************************************
   */
     
-
 /*----------Stack Configuration-----------------------------------------------*/
 #define STACK_SIZE       0x00000400      /*!< Stack size (in Words)           */
 __attribute__ ((section(".co_stack")))
@@ -266,6 +265,8 @@ void (* const g_pfnVectors[])(void) =
   */
 void Default_Reset_Handler(void)
 {
+   __asm volatile ("MSR msp, %0\n" : : "r" ((void (*)(void))((unsigned long)pulStack + sizeof(pulStack))) );
+
   /* Initialize data and bss */
   unsigned long *pulSrc, *pulDest;
 

--- a/mchf-eclipse/hardware/mchf_board.c
+++ b/mchf-eclipse/hardware/mchf_board.c
@@ -999,29 +999,37 @@ uint16_t data;
 //uint8_t *p = malloc(MAX_VAR_ADDR*2+2);
 
 static uint8_t p[MAX_VAR_ADDR*2+2];
+// length of array is 383*2 + 2 = 768
+// to allow for the 2 eeprom signature bytes
+// stored at index 0/1
+
 
 uint16_t i;
-// copy virtual EEPROM to RAM
-for(i=1; i <= MAX_VAR_ADDR+1; i++)
-    {
-    EE_ReadVariable(VirtAddVarTab[i], &data);
-    p[i*2+1] = (uint8_t)((0x00FF)&data);
-    data = data>>8;
-    p[i*2] = (uint8_t)((0x00FF)&data);
-    }
+// copy virtual EEPROM to RAM, this reads out 383 values and stores them in  2 bytes
+for(i=1; i <= MAX_VAR_ADDR; i++)
+{
+	EE_ReadVariable(VirtAddVarTab[i], &data);
+	p[i*2+1] = (uint8_t)((0x00FF)&data);
+	data = data>>8;
+	p[i*2] = (uint8_t)((0x00FF)&data);
+}
 p[0] = Read_24Cxx(0,16);
 p[1] = Read_24Cxx(1,16);
 // write RAM to serial EEPROM
 if(seq == false)
-    {
-    for(i=0; i <= MAX_VAR_ADDR*2+2;i++)
-	Write_24Cxx(i, p[i], ts.ser_eeprom_type);
-    }
+{
+	for(i=0; i < MAX_VAR_ADDR*2+2;i++)
+	{
+		// this will write  out 768 bytes (2 signature  and 383*2 data)
+		Write_24Cxx(i, p[i], ts.ser_eeprom_type);
+	}
+}
 else
-    {
-    Write_24Cxxseq(0, p, MAX_VAR_ADDR*2+2, ts.ser_eeprom_type);
-    Write_24Cxx(0x180, p[0x180], ts.ser_eeprom_type);
-    }
+{
+	// this will write  out 768 bytes (2 signature  and 383*2 data)
+	Write_24Cxxseq(0, p, MAX_VAR_ADDR*2+2, ts.ser_eeprom_type);
+	Write_24Cxx(0x180, p[0x180], ts.ser_eeprom_type);
+}
 ts.ser_eeprom_in_use = 0;		// serial EEPROM in use now
 }
 

--- a/mchf-eclipse/usb/otg/src/usb_core.c
+++ b/mchf-eclipse/usb/otg/src/usb_core.c
@@ -555,8 +555,10 @@ uint32_t USB_OTG_ReadOtgItr (USB_OTG_CORE_HANDLE *pdev)
 USB_OTG_STS USB_OTG_CoreInitHost(USB_OTG_CORE_HANDLE *pdev)
 {
   USB_OTG_STS                     status = USB_OTG_OK;
+#if defined ( USB_OTG_FS_CORE ) || defined ( USB_OTG_HS_CORE )
   USB_OTG_FSIZ_TypeDef            nptxfifosize;
   USB_OTG_FSIZ_TypeDef            ptxfifosize;  
+#endif
   USB_OTG_HCFG_TypeDef            hcfg;
   
 #ifdef USE_OTG_MODE
@@ -564,9 +566,11 @@ USB_OTG_STS USB_OTG_CoreInitHost(USB_OTG_CORE_HANDLE *pdev)
 #endif
   
   uint32_t                        i = 0;
-  
+
+#if defined ( USB_OTG_FS_CORE ) || defined ( USB_OTG_HS_CORE )
   nptxfifosize.d32 = 0;  
   ptxfifosize.d32 = 0;
+#endif
 #ifdef USE_OTG_MODE
   gotgctl.d32 = 0;
 #endif
@@ -1140,15 +1144,19 @@ USB_OTG_STS USB_OTG_CoreInitDev (USB_OTG_CORE_HANDLE *pdev)
   USB_OTG_DEPCTL_TypeDef  depctl;
   uint32_t i;
   USB_OTG_DCFG_TypeDef    dcfg;
+#if defined ( USB_OTG_FS_CORE ) || defined ( USB_OTG_HS_CORE )
   USB_OTG_FSIZ_TypeDef    nptxfifosize;
   USB_OTG_FSIZ_TypeDef    txfifosize;
+#endif
   USB_OTG_DIEPMSK_TypeDef msk;
   USB_OTG_DTHRCTL_TypeDef dthrctl;  
   
   depctl.d32 = 0;
   dcfg.d32 = 0;
+#if defined ( USB_OTG_FS_CORE ) || defined ( USB_OTG_HS_CORE )
   nptxfifosize.d32 = 0;
   txfifosize.d32 = 0;
+#endif
   msk.d32 = 0;
   
   /* Restart the Phy Clock */

--- a/mchf-eclipse/usb/usb_conf.h
+++ b/mchf-eclipse/usb/usb_conf.h
@@ -78,7 +78,9 @@
 #elif defined (__ICCARM__)     /* IAR Compiler */
   #define __packed    __packed
 #elif defined   ( __GNUC__ )   /* GNU Compiler */
-  #define __packed    __attribute__ ((__packed__))
+	#if ! defined ( __packed )
+		#define __packed    __attribute__ ((__packed__))
+	#endif
 #elif defined   (__TASKING__)  /* TASKING Compiler */
   #define __packed    __unaligned
 #endif /* __CC_ARM */


### PR DESCRIPTION
Please review this carefully. The fixes was made without having an EEPROM available but should be good if indeed only MAX_VAR_ADDRS [currently 383] configuration values are supposed to carry meaningful data and should be stored. It also now contains the bootload issue fix. Now the test_*  vars can go to where they belong...