### PR TITLE
Added support for issue #49 (Linein Channel Selectable)

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -1878,6 +1878,10 @@ static void audio_tx_processor(int16_t *src, int16_t *dst, int16_t size)
 			softdds_runf((float32_t *)ads.a_buffer, (float32_t *)ads.a_buffer,size/2);		// load audio buffer with the tone - DDS produces quadrature channels, but we need only one
 		}
 		else	{		// Not tune mode - use audio from CODEC
+				if(ts.tx_audio_source == TX_AUDIO_LINEIN_R) {	 	// Are we in LINE IN mode?
+					src++;
+					// use right channel data
+				}
 			// Fill I and Q buffers with left channel(same as right)
 			for(i = 0; i < size/2; i++)	{				// Copy to single buffer
 				ads.a_buffer[i] = (float)*src;
@@ -1885,7 +1889,7 @@ static void audio_tx_processor(int16_t *src, int16_t *dst, int16_t size)
 			}
 		}
 		//
-		if(ts.tx_audio_source == TX_AUDIO_LINEIN)		// Are we in LINE IN mode?
+		if(ts.tx_audio_source != TX_AUDIO_MIC)		// Are we in LINE IN mode?
 			gain_calc = LINE_IN_GAIN_RESCALE;			// Yes - fixed gain scaling for line input - the rest is done in hardware
 		else	{
 			gain_calc = (float)ts.tx_mic_gain_mult;		// We are in MIC In mode:  Calculate Microphone gain
@@ -1980,13 +1984,17 @@ static void audio_tx_processor(int16_t *src, int16_t *dst, int16_t size)
 	//
 	else if((ts.dmod_mode == DEMOD_AM) && (!ts.tune))	{	//	Is it in AM mode *AND* is frequency translation active?
 		if(ts.iq_freq_mode)	{				// is translation active?
+			if(ts.tx_audio_source == TX_AUDIO_LINEIN_R) {	 	// Are we in LINE IN mode?
+				src++;
+				// use right channel data
+			}
 			// Translation is active - Fill I and Q buffers with left channel(same as right)
 			for(i = 0; i < size/2; i++)	{				// Copy to single buffer
 				ads.a_buffer[i] = (float)*src;
 				src += 2;								// Next sample
 			}
 			//
-			if(ts.tx_audio_source == TX_AUDIO_LINEIN)		// Are we in LINE IN mode?
+			if(ts.tx_audio_source != TX_AUDIO_MIC)		// Are we in LINE IN mode?
 				gain_calc = LINE_IN_GAIN_RESCALE;			// Yes - fixed gain scaling for line input - the rest is done in hardware
 			else	{
 				gain_calc = (float)ts.tx_mic_gain_mult;		// We are in MIC In mode:  Calculate Microphone gain
@@ -2126,12 +2134,16 @@ static void audio_tx_processor(int16_t *src, int16_t *dst, int16_t size)
 		else
 			fm_mod_mult = 1;	// not in 5 kHz mode - used default (2.5 kHz) modulation factors
 		//
+		if(ts.tx_audio_source == TX_AUDIO_LINEIN_R) {	 	// Are we in LINE IN mode?
+			src++;
+			// use right channel data
+		}
 		for(i = 0; i < size/2; i++)	{				// Copy to single buffer
 			ads.a_buffer[i] = (float)*src;
 			src += 2;								// Next sample
 		}
 		//
-		if(ts.tx_audio_source == TX_AUDIO_LINEIN)		// Are we in LINE IN mode?
+		if(ts.tx_audio_source != TX_AUDIO_MIC)		// Are we in LINE IN mode?
 			gain_calc = LINE_IN_GAIN_RESCALE;			// Yes - fixed gain scaling for line input - the rest is done in hardware
 		else	{
 			gain_calc = (float)ts.tx_mic_gain_mult;		// We are in MIC In mode:  Calculate Microphone gain
@@ -2262,12 +2274,17 @@ static void audio_dv_tx_processor(int16_t *src, int16_t *dst, int16_t size)
 
 	// Not tune mode - use audio from CODEC
 	// Fill I and Q buffers with left channel(same as right)
+	if(ts.tx_audio_source == TX_AUDIO_LINEIN_R) {	 	// Are we in LINE IN mode?
+		src++;
+		// use right channel data
+	}
 	for(i = 0; i < size/2; i++)	{				// Copy to single buffer
 		ads.a_buffer[i] = (float)*src;
 		src += 2;								// Next sample
 	}
+
 	//
-	if(ts.tx_audio_source == TX_AUDIO_LINEIN)		// Are we in LINE IN mode?
+	if(ts.tx_audio_source != TX_AUDIO_MIC)		// Are we in LINE IN mode?
 		gain_calc = LINE_IN_GAIN_RESCALE;			// Yes - fixed gain scaling for line input - the rest is done in hardware
 	else	{
 		gain_calc = (float)ts.tx_mic_gain_mult;		// We are in MIC In mode:  Calculate Microphone gain

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -1397,7 +1397,9 @@ static void UiDriverProcessKeyboard(void)
 				case BUTTON_M3_PRESSED:	// Press-and-hold button M3:  Switch display between MIC and Line-In mode
 					if(ts.dmod_mode != DEMOD_CW)	{
 						if(ts.tx_audio_source == TX_AUDIO_MIC)
-							ts.tx_audio_source = TX_AUDIO_LINEIN;
+							ts.tx_audio_source = TX_AUDIO_LINEIN_L;
+						else if (ts.tx_audio_source == TX_AUDIO_LINEIN_L)
+							ts.tx_audio_source = TX_AUDIO_LINEIN_R;
 						else
 							ts.tx_audio_source = TX_AUDIO_MIC;
 						//
@@ -6187,8 +6189,10 @@ void UIDriverChangeAudioGain(uchar enabled)
 
 	if(ts.tx_audio_source == TX_AUDIO_MIC)		// Microphone gain
 		strcpy(temp, "MIC");
-	else										// Line gain
+	else if (ts.tx_audio_source == TX_AUDIO_LINEIN_L)										// Line gain
 		strcpy(temp, "LIN");
+	else
+		strcpy(temp, "L-R");
 
 	if(enabled)
 		UiLcdHy28_PrintText((POS_KS_IND_X + 1), (POS_KS_IND_Y + 1),temp,Black,Grey,0);

--- a/mchf-eclipse/drivers/ui/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/ui_menu.c
@@ -1435,12 +1435,13 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode)
 						TX_AUDIO_MIC,
 						1
 						);
-		//
 		if(ts.tx_audio_source == TX_AUDIO_MIC)
-			strcpy(options, " MIC");
-		else if(ts.tx_audio_source == TX_AUDIO_LINEIN)
-			strcpy(options, "LINE");
-		//
+			strcpy(options, "   MIC");
+		else if(ts.tx_audio_source == TX_AUDIO_LINEIN_L)
+			strcpy(options, "LINE-L");
+		else if(ts.tx_audio_source == TX_AUDIO_LINEIN_R)
+			strcpy(options, "LINE-R");
+
 		if(fchange)	{		// if there was a change, do update of on-screen information
 			if(ts.dmod_mode == DEMOD_CW)
 				UiDriverChangeKeyerSpeed(0);
@@ -1487,7 +1488,7 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode)
 	//
 	case MENU_LINE_GAIN:	// Line Gain setting
 
-		if(ts.tx_audio_source == TX_AUDIO_LINEIN)	{	// Allow adjustment only if in line-in mode
+		if(ts.tx_audio_source == TX_AUDIO_LINEIN_L && ts.tx_audio_source == TX_AUDIO_LINEIN_R)	{	// Allow adjustment only if in line-in mode
 			fchange = UiDriverMenuItemChangeUInt8(var, mode, &ts.tx_line_gain,
 							LINE_GAIN_MIN,
 							LINE_GAIN_MAX,
@@ -1507,7 +1508,7 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode)
 			}
 		}
 		//
-		if(ts.tx_audio_source != TX_AUDIO_LINEIN)	// Orange if not in LINE-IN mode
+		if(ts.tx_audio_source != TX_AUDIO_LINEIN_L && ts.tx_audio_source != TX_AUDIO_LINEIN_R)	// Orange if not in LINE-IN mode
 			clr = Orange;
 		//
 		sprintf(options, "  %u", ts.tx_line_gain);

--- a/mchf-eclipse/hardware/mchf_board.h
+++ b/mchf-eclipse/hardware/mchf_board.h
@@ -705,8 +705,9 @@ enum {
 
 // Audio sources for TX modulation
 #define TX_AUDIO_MIC			0
-#define TX_AUDIO_LINEIN			1
-#define TX_AUDIO_MAX_ITEMS		2
+#define TX_AUDIO_LINEIN_L		1
+#define TX_AUDIO_LINEIN_R		2
+#define TX_AUDIO_MAX_ITEMS		3
 //
 #define	LINE_GAIN_MIN			3
 #define	LINE_GAIN_MAX			31
@@ -1305,6 +1306,7 @@ typedef struct TransceiverState
 	uchar	power_level;
 
 	uchar 	tx_audio_source;
+	uchar   tx_line_channel;  // 1 LEFT 2 RIGHT
 	uchar	tx_mic_gain;
 	ulong	tx_mic_gain_mult;
 	ulong	tx_mic_gain_mult_temp;	// used to temporarily hold the mic gain when going from RX to TX


### PR DESCRIPTION
Changes: 060 now has settings MIC - LINE-L - LINE-R.
Stored settings are 100% compatible, i.e. if previously LINE was selected now LINE-L is display which is exactly the same thing. 
Long press on M3 now toggles through the 3 choices instead of two. L-R is displayed if right channel LINEIN is selected.