### PR TITLE
Replaced the existing USB files with similar ones in order to get a working virtual com port 

### DIFF
--- a/mchf-eclipse/Makefile
+++ b/mchf-eclipse/Makefile
@@ -70,7 +70,6 @@ usb/otg/src/usb_core.c \
 usb/otg/src/usb_hcd_int.c \
 usb/otg/src/usb_dcd.c \
 usb/otg/src/usb_dcd_int.c \
-usb/otg/src/usb_otg.c \
 usb/otg/src/usb_hcd.c \
 usb/usbd/core/src/usbd_core.c \
 usb/usbd/core/src/usbd_ioreq.c \

--- a/mchf-eclipse/drivers/cat/cat_driver.c
+++ b/mchf-eclipse/drivers/cat/cat_driver.c
@@ -20,7 +20,7 @@
 #include "usbd_usr.h"
 #include "usb_conf.h"
 #include "usbd_desc.h"
-
+#include "usbd_cdc_vcp.h"
 #include "cat_driver.h"
 
 __ALIGN_BEGIN USB_OTG_CORE_HANDLE    USB_OTG_dev __ALIGN_END ;
@@ -41,10 +41,6 @@ extern __IO CatDriver kd;
 	//EXTI_ClearITPendingBit(EXTI_Line18);
 //}
 
