### PR TITLE
Fixed a regression where the menu did not work properly (313 and 314).

### DIFF
--- a/mchf-eclipse/drivers/ui/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/ui_menu.c
@@ -2989,7 +2989,7 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode)
 		sprintf(options, "  %u", ts.dsp_notch_mu);
 		break;
 	case CONFIG_DSP_NOTCH_DECORRELATOR_BUFFER_LENGTH:		// Adjustment of DSP noise reduction de-correlation delay buffer length
-		tchange = UiDriverMenuItemChangeUInt8(var, mode, &ts.dsp_notch_mu,
+		tchange = UiDriverMenuItemChangeUInt8(var, mode, &ts.dsp_notch_delaybuf_len,
 				DSP_NOTCH_BUFLEN_MIN,
 				DSP_NOTCH_BUFLEN_MAX,
 				DSP_NOTCH_DELAYBUF_DEFAULT,


### PR DESCRIPTION
Was a copy'n'paste issue. Wrong variable was changed.

To check if similar issues are around: the sprintf at the end must use the same variable name which has been used by UiDriverMenuItemChange*Int* . 
The EnableOnOff/DisableOnOff etc. do the sprintf internally, so it will always print the variable being modified. But even this may be the wrong one but this is harder to check. You will have to look into older versions to identify issues here. Normally there is a good correlation between the CONFIG_... label and the variable name.