### PR TITLE
Slight cleanup of the (SPI) LCD code

### DIFF
--- a/mchf-eclipse/drivers/ui/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/ui_menu.c
@@ -3734,7 +3734,7 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode)
 		else	// beep not enabled - display frequency in red
 			clr = Orange;
 		//
-		sprintf(options, "   %u  ", (uint)ts.beep_frequency);
+		sprintf(options, "   %u  ", (uint32_t)ts.beep_frequency);
 		opt_pos = CONFIG_BEEP_FREQ % MENUSIZE;
 		break;
 	//


### PR DESCRIPTION
, replaced all single byte transfers of data with calls to the respective functions.
The Spi*Fast functions are not in use in this commit (but used in my testing).

Moved the delay in a section with disabled optimization at the end.
This may or may not solve the parallel display issue regarding optimization
with O3. Due to lack of parallel display I cannot test this.

No relevant changes for parallel mode.

Cosmetic change to ui_menu.c