-void OTG_FS_IRQHandler(void)
-{
-	USBD_OTG_ISR_Handler (&USB_OTG_dev);
-}
 
 void cat_driver_init(void)
 {
@@ -70,4 +66,61 @@ void cat_driver_thread(void)
 {
 	if(!kd.enabled)
 		return;
+}
+
+#define CAT_BUFFER_SIZE 256
+__IO uint8_t cat_buffer[CAT_BUFFER_SIZE];
+__IO int32_t cat_head = 0;
+__IO int32_t cat_tail = 0;
+
+CatInterfaceState cat_driver_state() { return USBD_User_GetStatus(); }
+
+int cat_buffer_remove(uint8_t* c_ptr) {
+    if (cat_head != cat_tail) {
+        int c = cat_buffer[cat_tail];
+        cat_tail = (cat_tail + 1) % CAT_BUFFER_SIZE;
+        *c_ptr = (uint8_t)c;
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
+int cat_buffer_add(uint8_t c) {
+    int32_t next_head = (cat_head + 1) % CAT_BUFFER_SIZE;
+    if (next_head != cat_tail) {
+        /* there is room */
+        cat_buffer[cat_head] = c;
+        cat_head = next_head;
+        return 1;
+    } else {
+        /* no room left in the buffer */
+        return 0;
+    }
+}
+
+
+uint8_t cat_driver_get_data(uint8_t* Buf,uint32_t Len) {
+	uint8_t res = 0;
+	if (cat_driver_has_data() >= Len) {
+		int i;
+		for  (i = 0; i < Len; i++) {
+			cat_buffer_remove(&Buf[i]);
+		}
+		res = 1;
+	}
+	return res;
+}
+uint8_t cat_driver_put_data(uint8_t* Buf,uint32_t Len) {
+	uint8_t res = 0;
+	if (USBD_User_GetStatus()) {
+	VCP_DataTx(Buf,Len);
+	res = 1;
+	}
+	return res;
+}
+
+uint8_t cat_driver_has_data() {
+	int32_t len = cat_head - cat_tail;
+	return len < 0?len+CAT_BUFFER_SIZE:len;
 }

--- a/mchf-eclipse/drivers/cat/cat_driver.h
+++ b/mchf-eclipse/drivers/cat/cat_driver.h
@@ -14,10 +14,23 @@
 #ifndef __CAT_DRIVER_H
 #define __CAT_DRIVER_H
 
+typedef enum CatInterfaceState {
+	DISCONNECTED = 0,
+	CONNECTED
+} CatInterfaceState;
+
+typedef enum {
+	UNKNOWN = 0,
+	FT817 = 1
+} CatInterfaceProtocol;
+
+
 // CAT driver public structure
 typedef struct CatDriver
 {
 	uchar	enabled;
+	CatInterfaceState state;
+	CatInterfaceProtocol protocol;
 
 } CatDriver;
 
@@ -26,4 +39,8 @@ void cat_driver_init(void);
 void cat_driver_stop(void);
 void cat_driver_thread(void);
 
+CatInterfaceState cat_driver_state();
+uint8_t cat_driver_get_data(uint8_t* Buf,uint32_t Len);
+uint8_t cat_driver_put_data(uint8_t* Buf,uint32_t Len);
+uint8_t cat_driver_has_data();
 #endif

--- a/mchf-eclipse/drivers/cat/usb/usbd_bsp.c
+++ b/mchf-eclipse/drivers/cat/usb/usbd_bsp.c
@@ -30,84 +30,205 @@
 #include "usbd_bsp.h"
 #include "usbd_conf.h"
 
-void USBD_OTG_BSP_Init(USB_OTG_CORE_HANDLE *pdev)
-{
+
+#ifndef USB_VCP_NVIC_PRIORITY
+#define USB_VCP_NVIC_PRIORITY			0x01
+#endif
+
+#ifndef USB_VCP_NVIC_SUBPRIORITY
+#define USB_VCP_NVIC_SUBPRIORITY		0x01
+#endif
+
+extern USB_OTG_CORE_HANDLE           USB_OTG_dev;
+extern uint32_t USBD_OTG_ISR_Handler(USB_OTG_CORE_HANDLE *pdev);
+
+/**
+* @brief  USB_OTG_BSP_Init
+*         Initilizes BSP configurations
+* @param  None
+* @retval None
+*/
+
+void USB_OTG_BSP_Init(USB_OTG_CORE_HANDLE *pdev) {
   GPIO_InitTypeDef GPIO_InitStructure;   
+#ifdef USE_USB_OTG_FS
+	RCC_AHB1PeriphClockCmd( RCC_AHB1Periph_GPIOA , ENABLE);  
+	GPIO_InitStructure.GPIO_Pin = 	GPIO_Pin_11 | 	// OTG FS Data -
+									GPIO_Pin_12;	// OTG FS Data +
 
-  //RCC_AHB1PeriphClockCmd( RCC_AHB1Periph_GPIOA , ENABLE);
-  
-  GPIO_InitStructure.GPIO_Pin = GPIO_Pin_11|GPIO_Pin_12;
-  GPIO_InitStructure.GPIO_Speed = GPIO_Speed_100MHz;
-  GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF;
-  GPIO_InitStructure.GPIO_OType = GPIO_OType_PP;
-  GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_NOPULL ;
-  GPIO_Init(GPIOA, &GPIO_InitStructure);  
-  
-  GPIO_PinAFConfig(GPIOA,GPIO_PinSource11,GPIO_AF_OTG1_FS) ; 
-  GPIO_PinAFConfig(GPIOA,GPIO_PinSource12,GPIO_AF_OTG1_FS) ;
+	GPIO_InitStructure.GPIO_Speed = GPIO_Speed_100MHz;
+	GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF;
+	GPIO_InitStructure.GPIO_OType = GPIO_OType_PP;
+	GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_NOPULL ;
+	GPIO_Init(GPIOA, &GPIO_InitStructure);  
 
-  //RCC_APB2PeriphClockCmd(RCC_APB2Periph_SYSCFG, ENABLE); // already on
-  RCC_AHB2PeriphClockCmd(RCC_AHB2Periph_OTG_FS, ENABLE) ; 
+	GPIO_PinAFConfig(GPIOA, GPIO_PinSource11, GPIO_AF_OTG1_FS); 
+	GPIO_PinAFConfig(GPIOA, GPIO_PinSource12, GPIO_AF_OTG1_FS);
+#ifndef USB_VCP_DISABLE_VBUS
+	// Configure  VBUS Pin
+	GPIO_InitStructure.GPIO_Pin = GPIO_Pin_9;
+	GPIO_InitStructure.GPIO_Speed = GPIO_Speed_100MHz;
+	GPIO_InitStructure.GPIO_Mode = GPIO_Mode_IN;
+	GPIO_InitStructure.GPIO_OType = GPIO_OType_OD;
+	GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_NOPULL ;
+	GPIO_Init(GPIOA, &GPIO_InitStructure);    
+#endif
+
+#ifndef USB_VCP_DISABLE_ID
+	// Configure ID pin
+	GPIO_InitStructure.GPIO_Pin = GPIO_Pin_10;
+	GPIO_InitStructure.GPIO_OType = GPIO_OType_OD;
+	GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_UP ;  
+	GPIO_InitStructure.GPIO_Speed = GPIO_Speed_100MHz;
+	GPIO_Init(GPIOA, &GPIO_InitStructure);  
+	GPIO_PinAFConfig(GPIOA, GPIO_PinSource10, GPIO_AF_OTG1_FS); 
+#endif
+
+	RCC_APB2PeriphClockCmd(RCC_APB2Periph_SYSCFG, ENABLE);
+	RCC_AHB2PeriphClockCmd(RCC_AHB2Periph_OTG_FS, ENABLE); 
+  
+#else
+	RCC_AHB1PeriphClockCmd(RCC_AHB1Periph_GPIOB, ENABLE);
+
+	GPIO_InitStructure.GPIO_Pin = 	GPIO_Pin_14 | // Data -
+									GPIO_Pin_15;  // Data +
+
+	GPIO_InitStructure.GPIO_Speed = GPIO_Speed_100MHz;
+	GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF;
+	GPIO_InitStructure.GPIO_OType = GPIO_OType_PP;
+	GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_NOPULL;
+	GPIO_Init(GPIOB, &GPIO_InitStructure);
+
+	GPIO_PinAFConfig(GPIOB, GPIO_PinSource14, GPIO_AF_OTG2_FS);
+	GPIO_PinAFConfig(GPIOB, GPIO_PinSource15, GPIO_AF_OTG2_FS);
+	
+#ifndef USB_VCP_DISABLE_VBUS
+	//Configure VBUS Pin
+	GPIO_InitStructure.GPIO_Pin = GPIO_Pin_13;
+	GPIO_InitStructure.GPIO_Speed = GPIO_Speed_100MHz;
+	GPIO_InitStructure.GPIO_Mode = GPIO_Mode_IN;
+	GPIO_InitStructure.GPIO_OType = GPIO_OType_OD;
+	GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_NOPULL;
+	GPIO_Init(GPIOB, &GPIO_InitStructure);
+	GPIO_PinAFConfig(GPIOB, GPIO_PinSource13, GPIO_AF_OTG2_FS);
+#endif
+
+#ifndef USB_VCP_DISABLE_ID
+	//Configure ID pin
+	GPIO_InitStructure.GPIO_Pin =  GPIO_Pin_12;
+	GPIO_InitStructure.GPIO_Speed = GPIO_Speed_100MHz;
+	GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF;
+	GPIO_InitStructure.GPIO_OType = GPIO_OType_OD;
+	GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_UP;
+	GPIO_Init(GPIOB, &GPIO_InitStructure);
+	GPIO_PinAFConfig(GPIOB, GPIO_PinSource12, GPIO_AF_OTG2_FS);
+#endif
+
+	RCC_APB2PeriphClockCmd(RCC_APB2Periph_SYSCFG, ENABLE);
+	RCC_AHB1PeriphClockCmd(RCC_AHB1Periph_OTG_HS, ENABLE);
+
+#endif
 }
 
-void USBD_OTG_BSP_DeInit(USB_OTG_CORE_HANDLE *pdev)
-{
-	GPIO_InitTypeDef GPIO_InitStructure;
+/**
+* @brief  USB_OTG_BSP_EnableInterrupt
+*         Enabele USB Global interrupt
+* @param  None
+* @retval None
+*/
+void USB_OTG_BSP_EnableInterrupt(USB_OTG_CORE_HANDLE *pdev) {
 	NVIC_InitTypeDef NVIC_InitStructure;
-
-	// IRQ channel stop
-	NVIC_InitStructure.NVIC_IRQChannel = OTG_FS_IRQn;
-	NVIC_InitStructure.NVIC_IRQChannelCmd = DISABLE;
+#ifdef USE_USB_OTG_FS
+	NVIC_PriorityGroupConfig(NVIC_PriorityGroup_1);
+	NVIC_InitStructure.NVIC_IRQChannel = OTG_FS_IRQn;  
+	NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = USB_VCP_NVIC_PRIORITY;
+	NVIC_InitStructure.NVIC_IRQChannelSubPriority = USB_VCP_NVIC_SUBPRIORITY + 2;
+	NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
+	NVIC_Init(&NVIC_InitStructure);
+#else
+	NVIC_PriorityGroupConfig(NVIC_PriorityGroup_1);
+	NVIC_InitStructure.NVIC_IRQChannel = OTG_HS_IRQn;
+	NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = USB_VCP_NVIC_PRIORITY;
+	NVIC_InitStructure.NVIC_IRQChannelSubPriority = USB_VCP_NVIC_SUBPRIORITY + 2;
+	NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
 	NVIC_Init(&NVIC_InitStructure);
 
-	// Stop peripheral clock
-	RCC_AHB2PeriphClockCmd(RCC_AHB2Periph_OTG_FS, DISABLE) ;
+	NVIC_PriorityGroupConfig(NVIC_PriorityGroup_1);
+	NVIC_InitStructure.NVIC_IRQChannel = OTG_HS_EP1_OUT_IRQn;
+	NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = USB_VCP_NVIC_PRIORITY;
+	NVIC_InitStructure.NVIC_IRQChannelSubPriority = USB_VCP_NVIC_SUBPRIORITY + 1;
+	NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
+	NVIC_Init(&NVIC_InitStructure);
 
-	// Pins back to input
-	GPIO_InitStructure.GPIO_Pin = GPIO_Pin_11 |GPIO_Pin_12;
-	GPIO_InitStructure.GPIO_Speed = GPIO_Speed_2MHz;
-	GPIO_InitStructure.GPIO_Mode = GPIO_Mode_OUT;
-	GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_DOWN;
-	GPIO_Init(GPIOA, &GPIO_InitStructure);
+	NVIC_PriorityGroupConfig(NVIC_PriorityGroup_1);
+	NVIC_InitStructure.NVIC_IRQChannel = OTG_HS_EP1_IN_IRQn;
+	NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = USB_VCP_NVIC_PRIORITY;
+	NVIC_InitStructure.NVIC_IRQChannelSubPriority = USB_VCP_NVIC_SUBPRIORITY;
+	NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
+	NVIC_Init(&NVIC_InitStructure); 
+
+#endif
+}
+/**
+* @brief  USB_OTG_BSP_uDelay
+*         This function provides delay time in micro sec
+* @param  usec : Value of delay required in micro sec
+* @retval None
+*/
+void USB_OTG_BSP_uDelay (const uint32_t usec) {
+	uint32_t count = 0;
+	const uint32_t utime = (120 * usec / 7);
+	
+	do
+	{
+		if ( ++count > utime ) {
+			return ;
+		}
+	} while (1);
 }
 
-void USBD_OTG_BSP_EnableInterrupt(USB_OTG_CORE_HANDLE *pdev)
-{
-  NVIC_InitTypeDef NVIC_InitStructure; 
-  
-  NVIC_PriorityGroupConfig(NVIC_PriorityGroup_1);
 
-  NVIC_InitStructure.NVIC_IRQChannel = OTG_FS_IRQn;  
-  NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 1;
-  NVIC_InitStructure.NVIC_IRQChannelSubPriority = 3;
-  NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
-  NVIC_Init(&NVIC_InitStructure);
+/**
+* @brief  USB_OTG_BSP_mDelay
+*          This function provides delay time in milli sec
+* @param  msec : Value of delay required in milli sec
+* @retval None
+*/
+void USB_OTG_BSP_mDelay (const uint32_t msec) {
+	USB_OTG_BSP_uDelay(msec * 1000);   
 }
 
-void USBD_OTG_BSP_uDelay (const uint32_t usec)
-{
-  uint32_t count = 0;
-  const uint32_t utime = (120 * usec / 7);
-  do
-  {
-    if ( ++count > utime )
-    {
-      return ;
-    }
-  }
-  while (1);
+
+#ifdef USE_USB_OTG_FS
+
+void OTG_FS_WKUP_IRQHandler(void) {
+	EXTI_ClearITPendingBit(EXTI_Line18);
 }
 
-void USBD_OTG_BSP_mDelay (const uint32_t msec)
-{
-	USBD_OTG_BSP_uDelay(msec * 1000);
+void OTG_FS_IRQHandler(void) {
+	USBD_OTG_ISR_Handler (&USB_OTG_dev);
 }
 
-void USBD_OTG_BSP_ConfigVBUS(USB_OTG_CORE_HANDLE *pdev)
-{
-}
-void USBD_OTG_BSP_DriveVBUS(USB_OTG_CORE_HANDLE *pdev,uint8_t state)
-{
+#else
+extern uint32_t USBD_OTG_ISR_Handler (USB_OTG_CORE_HANDLE *pdev);
+extern uint32_t USBD_OTG_EP1IN_ISR_Handler (USB_OTG_CORE_HANDLE *pdev);
+extern uint32_t USBD_OTG_EP1OUT_ISR_Handler (USB_OTG_CORE_HANDLE *pdev);
+
+void OTG_HS_WKUP_IRQHandler(void) {
+	EXTI_ClearITPendingBit(EXTI_Line20);
 }
 
+void OTG_HS_IRQHandler(void) {
+	USBD_OTG_ISR_Handler(&USB_OTG_dev);
+}
+
+void OTG_HS_EP1_IN_IRQHandler(void) {
+	USBD_OTG_EP1IN_ISR_Handler(&USB_OTG_dev);
+}
+
+void OTG_HS_EP1_OUT_IRQHandler(void) {
+	USBD_OTG_EP1OUT_ISR_Handler(&USB_OTG_dev);
+}
+
+#endif
 

--- a/mchf-eclipse/drivers/cat/usb/usbd_bsp.h
+++ b/mchf-eclipse/drivers/cat/usb/usbd_bsp.h
@@ -26,25 +26,66 @@
   */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
-#ifndef __USBD_BSP__H__
-#define __USBD_BSP__H__
+#ifndef __USB_BSP__H__
+#define __USB_BSP__H__
 
 /* Includes ------------------------------------------------------------------*/
 #include "usb_core.h"
 #include "usb_conf.h"
 
+/** @addtogroup USB_OTG_DRIVER
+  * @{
+  */
+  
+/** @defgroup USB_BSP
+  * @brief This file is the 
+  * @{
+  */ 
 
-//void BSP_Init(void);
 
-void USBD_OTG_BSP_Init (USB_OTG_CORE_HANDLE *pdev);
-void USBD_OTG_BSP_DeInit(USB_OTG_CORE_HANDLE *pdev);
-void USBD_OTG_BSP_uDelay (const uint32_t usec);
-void USBD_OTG_BSP_mDelay (const uint32_t msec);
-void USBD_OTG_BSP_EnableInterrupt (USB_OTG_CORE_HANDLE *pdev);
-//#ifdef USE_HOST_MODE
-void USBD_OTG_BSP_ConfigVBUS(USB_OTG_CORE_HANDLE *pdev);
-void USBD_OTG_BSP_DriveVBUS(USB_OTG_CORE_HANDLE *pdev,uint8_t state);
-//#endif
+/** @defgroup USB_BSP_Exported_Defines
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USB_BSP_Exported_Types
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USB_BSP_Exported_Macros
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+/** @defgroup USB_BSP_Exported_Variables
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+/** @defgroup USB_BSP_Exported_FunctionsPrototype
+  * @{
+  */ 
+void BSP_Init(void);
+
+void USB_OTG_BSP_Init (USB_OTG_CORE_HANDLE *pdev);
+void USB_OTG_BSP_uDelay (const uint32_t usec);
+void USB_OTG_BSP_mDelay (const uint32_t msec);
+void USB_OTG_BSP_EnableInterrupt (USB_OTG_CORE_HANDLE *pdev);
+#ifdef USE_HOST_MODE
+void USB_OTG_BSP_ConfigVBUS(USB_OTG_CORE_HANDLE *pdev);
+void USB_OTG_BSP_DriveVBUS(USB_OTG_CORE_HANDLE *pdev,uint8_t state);
+#endif
 /**
   * @}
   */ 

--- a/mchf-eclipse/drivers/cat/usb/usbd_cdc_vcp.c
+++ b/mchf-eclipse/drivers/cat/usb/usbd_cdc_vcp.c
@@ -25,38 +25,33 @@
   ******************************************************************************
   */ 
 
-// Common
-#include "mchf_board.h"
-
-#include <stdio.h>
-
-#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED 
-#pragma     data_alignment = 4 
-#endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
-
-#include "ui_driver.h"
-
 /* Includes ------------------------------------------------------------------*/
 #include "usbd_cdc_vcp.h"
 #include "usb_conf.h"
 
-// Transceiver state public structure
-extern __IO TransceiverState 	ts;
+#include "usb_core.h"
+#include "usbd_core.h"
+
+#include "usbd_cdc_core.h"
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
-LINE_CODING linecoding =
-  {
-    115200, /* baud rate*/
-    0x00,   /* stop bits-1*/
-    0x00,   /* parity - none*/
-    0x08    /* nb. of bits 8*/
-  };
+/* Private function prototypes -----------------------------------------------*/
+extern USB_OTG_CORE_HANDLE           USB_OTG_dev;
 
-
-USART_InitTypeDef USART_InitStructure;
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+LINE_CODING linecoding = {
+	115200, /* baud rate */
+	0x00,   /* stop bits-1 */
+	0x00,   /* parity - none */
+	0x08,   /* nb. of bits 8 */
+	1		/* Changed flag */
+};
 
 /* These are external variables imported from CDC core to be used for IN 
    transfer management. */
@@ -71,10 +66,7 @@ extern uint32_t APP_Rx_ptr_in;    /* Increment this pointer or roll it back to
 static uint16_t VCP_Init     (void);
 static uint16_t VCP_DeInit   (void);
 static uint16_t VCP_Ctrl     (uint32_t Cmd, uint8_t* Buf, uint32_t Len);
-static uint16_t VCP_DataTx   (uint8_t* Buf, uint32_t Len);
-static uint16_t VCP_DataRx   (uint8_t* Buf, uint32_t Len);
-
-static uint16_t VCP_COMConfig(uint8_t Conf);
+//static uint16_t VCP_COMConfig(uint8_t Conf);
 
 CDC_IF_Prop_TypeDef VCP_fops = 
 {
@@ -92,41 +84,7 @@ CDC_IF_Prop_TypeDef VCP_fops =
   * @param  None
   * @retval Result of the opeartion (USBD_OK in all cases)
   */
-static uint16_t VCP_Init(void)
-{
-//  NVIC_InitTypeDef NVIC_InitStructure;
-  
-  /* EVAL_COM1 default configuration */
-  /* EVAL_COM1 configured as follow:
-        - BaudRate = 115200 baud  
-        - Word Length = 8 Bits
-        - One Stop Bit
-        - Parity Odd
-        - Hardware flow control disabled
-        - Receive and transmit enabled
-  */
-//  USART_InitStructure.USART_BaudRate = 115200;
-//  USART_InitStructure.USART_WordLength = USART_WordLength_8b;
-//  USART_InitStructure.USART_StopBits = USART_StopBits_1;
-//  USART_InitStructure.USART_Parity = USART_Parity_Odd;
-//  USART_InitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_None;
-//  USART_InitStructure.USART_Mode = USART_Mode_Rx | USART_Mode_Tx;
-
-  /* Configure and enable the USART */
-//  STM_EVAL_COMInit(COM1, &USART_InitStructure);
-
-  /* Enable the USART Receive interrupt */
-//  USART_ITConfig(EVAL_COM1, USART_IT_RXNE, ENABLE);
-
-  /* Enable USART Interrupt */
-//  NVIC_InitStructure.NVIC_IRQChannel = EVAL_COM1_IRQn;
-//  NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 0;
-//  NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0;
-//  NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
-//  NVIC_Init(&NVIC_InitStructure);
-
-	printf("VCP_Init\n\r");
-  
+static uint16_t VCP_Init(void) {
   return USBD_OK;
 }
 
@@ -136,9 +94,7 @@ static uint16_t VCP_Init(void)
   * @param  None
   * @retval Result of the opeartion (USBD_OK in all cases)
   */
-static uint16_t VCP_DeInit(void)
-{
-
+static uint16_t VCP_DeInit(void) {
   return USBD_OK;
 }
 
@@ -152,7 +108,14 @@ static uint16_t VCP_DeInit(void)
   * @retval Result of the opeartion (USBD_OK in all cases)
   */
 static uint16_t VCP_Ctrl (uint32_t Cmd, uint8_t* Buf, uint32_t Len)
-{ 
+{ /*
+	int i;
+	printf("Command: 0x%02X: ", Cmd);
+	for (i = 0; i < Len; i++) {
+		printf("0x%02X ", Buf[i]);
+	}
+	printf("\n");
+	*/
   switch (Cmd)
   {
   case SEND_ENCAPSULATED_COMMAND:
@@ -180,8 +143,9 @@ static uint16_t VCP_Ctrl (uint32_t Cmd, uint8_t* Buf, uint32_t Len)
     linecoding.format = Buf[4];
     linecoding.paritytype = Buf[5];
     linecoding.datatype = Buf[6];
-    /* Set the new configuration */
-    VCP_COMConfig(OTHER_CONFIG);
+	linecoding.changed = 1;
+  
+    //VCP_COMConfig(OTHER_CONFIG);
     break;
 
   case GET_LINE_CODING:
@@ -195,34 +159,13 @@ static uint16_t VCP_Ctrl (uint32_t Cmd, uint8_t* Buf, uint32_t Len)
     break;
 
   case SET_CONTROL_LINE_STATE:
-  {
-	  //printf("SET_CONTROL_LINE_STATE\n\r");
-	  //printf("wValue %02x %02x\n\r",Buf[0],Buf[1]);
-
-	  // PTT on
-	  if((ts.txrx_mode == TRX_MODE_RX) && (Buf[0] == 0x03))
-	  {
-		  if(!ts.tx_disable)	{
-			  ts.txrx_mode = TRX_MODE_TX;
-			  ui_driver_toggle_tx();			// cat
-		  }
-	  }
-
-	  // PTT off
-	  if((ts.txrx_mode == TRX_MODE_TX) && (Buf[0] == 0x00))
-	  {
-		  ts.txrx_mode = TRX_MODE_RX;
-		  ui_driver_toggle_tx();			// cat
-	  }
-
-	  break;
-  }
+	//printf("Set control line state\n");
+    /* Not  needed for this driver */
+    break;
 
   case SEND_BREAK:
-  {
-	  //printf("SEND_BREAK\n\r");
-	  break;
-  }
+    /* Not  needed for this driver */
+    break;    
     
   default:
     break;
@@ -239,26 +182,23 @@ static uint16_t VCP_Ctrl (uint32_t Cmd, uint8_t* Buf, uint32_t Len)
   * @param  Len: Number of data to be sent (in bytes)
   * @retval Result of the opeartion: USBD_OK if all operations are OK else VCP_FAIL
   */
-static uint16_t VCP_DataTx (uint8_t* Buf, uint32_t Len)
-{
-  if (linecoding.datatype == 7)
-  {
-//    APP_Rx_Buffer[APP_Rx_ptr_in] = USART_ReceiveData(EVAL_COM1) & 0x7F;
-  }
-  else if (linecoding.datatype == 8)
-  {
-//    APP_Rx_Buffer[APP_Rx_ptr_in] = USART_ReceiveData(EVAL_COM1);
-  }
-  
-  APP_Rx_ptr_in++;
-  
-  /* To avoid buffer overflow */
-  if(APP_Rx_ptr_in == APP_RX_DATA_SIZE)
-  {
-    APP_Rx_ptr_in = 0;
-  }  
-  
-  return USBD_OK;
+uint16_t VCP_DataTx (uint8_t* Buf, uint32_t Len) {
+	uint32_t tx_counter = 0;
+	
+	while (tx_counter < Len) {
+		APP_Rx_Buffer[APP_Rx_ptr_in] = *(Buf+tx_counter);
+		
+		APP_Rx_ptr_in++;
+		
+		/* To avoid buffer overflow */
+		if (APP_Rx_ptr_in >= APP_RX_DATA_SIZE) {
+			APP_Rx_ptr_in = 0;
+		}
+		
+		tx_counter++;
+	}
+	
+	return USBD_OK;
 }
 
 /**
@@ -276,140 +216,14 @@ static uint16_t VCP_DataTx (uint8_t* Buf, uint32_t Len)
   * @param  Len: Number of data received (in bytes)
   * @retval Result of the opeartion: USBD_OK if all operations are OK else VCP_FAIL
   */
-static uint16_t VCP_DataRx (uint8_t* Buf, uint32_t Len)
-{
-  uint32_t i;
-  
-  for (i = 0; i < Len; i++)
-  {
-//    USART_SendData(EVAL_COM1, *(Buf + i) );
-//    while(USART_GetFlagStatus(EVAL_COM1, USART_FLAG_TXE) == RESET);
-  } 
- 
-  return USBD_OK;
+uint16_t VCP_DataRx (uint8_t* Buf, uint32_t Len) {
+	uint32_t i;
+
+	VCP_DataTx(Buf,Len);
+	for (i = 0; i < Len; i++) {
+		/* Add data to internal buffer */
+
+	}
+	
+	return USBD_OK;
 }
-
-/**
-  * @brief  VCP_COMConfig
-  *         Configure the COM Port with default values or values received from host.
-  * @param  Conf: can be DEFAULT_CONFIG to set the default configuration or OTHER_CONFIG
-  *         to set a configuration received from the host.
-  * @retval None.
-  */
-static uint16_t VCP_COMConfig(uint8_t Conf)
-{
-  if (Conf == DEFAULT_CONFIG)  
-  {
-    /* EVAL_COM1 default configuration */
-    /* EVAL_COM1 configured as follow:
-    - BaudRate = 115200 baud  
-    - Word Length = 8 Bits
-    - One Stop Bit
-    - Parity Odd
-    - Hardware flow control disabled
-    - Receive and transmit enabled
-    */
-//    USART_InitStructure.USART_BaudRate = 115200;
-//    USART_InitStructure.USART_WordLength = USART_WordLength_8b;
-//    USART_InitStructure.USART_StopBits = USART_StopBits_1;
-//    USART_InitStructure.USART_Parity = USART_Parity_Odd;
-//    USART_InitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_None;
-//    USART_InitStructure.USART_Mode = USART_Mode_Rx | USART_Mode_Tx;
-    
-    /* Configure and enable the USART */
-//    STM_EVAL_COMInit(COM1, &USART_InitStructure);
-    
-    /* Enable the USART Receive interrupt */
-//    USART_ITConfig(EVAL_COM1, USART_IT_RXNE, ENABLE);
-  }
-  else
-  {
-    /* set the Stop bit*/
-    switch (linecoding.format)
-    {
-    case 0:
-  //    USART_InitStructure.USART_StopBits = USART_StopBits_1;
-      break;
-    case 1:
-  //    USART_InitStructure.USART_StopBits = USART_StopBits_1_5;
-      break;
-    case 2:
-  //    USART_InitStructure.USART_StopBits = USART_StopBits_2;
-      break;
-    default :
-  //    VCP_COMConfig(DEFAULT_CONFIG);
-      return (USBD_FAIL);
-    }
-    
-    /* set the parity bit*/
-    switch (linecoding.paritytype)
-    {
-    case 0:
-  //    USART_InitStructure.USART_Parity = USART_Parity_No;
-      break;
-    case 1:
- //     USART_InitStructure.USART_Parity = USART_Parity_Even;
-      break;
-    case 2:
- //     USART_InitStructure.USART_Parity = USART_Parity_Odd;
-      break;
-    default :
- //     VCP_COMConfig(DEFAULT_CONFIG);
-      return (USBD_FAIL);
-    }
-    
-    /*set the data type : only 8bits and 9bits is supported */
-    switch (linecoding.datatype)
-    {
-    case 0x07:
-      /* With this configuration a parity (Even or Odd) should be set */
-//      USART_InitStructure.USART_WordLength = USART_WordLength_8b;
-      break;
-    case 0x08:
-//      if (USART_InitStructure.USART_Parity == USART_Parity_No)
-  //    {
-  //      USART_InitStructure.USART_WordLength = USART_WordLength_8b;
-  //    }
-  //    else
-  //    {
-   //     USART_InitStructure.USART_WordLength = USART_WordLength_9b;
-   //   }
-      
-      break;
-    default :
-  //    VCP_COMConfig(DEFAULT_CONFIG);
-      return (USBD_FAIL);
-    }
-    
- //   USART_InitStructure.USART_BaudRate = linecoding.bitrate;
- //   USART_InitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_None;
-//    USART_InitStructure.USART_Mode = USART_Mode_Rx | USART_Mode_Tx;
-    
-    /* Configure and enable the USART */
-//    STM_EVAL_COMInit(COM1, &USART_InitStructure);
-  }
-  return USBD_OK;
-}
-
-/**
-  * @brief  EVAL_COM_IRQHandler
-  *         
-  * @param  None.
-  * @retval None.
-  */
-//void EVAL_COM_IRQHandler(void)
-//{
-//  if (USART_GetITStatus(EVAL_COM1, USART_IT_RXNE) != RESET)
-//  {
-    /* Send the received data to the PC Host*/
-//    VCP_DataTx (0,0);
-//  }
-
-  /* If overrun condition occurs, clear the ORE flag and recover communication */
-//  if (USART_GetFlagStatus(EVAL_COM1, USART_FLAG_ORE) != RESET)
-//  {
-//    (void)USART_ReceiveData(EVAL_COM1);
-//  }
-//}
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/mchf-eclipse/drivers/cat/usb/usbd_cdc_vcp.c
+++ b/mchf-eclipse/drivers/cat/usb/usbd_cdc_vcp.c
@@ -34,6 +34,10 @@
 
 #include "usbd_cdc_core.h"
 
+// TODO: create proper header file
+extern int cat_buffer_add(uint8_t c);
+
+
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
 /* Private macro -------------------------------------------------------------*/
@@ -219,11 +223,8 @@ uint16_t VCP_DataTx (uint8_t* Buf, uint32_t Len) {
 uint16_t VCP_DataRx (uint8_t* Buf, uint32_t Len) {
 	uint32_t i;
 
-	VCP_DataTx(Buf,Len);
 	for (i = 0; i < Len; i++) {
-		/* Add data to internal buffer */
-
+		cat_buffer_add(Buf[i]);
 	}
-	
 	return USBD_OK;
 }

--- a/mchf-eclipse/drivers/cat/usb/usbd_cdc_vcp.h
+++ b/mchf-eclipse/drivers/cat/usb/usbd_cdc_vcp.h
@@ -30,15 +30,12 @@
 #define __USBD_CDC_VCP_H
 
 /* Includes ------------------------------------------------------------------*/
-#ifdef STM32F2XX
- #include "stm32f2xx.h"
-#elif defined(STM32F10X_CL)
- #include "stm32f10x.h"
-#endif /* STM32F2XX */
 
 #include "usbd_cdc_core.h"
 #include "usbd_conf.h"
 
+uint16_t VCP_DataTx   (uint8_t* Buf, uint32_t Len);
+uint16_t VCP_DataRx   (uint8_t* Buf, uint32_t Len);
 
 /* Exported typef ------------------------------------------------------------*/
 /* The following structures groups all needed parameters to be configured for the 
@@ -50,17 +47,8 @@ typedef struct
   uint8_t  format;
   uint8_t  paritytype;
   uint8_t  datatype;
+	uint8_t changed;
 }LINE_CODING;
-
-/* Exported constants --------------------------------------------------------*/
-/* The following define is used to route the USART IRQ handler to be used.
-   The IRQ handler function is implemented in the usbd_cdc_vcp.c file. */
-          
-#ifdef USE_STM3210C_EVAL
- #define EVAL_COM_IRQHandler            USART2_IRQHandler
-#else
- #define EVAL_COM_IRQHandler            USART3_IRQHandler  
-#endif /* USE_STM322xG_EVAL */
 
 
 #define DEFAULT_CONFIG                  0

--- a/mchf-eclipse/drivers/cat/usb/usbd_conf.h
+++ b/mchf-eclipse/drivers/cat/usb/usbd_conf.h
@@ -51,7 +51,7 @@
 
 /* CDC Endpoints parameters: you can fine tune these values depending on the needed baudrates and performance. */
 #ifdef USE_USB_OTG_HS
- #define CDC_DATA_MAX_PACKET_SIZE       512  /* Endpoint IN & OUT Packet size */
+ #define CDC_DATA_MAX_PACKET_SIZE       64  /* Endpoint IN & OUT Packet size */
  #define CDC_CMD_PACKET_SZE             8    /* Control Endpoint Packet size */
 
  #define CDC_IN_FRAME_INTERVAL          40   /* Number of micro-frames between IN transfers */
@@ -67,5 +67,41 @@
 #endif /* USE_USB_OTG_HS */
 
 #define APP_FOPS                        VCP_fops
+/**
+  * @}
+  */ 
 
-#endif
+/** @defgroup USB_CONF_Exported_Types
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USB_CONF_Exported_Macros
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+/** @defgroup USB_CONF_Exported_Variables
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+/** @defgroup USB_CONF_Exported_FunctionsPrototype
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+#endif //__USBD_CONF__H__
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/mchf-eclipse/drivers/cat/usb/usbd_desc.c
+++ b/mchf-eclipse/drivers/cat/usb/usbd_desc.c
@@ -32,64 +32,27 @@
 #include "usbd_conf.h"
 #include "usb_regs.h"
 
-/** @addtogroup STM32_USB_OTG_DEVICE_LIBRARY
-  * @{
-  */
-
-
-/** @defgroup USBD_DESC 
-  * @brief USBD descriptors module
-  * @{
-  */ 
-
-/** @defgroup USBD_DESC_Private_TypesDefinitions
-  * @{
-  */ 
-/**
-  * @}
-  */ 
-
-
-/** @defgroup USBD_DESC_Private_Defines
-  * @{
-  */ 
 #define USBD_VID                        0x0483
-
 #define USBD_PID                        0x5740
 
 /** @defgroup USB_String_Descriptors
   * @{
   */ 
 #define USBD_LANGID_STRING              0x409
-#define USBD_MANUFACTURER_STRING        ((uint8_t*)"STMicroelectronics")
+#define USBD_MANUFACTURER_STRING        "STMicroelectronics"
 
-#define USBD_PRODUCT_HS_STRING          ((uint8_t*)"STM32 Virtual ComPort in HS mode")
-#define USBD_SERIALNUMBER_HS_STRING     ((uint8_t*)"00000000050B")
+#define USBD_PRODUCT_HS_STRING          "STM32 Virtual ComPort in HS mode"
+#define USBD_SERIALNUMBER_HS_STRING     "00000000050B"
 
-#define USBD_PRODUCT_FS_STRING          ((uint8_t*)"STM32 Virtual ComPort in FS Mode")
-#define USBD_SERIALNUMBER_FS_STRING     ((uint8_t*)"00000000050C")
+#define USBD_PRODUCT_FS_STRING          "STM32 Virtual ComPort in FS Mode"
+#define USBD_SERIALNUMBER_FS_STRING     "00000000050C"
 
-#define USBD_CONFIGURATION_HS_STRING    ((uint8_t*)"VCP Config")
-#define USBD_INTERFACE_HS_STRING        ((uint8_t*)"VCP Interface")
+#define USBD_CONFIGURATION_HS_STRING    "VCP Config"
+#define USBD_INTERFACE_HS_STRING        "VCP Interface"
 
-#define USBD_CONFIGURATION_FS_STRING    ((uint8_t*)"VCP Config")
-#define USBD_INTERFACE_FS_STRING        ((uint8_t*)"VCP Interface")
-/**
-  * @}
-  */ 
+#define USBD_CONFIGURATION_FS_STRING    "VCP Config"
+#define USBD_INTERFACE_FS_STRING        "VCP Interface"
 
-
-/** @defgroup USBD_DESC_Private_Macros
-  * @{
-  */ 
-/**
-  * @}
-  */ 
-
-
-/** @defgroup USBD_DESC_Private_Variables
-  * @{
-  */ 
 
 USBD_DEVICE USR_desc =
 {
@@ -103,11 +66,6 @@ USBD_DEVICE USR_desc =
   
 };
 
-#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
-  #if defined ( __ICCARM__ ) /*!< IAR Compiler */
-    #pragma data_alignment=4   
-  #endif
-#endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
 /* USB Standard Device Descriptor */
 __ALIGN_BEGIN uint8_t USBD_DeviceDesc[USB_SIZ_DEVICE_DESC] __ALIGN_END =
   {
@@ -131,11 +89,6 @@ __ALIGN_BEGIN uint8_t USBD_DeviceDesc[USB_SIZ_DEVICE_DESC] __ALIGN_END =
     USBD_CFG_MAX_NUM            /*bNumConfigurations*/
   } ; /* USB_DeviceDescriptor */
 
-#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
-  #if defined ( __ICCARM__ ) /*!< IAR Compiler */
-    #pragma data_alignment=4   
-  #endif
-#endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
 /* USB Standard Device Descriptor */
 __ALIGN_BEGIN uint8_t USBD_DeviceQualifierDesc[USB_LEN_DEV_QUALIFIER_DESC] __ALIGN_END =
 {
@@ -151,11 +104,6 @@ __ALIGN_BEGIN uint8_t USBD_DeviceQualifierDesc[USB_LEN_DEV_QUALIFIER_DESC] __ALI
   0x00,
 };
 
-#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
-  #if defined ( __ICCARM__ ) /*!< IAR Compiler */
-    #pragma data_alignment=4   
-  #endif
-#endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
 /* USB Standard Device Descriptor */
 __ALIGN_BEGIN uint8_t USBD_LangIDDesc[USB_SIZ_STRING_LANGID] __ALIGN_END =
 {
@@ -164,22 +112,6 @@ __ALIGN_BEGIN uint8_t USBD_LangIDDesc[USB_SIZ_STRING_LANGID] __ALIGN_END =
      LOBYTE(USBD_LANGID_STRING),
      HIBYTE(USBD_LANGID_STRING), 
 };
-/**
-  * @}
-  */ 
-
-
-/** @defgroup USBD_DESC_Private_FunctionPrototypes
-  * @{
-  */ 
-/**
-  * @}
-  */ 
-
-
-/** @defgroup USBD_DESC_Private_Functions
-  * @{
-  */ 
 
 /**
 * @brief  USBD_USR_DeviceDescriptor 
@@ -217,16 +149,7 @@ uint8_t *  USBD_USR_LangIDStrDescriptor( uint8_t speed , uint16_t *length)
 */
 uint8_t *  USBD_USR_ProductStrDescriptor( uint8_t speed , uint16_t *length)
 {
- 
-  
-  if(speed == 0)
-  {   
-    USBD_GetString (USBD_PRODUCT_HS_STRING, USBD_StrDesc, length);
-  }
-  else
-  {
-    USBD_GetString (USBD_PRODUCT_FS_STRING, USBD_StrDesc, length);    
-  }
+  USBD_GetString (USBD_PRODUCT_FS_STRING, USBD_StrDesc, length);    
   return USBD_StrDesc;
 }
 
@@ -252,14 +175,7 @@ uint8_t *  USBD_USR_ManufacturerStrDescriptor( uint8_t speed , uint16_t *length)
 */
 uint8_t *  USBD_USR_SerialStrDescriptor( uint8_t speed , uint16_t *length)
 {
-  if(speed  == USB_OTG_SPEED_HIGH)
-  {    
-    USBD_GetString (USBD_SERIALNUMBER_HS_STRING, USBD_StrDesc, length);
-  }
-  else
-  {
-    USBD_GetString (USBD_SERIALNUMBER_FS_STRING, USBD_StrDesc, length);    
-  }
+  USBD_GetString (USBD_SERIALNUMBER_FS_STRING, USBD_StrDesc, length);    
   return USBD_StrDesc;
 }
 
@@ -272,14 +188,7 @@ uint8_t *  USBD_USR_SerialStrDescriptor( uint8_t speed , uint16_t *length)
 */
 uint8_t *  USBD_USR_ConfigStrDescriptor( uint8_t speed , uint16_t *length)
 {
-  if(speed  == USB_OTG_SPEED_HIGH)
-  {  
-    USBD_GetString (USBD_CONFIGURATION_HS_STRING, USBD_StrDesc, length);
-  }
-  else
-  {
-    USBD_GetString (USBD_CONFIGURATION_FS_STRING, USBD_StrDesc, length); 
-  }
+  USBD_GetString (USBD_CONFIGURATION_FS_STRING, USBD_StrDesc, length); 
   return USBD_StrDesc;  
 }
 
@@ -293,30 +202,11 @@ uint8_t *  USBD_USR_ConfigStrDescriptor( uint8_t speed , uint16_t *length)
 */
 uint8_t *  USBD_USR_InterfaceStrDescriptor( uint8_t speed , uint16_t *length)
 {
-  if(speed == 0)
-  {
-    USBD_GetString (USBD_INTERFACE_HS_STRING, USBD_StrDesc, length);
-  }
-  else
-  {
-    USBD_GetString (USBD_INTERFACE_FS_STRING, USBD_StrDesc, length);
-  }
+  USBD_GetString (USBD_INTERFACE_FS_STRING, USBD_StrDesc, length);
   return USBD_StrDesc;  
 }
 
-/**
-  * @}
-  */ 
 
-
-/**
-  * @}
-  */ 
-
-
-/**
-  * @}
-  */ 
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
 

--- a/mchf-eclipse/drivers/cat/usb/usbd_usr.c
+++ b/mchf-eclipse/drivers/cat/usb/usbd_usr.c
@@ -25,14 +25,13 @@
   ******************************************************************************
   */ 
 
-// Common
-#include "mchf_board.h"
-
 /* Includes ------------------------------------------------------------------*/
 #include "usbd_usr.h"
 #include "usbd_ioreq.h"
 
 #include <stdio.h>
+
+int usb_otg_cdc_status = 0;
 
 USBD_Usr_cb_TypeDef USR_cb =
 {
@@ -41,122 +40,48 @@ USBD_Usr_cb_TypeDef USR_cb =
   USBD_USR_DeviceConfigured,
   USBD_USR_DeviceSuspended,
   USBD_USR_DeviceResumed,
-  
-  
   USBD_USR_DeviceConnected,
   USBD_USR_DeviceDisconnected,    
 };
 
-//
-// call to here commented out
-// in USBD_Init() in usbd_core.c
-//
-void USBD_USR_Init(void)
-{
-	//printf("USBD_USR_Init\n\r");
-	//while(1);
+void USBD_USR_Init(void) {
+	usb_otg_cdc_status = 0;
+}
 
-  /* Initialize LEDs */
-  //STM_EVAL_LEDInit(LED1);
-  //STM_EVAL_LEDInit(LED2);
-  //STM_EVAL_LEDInit(LED3);
-  //STM_EVAL_LEDInit(LED4);
-  
-  //LCD_LOG_Init();
-  
-#ifdef USE_USB_OTG_HS 
-  //LCD_LOG_SetHeader(" USB OTG HS VCP Device");
-#else
-  //LCD_LOG_SetHeader(" USB OTG FS VCP Device");
-#endif
-  //LCD_UsrLog("> USB device library started.\n");
-  //LCD_LOG_SetFooter ("     USB Device Library v1.1.0" );
+void USBD_USR_DeviceReset(uint8_t speed ) {
+	usb_otg_cdc_status = 0;
+}
+
+void USBD_USR_DeviceConfigured (void) {
+	usb_otg_cdc_status = 1;
+}
+
+void USBD_USR_DeviceSuspended(void) {
+	usb_otg_cdc_status = 0;
+}
+
+void USBD_USR_DeviceResumed(void) {
+	usb_otg_cdc_status = 0;
+}
+
+void USBD_USR_DeviceConnected (void) {
+	usb_otg_cdc_status = 0;
+}
+
+void USBD_USR_DeviceDisconnected (void) {
+	usb_otg_cdc_status = 0;
+}
+
+int USBD_User_GetStatus(void) {
+	return usb_otg_cdc_status;
 }
 
 /**
-* @brief  USBD_USR_DeviceReset 
-*         Displays the message on LCD on device Reset Event
-* @param  speed : device speed
-* @retval None
-*/
-void USBD_USR_DeviceReset(uint8_t speed )
-{
- switch (speed)
- {
-   case USB_OTG_SPEED_HIGH: 
-     //LCD_LOG_SetFooter ("     USB Device Library v1.1.0 [HS]" );
-     break;
-
-  case USB_OTG_SPEED_FULL: 
-     //LCD_LOG_SetFooter ("     USB Device Library v1.1.0 [FS]" );
-     break;
- //default:
-     //LCD_LOG_SetFooter ("     USB Device Library v1.1.0 [??]" );
- }
-}
-
+* @}
+*/ 
 
 /**
-* @brief  USBD_USR_DeviceConfigured
-*         Displays the message on LCD on device configuration Event
-* @param  None
-* @retval Staus
-*/
-void USBD_USR_DeviceConfigured (void)
-{
-  //LCD_UsrLog("> VCP Interface configured.\n");
-}
+* @}
+*/ 
 
-/**
-* @brief  USBD_USR_DeviceSuspended 
-*         Displays the message on LCD on device suspend Event
-* @param  None
-* @retval None
-*/
-void USBD_USR_DeviceSuspended(void)
-{
-  //LCD_UsrLog("> USB Device in Suspend Mode.\n");
-  /* Users can do their application actions here for the USB-Reset */
-}
-
-
-/**
-* @brief  USBD_USR_DeviceResumed 
-*         Displays the message on LCD on device resume Event
-* @param  None
-* @retval None
-*/
-void USBD_USR_DeviceResumed(void)
-{
-    //LCD_UsrLog("> USB Device in Idle Mode.\n");
-  /* Users can do their application actions here for the USB-Reset */
-}
-
-
-/**
-* @brief  USBD_USR_DeviceConnected
-*         Displays the message on LCD on device connection Event
-* @param  None
-* @retval Staus
-*/
-void USBD_USR_DeviceConnected (void)
-{
-  //LCD_UsrLog("> USB Device Connected.\n");
-
-	//printf("USB Device Connected.\n\r");
-}
-
-
-/**
-* @brief  USBD_USR_DeviceDisonnected
-*         Displays the message on LCD on device disconnection Event
-* @param  None
-* @retval Staus
-*/
-void USBD_USR_DeviceDisconnected (void)
-{
-  //LCD_UsrLog("> USB Device Disconnected.\n");
-
-	//printf("USB Device Disconnected.\n\r");
-}
-
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/mchf-eclipse/drivers/keyboard/usb/usbh_bsp.c
+++ b/mchf-eclipse/drivers/keyboard/usb/usbh_bsp.c
@@ -335,18 +335,19 @@ void  USBH_OTG_BSP_ConfigVBUS(USB_OTG_CORE_HANDLE *pdev)
 #else
   #ifdef USE_USB_OTG_FS  
   RCC_AHB1PeriphClockCmd( RCC_AHB1Periph_GPIOH , ENABLE);  
-  
+#if 0
   GPIO_InitStructure.GPIO_Pin = HOST_POWERSW_VBUS;
   GPIO_InitStructure.GPIO_Speed = GPIO_Speed_100MHz;
   GPIO_InitStructure.GPIO_Mode = GPIO_Mode_OUT;
   GPIO_InitStructure.GPIO_OType = GPIO_OType_PP;
   GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_NOPULL ;
   GPIO_Init(HOST_POWERSW_PORT,&GPIO_InitStructure);
+#endif
   #endif  
 #endif
 
   /* By Default, DISABLE is needed on output of the Power Switch */
-  GPIO_SetBits(HOST_POWERSW_PORT, HOST_POWERSW_VBUS);
+  // GPIO_SetBits(HOST_POWERSW_PORT, HOST_POWERSW_VBUS);
   
   USB_OTG_BSP_mDelay(200);   /* Delay is need for stabilising the Vbus Low 
   in Reset Condition, when Vbus=1 and Reset-button is pressed by user */

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -10009,7 +10009,7 @@ static void __attribute__ ((noinline)) UiReadWriteSettingEEPROM_UInt32(uint16_t 
 	}
 }
 
-void UiReadSettingsBandMode(const uint8_t i, const uint16_t band_mode, const uint16_t band_freq_high, const uint16_t  band_freq_low) {
+void UiReadSettingsBandMode(const uint8_t i, const uint16_t band_mode, const uint16_t band_freq_high, const uint16_t  band_freq_low, uint16_t* band_dial_value, uint16_t* band_decod_mode, uint16_t* band_filter_mode) {
 	uint32_t value32;
 	uint16_t value16;
 
@@ -10057,7 +10057,7 @@ void UiReadSettingsBandMode(const uint8_t i, const uint16_t band_mode, const uin
 
 }
 
-static void UiReadWriteSettingsBandMode(const uint8_t i,const uint16_t band_mode, const uint16_t band_freq_high, const uint16_t band_freq_low) {
+static void UiReadWriteSettingsBandMode(const uint8_t i,const uint16_t band_mode, const uint16_t band_freq_high, const uint16_t band_freq_low,uint16_t* band_dial_value, uint16_t* band_decod_mode, uint16_t* band_filter_mode) {
 
 	// ------------------------------------------------------------------------------------
 	// Read Band and Mode saved values - update if changed
@@ -10138,9 +10138,9 @@ void UiDriverLoadEepromValues(void)
 	//
 	for(i = 0; i < MAX_BANDS; i++)
 	{	// read from stored bands
-		UiReadSettingsBandMode(i,EEPROM_BAND0_MODE,EEPROM_BAND0_FREQ_HIGH,EEPROM_BAND0_FREQ_LOW);
-		UiReadSettingsBandMode(i,EEPROM_BAND0_MODE_A,EEPROM_BAND0_FREQ_HIGH_A,EEPROM_BAND0_FREQ_LOW_A);
-		UiReadSettingsBandMode(i,EEPROM_BAND0_MODE_B,EEPROM_BAND0_FREQ_HIGH_B,EEPROM_BAND0_FREQ_LOW_B);
+		UiReadSettingsBandMode(i,EEPROM_BAND0_MODE,EEPROM_BAND0_FREQ_HIGH,EEPROM_BAND0_FREQ_LOW, band_dial_value, band_decod_mode, band_filter_mode);
+		UiReadSettingsBandMode(i,EEPROM_BAND0_MODE_A,EEPROM_BAND0_FREQ_HIGH_A,EEPROM_BAND0_FREQ_LOW_A, band_dial_value_a, band_decod_mode_b, band_filter_mode_a);
+		UiReadSettingsBandMode(i,EEPROM_BAND0_MODE_B,EEPROM_BAND0_FREQ_HIGH_B,EEPROM_BAND0_FREQ_LOW_B, band_dial_value_b, band_decod_mode_b, band_filter_mode_b);
 	}
 	//
 	// ------------------------------------------------------------------------------------
@@ -10410,9 +10410,9 @@ void UiDriverSaveEepromValuesPowerDown(void)
 	//
 
 	for(i = 0; i < MAX_BANDS; i++)	{	// scan through each band's frequency/mode data     qqqqq
-		UiReadWriteSettingsBandMode(i,EEPROM_BAND0_MODE,EEPROM_BAND0_FREQ_HIGH,EEPROM_BAND0_FREQ_LOW);
-		UiReadWriteSettingsBandMode(i,EEPROM_BAND0_MODE_A,EEPROM_BAND0_FREQ_HIGH_A,EEPROM_BAND0_FREQ_LOW_A);
-		UiReadWriteSettingsBandMode(i,EEPROM_BAND0_MODE_B,EEPROM_BAND0_FREQ_HIGH_B,EEPROM_BAND0_FREQ_LOW_B);
+		UiReadWriteSettingsBandMode(i,EEPROM_BAND0_MODE,EEPROM_BAND0_FREQ_HIGH,EEPROM_BAND0_FREQ_LOW,  band_dial_value, band_decod_mode, band_filter_mode);
+		UiReadWriteSettingsBandMode(i,EEPROM_BAND0_MODE_A,EEPROM_BAND0_FREQ_HIGH_A,EEPROM_BAND0_FREQ_LOW_A, band_dial_value_a, band_decod_mode_a, band_filter_mode_a);
+		UiReadWriteSettingsBandMode(i,EEPROM_BAND0_MODE_B,EEPROM_BAND0_FREQ_HIGH_B,EEPROM_BAND0_FREQ_LOW_B, band_dial_value_b, band_decod_mode_b, band_filter_mode_b);
 	}
 
 	UiReadWriteSettingEEPROM_UInt16(EEPROM_FREQ_STEP,df.selected_idx,3);

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -10009,7 +10009,7 @@ static void __attribute__ ((noinline)) UiReadWriteSettingEEPROM_UInt32(uint16_t 
 	}
 }
 
-void UiReadSettingsBandMode(const uint8_t i, const uint16_t band_mode, const uint16_t band_freq_high, const uint16_t  band_freq_low, uint16_t* band_dial_value, uint16_t* band_decod_mode, uint16_t* band_filter_mode) {
+void UiReadSettingsBandMode(const uint8_t i, const uint16_t band_mode, const uint16_t band_freq_high, const uint16_t  band_freq_low, __IO uint32_t* band_dial_value, __IO uint32_t* band_decod_mode, __IO uint32_t* band_filter_mode) {
 	uint32_t value32;
 	uint16_t value16;
 
@@ -10057,7 +10057,7 @@ void UiReadSettingsBandMode(const uint8_t i, const uint16_t band_mode, const uin
 
 }
 
-static void UiReadWriteSettingsBandMode(const uint8_t i,const uint16_t band_mode, const uint16_t band_freq_high, const uint16_t band_freq_low,uint16_t* band_dial_value, uint16_t* band_decod_mode, uint16_t* band_filter_mode) {
+static void UiReadWriteSettingsBandMode(const uint8_t i,const uint16_t band_mode, const uint16_t band_freq_high, const uint16_t band_freq_low, __IO uint32_t* band_dial_value, __IO uint32_t* band_decod_mode, __IO uint32_t* band_filter_mode) {
 
 	// ------------------------------------------------------------------------------------
 	// Read Band and Mode saved values - update if changed

--- a/mchf-eclipse/main.c
+++ b/mchf-eclipse/main.c
@@ -40,7 +40,7 @@
 //
 //
 //
-
+#include "cat_driver.h"
 // Transceiver state public structure
 __IO TransceiverState ts;
 
@@ -1151,7 +1151,13 @@ int main(void)
 	{
 		// UI events processing
 		ui_driver_thread();
-
+		{
+			uint8_t bufc;
+			while (cat_driver_get_data(&bufc,1))
+			{
+				cat_driver_put_data("A",1);
+			}
+		}
 		// Audio driver processing
 		//audio_driver_thread();
 

--- a/mchf-eclipse/usb/otg/inc/usb_core.h
+++ b/mchf-eclipse/usb/otg/inc/usb_core.h
@@ -297,15 +297,15 @@ typedef struct USB_OTG_handle
 {
   USB_OTG_CORE_CFGS    cfg;
   USB_OTG_CORE_REGS    regs;
-//#ifdef USE_DEVICE_MODE
+#ifdef USE_DEVICE_MODE
   DCD_DEV     dev;
-//#endif
-//#ifdef USE_HOST_MODE
+#endif
+#ifdef USE_HOST_MODE
   HCD_DEV     host;
-//#endif
-//#ifdef USE_OTG_MODE
+#endif
+#ifdef USE_OTG_MODE
   OTG_DEV     otg;
-//#endif
+#endif
 }
 USB_OTG_CORE_HANDLE , *PUSB_OTG_CORE_HANDLE;
 
@@ -359,7 +359,6 @@ USB_OTG_STS  USB_OTG_SetCurrentMode  (USB_OTG_CORE_HANDLE *pdev,
     uint8_t mode);
 
 /*********************** HOST APIs ********************************************/
-//#define USE_HOST_MODE
 #ifdef USE_HOST_MODE
 USB_OTG_STS  USB_OTG_CoreInitHost    (USB_OTG_CORE_HANDLE *pdev);
 USB_OTG_STS  USB_OTG_EnableHostInt   (USB_OTG_CORE_HANDLE *pdev);
@@ -376,7 +375,6 @@ uint8_t      USB_OTG_IsEvenFrame     (USB_OTG_CORE_HANDLE *pdev) ;
 void         USB_OTG_StopHost        (USB_OTG_CORE_HANDLE *pdev);
 #endif
 /********************* DEVICE APIs ********************************************/
-//#define USE_DEVICE_MODE
 #ifdef USE_DEVICE_MODE
 USB_OTG_STS  USB_OTG_CoreInitDev         (USB_OTG_CORE_HANDLE *pdev);
 USB_OTG_STS  USB_OTG_EnableDevInt        (USB_OTG_CORE_HANDLE *pdev);

--- a/mchf-eclipse/usb/otg/inc/usb_dcd.h
+++ b/mchf-eclipse/usb/otg/inc/usb_dcd.h
@@ -108,8 +108,6 @@ EXPORTED FUNCTION FROM THE USB-OTG LAYER
 void       DCD_Init(USB_OTG_CORE_HANDLE *pdev ,
                     USB_OTG_CORE_ID_TypeDef coreID);
 
-void 		DCD_DeInit(USB_OTG_CORE_HANDLE *pdev);
-
 void        DCD_DevConnect (USB_OTG_CORE_HANDLE *pdev);
 void        DCD_DevDisconnect (USB_OTG_CORE_HANDLE *pdev);
 void        DCD_EP_SetAddress (USB_OTG_CORE_HANDLE *pdev,

--- a/mchf-eclipse/usb/otg/src/usb_core.c
+++ b/mchf-eclipse/usb/otg/src/usb_core.c
@@ -29,6 +29,63 @@
 #include "usb_core.h"
 #include "usbd_bsp.h"
 
+
+/** @addtogroup USB_OTG_DRIVER
+* @{
+*/
+
+/** @defgroup USB_CORE 
+* @brief This file includes the USB-OTG Core Layer
+* @{
+*/
+
+
+/** @defgroup USB_CORE_Private_Defines
+* @{
+*/ 
+
+/**
+* @}
+*/ 
+
+
+/** @defgroup USB_CORE_Private_TypesDefinitions
+* @{
+*/ 
+/**
+* @}
+*/ 
+
+
+
+/** @defgroup USB_CORE_Private_Macros
+* @{
+*/ 
+/**
+* @}
+*/ 
+
+
+/** @defgroup USB_CORE_Private_Variables
+* @{
+*/ 
+/**
+* @}
+*/ 
+
+
+/** @defgroup USB_CORE_Private_FunctionPrototypes
+* @{
+*/ 
+/**
+* @}
+*/ 
+
+
+/** @defgroup USB_CORE_Private_Functions
+* @{
+*/ 
+
 /**
 * @brief  USB_OTG_EnableCommonInt
 *         Initializes the commmon interrupts, used in both device and modes
@@ -73,7 +130,7 @@ static USB_OTG_STS USB_OTG_CoreReset(USB_OTG_CORE_HANDLE *pdev)
   /* Wait for AHB master IDLE state. */
   do
   {
-    USBD_OTG_BSP_uDelay(3);
+    USB_OTG_BSP_uDelay(3);
     greset.d32 = USB_OTG_READ_REG32(&pdev->regs.GREGS->GRSTCTL);
     if (++count > 200000)
     {
@@ -95,7 +152,7 @@ static USB_OTG_STS USB_OTG_CoreReset(USB_OTG_CORE_HANDLE *pdev)
   }
   while (greset.b.csftrst == 1);
   /* Wait for 3 PHY Clocks*/
-  USBD_OTG_BSP_uDelay(3);
+  USB_OTG_BSP_uDelay(3);
   return status;
 }
 
@@ -341,7 +398,7 @@ USB_OTG_STS USB_OTG_CoreInit(USB_OTG_CORE_HANDLE *pdev)
     }
     
     USB_OTG_WRITE_REG32 (&pdev->regs.GREGS->GCCFG, gccfg.d32);
-    USBD_OTG_BSP_mDelay(20);
+    USB_OTG_BSP_mDelay(20);
   }
   /* case the HS core is working in FS mode */
   if(pdev->cfg.dma_enable == 1)
@@ -424,7 +481,7 @@ USB_OTG_STS USB_OTG_FlushTxFifo (USB_OTG_CORE_HANDLE *pdev , uint32_t num )
   }
   while (greset.b.txfflsh == 1);
   /* Wait for 3 PHY Clocks*/
-  USBD_OTG_BSP_uDelay(3);
+  USB_OTG_BSP_uDelay(3);
   return status;
 }
 
@@ -453,7 +510,7 @@ USB_OTG_STS USB_OTG_FlushRxFifo( USB_OTG_CORE_HANDLE *pdev )
   }
   while (greset.b.rxfflsh == 1);
   /* Wait for 3 PHY Clocks*/
-  USBD_OTG_BSP_uDelay(3);
+  USB_OTG_BSP_uDelay(3);
   return status;
 }
 
@@ -484,7 +541,7 @@ USB_OTG_STS USB_OTG_SetCurrentMode(USB_OTG_CORE_HANDLE *pdev , uint8_t mode)
   }
   
   USB_OTG_WRITE_REG32(&pdev->regs.GREGS->GUSBCFG, usbcfg.d32);
-  USBD_OTG_BSP_mDelay(50);
+  USB_OTG_BSP_mDelay(50);
   return status;
 }
 
@@ -555,10 +612,8 @@ uint32_t USB_OTG_ReadOtgItr (USB_OTG_CORE_HANDLE *pdev)
 USB_OTG_STS USB_OTG_CoreInitHost(USB_OTG_CORE_HANDLE *pdev)
 {
   USB_OTG_STS                     status = USB_OTG_OK;
-#if defined ( USB_OTG_FS_CORE ) || defined ( USB_OTG_HS_CORE )
   USB_OTG_FSIZ_TypeDef            nptxfifosize;
   USB_OTG_FSIZ_TypeDef            ptxfifosize;  
-#endif
   USB_OTG_HCFG_TypeDef            hcfg;
   
 #ifdef USE_OTG_MODE
@@ -566,11 +621,9 @@ USB_OTG_STS USB_OTG_CoreInitHost(USB_OTG_CORE_HANDLE *pdev)
 #endif
   
   uint32_t                        i = 0;
-
-#if defined ( USB_OTG_FS_CORE ) || defined ( USB_OTG_HS_CORE )
+  
   nptxfifosize.d32 = 0;  
   ptxfifosize.d32 = 0;
-#endif
 #ifdef USE_OTG_MODE
   gotgctl.d32 = 0;
 #endif
@@ -578,7 +631,7 @@ USB_OTG_STS USB_OTG_CoreInitHost(USB_OTG_CORE_HANDLE *pdev)
   
   
   /* configure charge pump IO */
-  USBD_OTG_BSP_ConfigVBUS(pdev);
+  USB_OTG_BSP_ConfigVBUS(pdev);
   
   /* Restart the Phy Clock */
   USB_OTG_WRITE_REG32(pdev->regs.PCGCCTL, 0);
@@ -678,7 +731,7 @@ void USB_OTG_DriveVbus (USB_OTG_CORE_HANDLE *pdev, uint8_t state)
   hprt0.d32 = 0;
   
   /* enable disable the external charge pump */
-  USBD_OTG_BSP_DriveVBUS(pdev, state);
+  USB_OTG_BSP_DriveVBUS(pdev, state);
   
   /* Turn on the Host port power. */
   hprt0.d32 = USB_OTG_ReadHPRT0(pdev);
@@ -693,7 +746,7 @@ void USB_OTG_DriveVbus (USB_OTG_CORE_HANDLE *pdev, uint8_t state)
     USB_OTG_WRITE_REG32(pdev->regs.HPRT0, hprt0.d32);
   }
   
-  USBD_OTG_BSP_mDelay(200);
+  USB_OTG_BSP_mDelay(200);
 }
 /**
 * @brief  USB_OTG_EnableHostInt: Enables the Host mode interrupts
@@ -787,10 +840,10 @@ uint32_t USB_OTG_ResetPort(USB_OTG_CORE_HANDLE *pdev)
   hprt0.d32 = USB_OTG_ReadHPRT0(pdev);
   hprt0.b.prtrst = 1;
   USB_OTG_WRITE_REG32(pdev->regs.HPRT0, hprt0.d32);
-  USBD_OTG_BSP_mDelay (10);                                /* See Note #1 */
+  USB_OTG_BSP_mDelay (10);                                /* See Note #1 */
   hprt0.b.prtrst = 0;
   USB_OTG_WRITE_REG32(pdev->regs.HPRT0, hprt0.d32);
-  USBD_OTG_BSP_mDelay (20);
+  USB_OTG_BSP_mDelay (20);   
   return 1;
 }
 
@@ -1144,19 +1197,15 @@ USB_OTG_STS USB_OTG_CoreInitDev (USB_OTG_CORE_HANDLE *pdev)
   USB_OTG_DEPCTL_TypeDef  depctl;
   uint32_t i;
   USB_OTG_DCFG_TypeDef    dcfg;
-#if defined ( USB_OTG_FS_CORE ) || defined ( USB_OTG_HS_CORE )
   USB_OTG_FSIZ_TypeDef    nptxfifosize;
   USB_OTG_FSIZ_TypeDef    txfifosize;
-#endif
   USB_OTG_DIEPMSK_TypeDef msk;
   USB_OTG_DTHRCTL_TypeDef dthrctl;  
   
   depctl.d32 = 0;
   dcfg.d32 = 0;
-#if defined ( USB_OTG_FS_CORE ) || defined ( USB_OTG_HS_CORE )
   nptxfifosize.d32 = 0;
   txfifosize.d32 = 0;
-#endif
   msk.d32 = 0;
   
   /* Restart the Phy Clock */
@@ -1912,7 +1961,7 @@ void USB_OTG_ActiveRemoteWakeup(USB_OTG_CORE_HANDLE *pdev)
       if(pdev->cfg.low_power)
       {
         /* un-gate USB Core clock */
-        power.d32 = USB_OTG_READ_REG32(pdev->regs.PCGCCTL);
+        power.d32 = USB_OTG_READ_REG32(&pdev->regs.PCGCCTL);
         power.b.gatehclk = 0;
         power.b.stoppclk = 0;
         USB_OTG_WRITE_REG32(pdev->regs.PCGCCTL, power.d32);
@@ -1921,7 +1970,7 @@ void USB_OTG_ActiveRemoteWakeup(USB_OTG_CORE_HANDLE *pdev)
       dctl.d32 = 0;
       dctl.b.rmtwkupsig = 1;
       USB_OTG_MODIFY_REG32(&pdev->regs.DREGS->DCTL, 0, dctl.d32);
-// aaaa      USB_OTG_BSP_mDelay(5);
+      USB_OTG_BSP_mDelay(5);
       USB_OTG_MODIFY_REG32(&pdev->regs.DREGS->DCTL, dctl.d32, 0 );
     }
   }
@@ -1946,7 +1995,7 @@ void USB_OTG_UngateClock(USB_OTG_CORE_HANDLE *pdev)
     if(dsts.b.suspsts == 1)
     {
       /* un-gate USB Core clock */
-      power.d32 = USB_OTG_READ_REG32(pdev->regs.PCGCCTL);
+      power.d32 = USB_OTG_READ_REG32(&pdev->regs.PCGCCTL);
       power.b.gatehclk = 0;
       power.b.stoppclk = 0;
       USB_OTG_WRITE_REG32(pdev->regs.PCGCCTL, power.d32);

--- a/mchf-eclipse/usb/otg/src/usb_dcd.c
+++ b/mchf-eclipse/usb/otg/src/usb_dcd.c
@@ -140,13 +140,9 @@ void DCD_Init(USB_OTG_CORE_HANDLE *pdev ,
   /* Init Device */
   USB_OTG_CoreInitDev(pdev);
   
+  
   /* Enable USB Global interrupt */
   USB_OTG_EnableGlobalInt(pdev);
-}
-
-void DCD_DeInit(USB_OTG_CORE_HANDLE *pdev)
-{
-	USB_OTG_DisableGlobalInt(pdev);
 }
 
 
@@ -394,7 +390,7 @@ void  DCD_DevConnect (USB_OTG_CORE_HANDLE *pdev)
   /* Connect device */
   dctl.b.sftdiscon  = 0;
   USB_OTG_WRITE_REG32(&pdev->regs.DREGS->DCTL, dctl.d32);
-  USBD_OTG_BSP_mDelay(3);
+  USB_OTG_BSP_mDelay(3);
 #endif
 }
 
@@ -412,7 +408,7 @@ void  DCD_DevDisconnect (USB_OTG_CORE_HANDLE *pdev)
   /* Disconnect device for 3ms */
   dctl.b.sftdiscon  = 1;
   USB_OTG_WRITE_REG32(&pdev->regs.DREGS->DCTL, dctl.d32);
-  USBD_OTG_BSP_mDelay(3);
+  USB_OTG_BSP_mDelay(3);
 #endif
 }
 

--- a/mchf-eclipse/usb/otg/src/usb_dcd_int.c
+++ b/mchf-eclipse/usb/otg/src/usb_dcd_int.c
@@ -352,8 +352,7 @@ static uint32_t DCD_HandleResume_ISR(USB_OTG_CORE_HANDLE *pdev)
   if(pdev->cfg.low_power)
   {
     /* un-gate USB Core clock */
-    // power.d32 = USB_OTG_READ_REG32((&pdev->regs.PCGCCTL));
-	power.d32 = USB_OTG_READ_REG32(pdev->regs.PCGCCTL);
+    power.d32 = USB_OTG_READ_REG32(&pdev->regs.PCGCCTL);
     power.b.gatehclk = 0;
     power.b.stoppclk = 0;
     USB_OTG_WRITE_REG32(pdev->regs.PCGCCTL, power.d32);

--- a/mchf-eclipse/usb/usb_conf.h
+++ b/mchf-eclipse/usb/usb_conf.h
@@ -29,26 +29,191 @@
 #ifndef __USB_CONF__H__
 #define __USB_CONF__H__
 
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f4xx.h"
 #include "mchf_board.h"
 
-#define USE_EMBEDDED_PHY
+#include <stdio.h>
+
+/** @addtogroup USB_OTG_DRIVER
+  * @{
+  */
+  
+/** @defgroup USB_CONF
+  * @brief USB low level driver configuration file
+  * @{
+  */ 
+
+/** @defgroup USB_CONF_Exported_Defines
+  * @{
+  */ 
+
+/* USB Core and PHY interface configuration.
+   Tip: To avoid modifying these defines each time you need to change the USB
+        configuration, you can declare the needed define in your toolchain
+        compiler preprocessor.
+   */
+/****************** USB OTG FS PHY CONFIGURATION *******************************
+*  The USB OTG FS Core supports one on-chip Full Speed PHY.
+*  
+*  The USE_EMBEDDED_PHY symbol is defined in the project compiler preprocessor 
+*  when FS core is used.
+*******************************************************************************/
+#ifndef USE_USB_OTG_FS
+	#ifndef USE_USB_OTG_HS
+		#define	USE_USB_OTG_FS
+	#endif
+#endif /* USE_USB_OTG_FS */
+
+#ifdef USE_USB_OTG_FS 
+ #define USB_OTG_FS_CORE
+#endif
+
+/****************** USB OTG HS PHY CONFIGURATION *******************************
+*  The USB OTG HS Core supports two PHY interfaces:
+*   (i)  An ULPI interface for the external High Speed PHY: the USB HS Core will 
+*        operate in High speed mode
+*   (ii) An on-chip Full Speed PHY: the USB HS Core will operate in Full speed mode
+*
+*  You can select the PHY to be used using one of these two defines:
+*   (i)  USE_ULPI_PHY: if the USB OTG HS Core is to be used in High speed mode 
+*   (ii) USE_EMBEDDED_PHY: if the USB OTG HS Core is to be used in Full speed mode
+*
+*  Notes: 
+*   - The USE_ULPI_PHY symbol is defined in the project compiler preprocessor as 
+*     default PHY when HS core is used.
+*   - On STM322xG-EVAL and STM324xG-EVAL boards, only configuration(i) is available.
+*     Configuration (ii) need a different hardware, for more details refer to your
+*     STM32 device datasheet.
+*******************************************************************************/
+#ifndef USE_USB_OTG_HS
+ //#define USE_USB_OTG_HS
+#endif /* USE_USB_OTG_HS */
+
+#ifndef USE_ULPI_PHY
+ //#define USE_ULPI_PHY
+#endif /* USE_ULPI_PHY */
+
+#ifndef USE_EMBEDDED_PHY
+ #define USE_EMBEDDED_PHY
+#endif /* USE_EMBEDDED_PHY */
+
+#ifdef USE_USB_OTG_HS 
+ #define USB_OTG_HS_CORE
+#endif
+
+/*******************************************************************************
+*                      FIFO Size Configuration in Device mode
+*  
+*  (i) Receive data FIFO size = RAM for setup packets + 
+*                   OUT endpoint control information +
+*                   data OUT packets + miscellaneous
+*      Space = ONE 32-bits words
+*     --> RAM for setup packets = 10 spaces
+*        (n is the nbr of CTRL EPs the device core supports) 
+*     --> OUT EP CTRL info      = 1 space
+*        (one space for status information written to the FIFO along with each 
+*        received packet)
+*     --> data OUT packets      = (Largest Packet Size / 4) + 1 spaces 
+*        (MINIMUM to receive packets)
+*     --> OR data OUT packets  = at least 2*(Largest Packet Size / 4) + 1 spaces 
+*        (if high-bandwidth EP is enabled or multiple isochronous EPs)
+*     --> miscellaneous = 1 space per OUT EP
+*        (one space for transfer complete status information also pushed to the 
+*        FIFO with each endpoint's last packet)
+*
+*  (ii)MINIMUM RAM space required for each IN EP Tx FIFO = MAX packet size for 
+*       that particular IN EP. More space allocated in the IN EP Tx FIFO results
+*       in a better performance on the USB and can hide latencies on the AHB.
+*
+*  (iii) TXn min size = 16 words. (n  : Transmit FIFO index)
+*   (iv) When a TxFIFO is not used, the Configuration should be as follows: 
+*       case 1 :  n > m    and Txn is not used    (n,m  : Transmit FIFO indexes)
+*       --> Txm can use the space allocated for Txn.
+*       case2  :  n < m    and Txn is not used    (n,m  : Transmit FIFO indexes)
+*       --> Txn should be configured with the minimum space of 16 words
+*  (v) The FIFO is used optimally when used TxFIFOs are allocated in the top 
+*       of the FIFO.Ex: use EP1 and EP2 as IN instead of EP1 and EP3 as IN ones.
+*   (vi) In HS case 12 FIFO locations should be reserved for internal DMA registers
+*        so total FIFO size should be 1012 Only instead of 1024       
+*******************************************************************************/
  
+/****************** USB OTG HS CONFIGURATION **********************************/
+#ifdef USB_OTG_HS_CORE
+ #define RX_FIFO_HS_SIZE                          512
+ #define TX0_FIFO_HS_SIZE                          64
+ #define TX1_FIFO_HS_SIZE                         372
+ #define TX2_FIFO_HS_SIZE                          64
+ #define TX3_FIFO_HS_SIZE                           0
+ #define TX4_FIFO_HS_SIZE                           0
+ #define TX5_FIFO_HS_SIZE                           0
+
+// #define USB_OTG_HS_SOF_OUTPUT_ENABLED
+
+ #ifdef USE_ULPI_PHY
+  #define USB_OTG_ULPI_PHY_ENABLED
+ #endif
+ #ifdef USE_EMBEDDED_PHY 
+   #define USB_OTG_EMBEDDED_PHY_ENABLED
+   /* wakeup is working only when HS core is configured in FS mode */
+   #define USB_OTG_HS_LOW_PWR_MGMT_SUPPORT
+ #endif
+ /* #define USB_OTG_HS_INTERNAL_DMA_ENABLED */ /* Be aware that enabling DMA mode will result in data being sent only by
+                                                  multiple of 4 packet sizes. This is due to the fact that USB DMA does
+                                                  not allow sending data from non word-aligned addresses.
+                                                  For this specific application, it is advised to not enable this option
+                                                  unless required. */
+ #define USB_OTG_HS_DEDICATED_EP1_ENABLED
+#endif
+
+
+#define RX_FIFO_FS_SIZE   128
+#define TXH_NP_FS_FIFOSIZ  96
+#define TXH_P_FS_FIFOSIZ   96
+
 /****************** USB OTG FS CONFIGURATION **********************************/
+#ifdef USB_OTG_FS_CORE
  #define RX_FIFO_FS_SIZE                          128
  #define TX0_FIFO_FS_SIZE                          32
  #define TX1_FIFO_FS_SIZE                         128
  #define TX2_FIFO_FS_SIZE                          32 
  #define TX3_FIFO_FS_SIZE                           0
 
+// #define USB_OTG_FS_LOW_PWR_MGMT_SUPPORT
+// #define USB_OTG_FS_SOF_OUTPUT_ENABLED
+#endif
+
 /****************** USB OTG MISC CONFIGURATION ********************************/
 //#define VBUS_SENSING_ENABLED
 
 /****************** USB OTG MODE CONFIGURATION ********************************/
-#define USE_DEVICE_MODE
 #define USE_HOST_MODE
+#define USE_DEVICE_MODE
+// #define USE_OTG_MODE
 
-//#define USE_USB_OTG_FS
-//#define USB_OTG_FS_CORE
+#ifndef USB_OTG_FS_CORE
+ #ifndef USB_OTG_HS_CORE
+    #error  "USB_OTG_HS_CORE or USB_OTG_FS_CORE should be defined"
+ #endif
+#endif
+
+#ifndef USE_DEVICE_MODE
+ #ifndef USE_HOST_MODE
+    #error  "USE_DEVICE_MODE or USE_HOST_MODE should be defined"
+ #endif
+#endif
+
+#ifndef USE_USB_OTG_HS
+ #ifndef USE_USB_OTG_FS
+    #error  "USE_USB_OTG_HS or USE_USB_OTG_FS should be defined"
+ #endif
+#else //USE_USB_OTG_HS
+ #ifndef USE_ULPI_PHY
+  #ifndef USE_EMBEDDED_PHY
+     #error  "USE_ULPI_PHY or USE_EMBEDDED_PHY should be defined"
+  #endif
+ #endif
+#endif
 
 /****************** C Compilers dependant keywords ****************************/
 /* In HS mode and when the DMA is used, all variables and data structures dealing
@@ -77,15 +242,57 @@
   #define __packed    __packed
 #elif defined (__ICCARM__)     /* IAR Compiler */
   #define __packed    __packed
-#elif defined   ( __GNUC__ )   /* GNU Compiler */
-	#if ! defined ( __packed )
-		#define __packed    __attribute__ ((__packed__))
-	#endif
+#elif defined   ( __GNUC__ )   /* GNU Compiler */                        
+  #define __packed    __attribute__ ((__packed__))
 #elif defined   (__TASKING__)  /* TASKING Compiler */
   #define __packed    __unaligned
 #endif /* __CC_ARM */
 
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USB_CONF_Exported_Types
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
+/** @defgroup USB_CONF_Exported_Macros
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+/** @defgroup USB_CONF_Exported_Variables
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+/** @defgroup USB_CONF_Exported_FunctionsPrototype
+  * @{
+  */ 
+/**
+  * @}
+  */ 
+
+
 #endif //__USB_CONF__H__
 
 
+/**
+  * @}
+  */ 
+
+/**
+  * @}
+  */ 
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
 

--- a/mchf-eclipse/usb/usbd/class/cdc/src/usbd_cdc_core.c
+++ b/mchf-eclipse/usb/usbd/class/cdc/src/usbd_cdc_core.c
@@ -541,10 +541,7 @@ static uint8_t  usbd_cdc_Setup (void  *pdev,
       else /* No Data request */
       {
         /* Transfer the command to the interface layer */
-    	  //
-    	  // add on - send wValue instead of NULL buffer
-    	  //
-        APP_FOPS.pIf_Ctrl(req->bRequest, (uint8_t*)&(req->wValue), 0);
+        APP_FOPS.pIf_Ctrl(req->bRequest, NULL, 0);
       }
       
       return USBD_OK;
@@ -563,7 +560,7 @@ static uint8_t  usbd_cdc_Setup (void  *pdev,
       if( (req->wValue >> 8) == CDC_DESCRIPTOR_TYPE)
       {
 #ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
-        pbuf = usbd_cdc_Desc;
+        pbuf = usbd_cdc_Desc;   
 #else
         pbuf = usbd_cdc_CfgDesc + 9 + (9 * USBD_ITF_MAX_NUM);
 #endif 

--- a/mchf-eclipse/usb/usbd/core/inc/usbd_usr.h
+++ b/mchf-eclipse/usb/usbd/core/inc/usbd_usr.h
@@ -32,7 +32,6 @@
 /* Includes ------------------------------------------------------------------*/
 #include "usbd_core.h"
 
-
 /** @addtogroup USBD_USER
   * @{
   */
@@ -108,6 +107,8 @@ void     USBD_USR_HS_DeviceResumed(void);
 
 void     USBD_USR_HS_DeviceConnected(void);
 void     USBD_USR_HS_DeviceDisconnected(void);  
+
+extern int USBD_User_GetStatus(void);
 
 /**
   * @}

--- a/mchf-eclipse/usb/usbd/core/src/usbd_core.c
+++ b/mchf-eclipse/usb/usbd/core/src/usbd_core.c
@@ -138,22 +138,23 @@ void USBD_Init(USB_OTG_CORE_HANDLE *pdev,
                USBD_Usr_cb_TypeDef *usr_cb)
 {
   /* Hardware Init */
-  USBD_OTG_BSP_Init(pdev);
-
+  USB_OTG_BSP_Init(pdev);  
+  
+  USBD_DeInit(pdev);
+  
   /*Register class and user callbacks */
   pdev->dev.class_cb = class_cb;
-  pdev->dev.usr_cb = usr_cb;
-  pdev->dev.usr_device = pDevice;
+  pdev->dev.usr_cb = usr_cb;  
+  pdev->dev.usr_device = pDevice;    
   
   /* set USB OTG core params */
-  DCD_Init(pdev,coreID);
+  DCD_Init(pdev , coreID);
   
-  // Upon Init call usr callback
-  // causes hard fault and crash
-  //pdev->dev.usr_cb->Init();
+  /* Upon Init call usr callback */
+  pdev->dev.usr_cb->Init();
   
   /* Enable Interrupts */
-  USBD_OTG_BSP_EnableInterrupt(pdev);
+  USB_OTG_BSP_EnableInterrupt(pdev);
 }
 
 /**
@@ -164,12 +165,8 @@ void USBD_Init(USB_OTG_CORE_HANDLE *pdev,
 */
 USBD_Status USBD_DeInit(USB_OTG_CORE_HANDLE *pdev)
 {
-  // Interrupts disable
-  DCD_DeInit(pdev);
+  /* Software Init */
   
-  // Stop pins
-  USBD_OTG_BSP_DeInit(pdev);
-
   return USBD_OK;
 }
 


### PR DESCRIPTION
The old code was somehow broken, it stopped working after a few bytes CDC traffic (around 62 to 77).
Was not able to find the issue, replace it with working code from STM32 libs.
There may be issues with host mode (was not enabled, not tested),
audio (also not enabled).
All in all there is no loss in existing, working functionality. Using this
code will enable development of proper CAT remote control for the mcHF.

Currently there is no useful code there. Only an echo when using the virtual
comm port is provided, which allows minimal testing.


