### PR TITLE
added .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+mchf-eclipse/drivers/ui/lcd/ui_lcd_hy28.c ident


### PR DESCRIPTION
It seems that you did not checked in .gitattributes. Now the automatic ID is working. However, of course the commit idea is not always a DF8OE Github Commit, I see may ids in my builds. But even this is better than before, now we can distinguish builds by asking for the id. In a normal clone of the df8oe repository the ids will match the "official" ones.