### PR TITLE
Very experimental USB AUDIO Support. If enabled in mchf_board.h

### DIFF
--- a/mchf-eclipse/drivers/cat/cat_driver.c
+++ b/mchf-eclipse/drivers/cat/cat_driver.c
@@ -50,7 +50,11 @@ void cat_driver_init(void)
 	USBD_Init(	&USB_OTG_dev,
 			USB_OTG_FS_CORE_ID,
 			&USR_desc,
+#ifndef USB_AUDIO_SUPPORT
 			&USBD_CDC_cb,
+#else
+			&USBD_AUDIO_cb,
+#endif
 			&USR_cb);
 
 	printf("cat driver started\n\r");

--- a/mchf-eclipse/drivers/cat/usb/usbd_conf.h
+++ b/mchf-eclipse/drivers/cat/usb/usbd_conf.h
@@ -49,6 +49,11 @@
 #define CDC_OUT_EP                      0x01  /* EP1 for data OUT */
 #define CDC_CMD_EP                      0x82  /* EP2 for CDC commands */
 
+#define AUDIO_TOTAL_IF_NUM 0x03
+
+#define AUDIO_OUT_EP 0x01
+#define AUDIO_IN_EP 0x81
+
 /* CDC Endpoints parameters: you can fine tune these values depending on the needed baudrates and performance. */
 #ifdef USE_USB_OTG_HS
  #define CDC_DATA_MAX_PACKET_SIZE       64  /* Endpoint IN & OUT Packet size */

--- a/mchf-eclipse/hardware/mchf_board.h
+++ b/mchf-eclipse/hardware/mchf_board.h
@@ -55,6 +55,9 @@
 // -----------------------------------------------------------------------------
 //#define 	DEBUG_BUILD
 
+// #define USB_AUDIO_SUPPORT // uncomment this to get experimental USB AUDIO Support
+
+
 #define		WD_REFRESH_WINDOW		80
 #define		WD_REFRESH_COUNTER		127
 

--- a/mchf-eclipse/usb/otg/src/usb_core.c
+++ b/mchf-eclipse/usb/otg/src/usb_core.c
@@ -1397,8 +1397,8 @@ USB_OTG_STS USB_OTG_EnableDevInt(USB_OTG_CORE_HANDLE *pdev)
   intmsk.b.outepintr  = 1;
   intmsk.b.sofintr    = 1; 
   
-  intmsk.b.incomplisoin    = 1; 
-  intmsk.b.incomplisoout    = 1;   
+//  intmsk.b.incomplisoin    = 1;
+//  intmsk.b.incomplisoout    = 1;
 #ifdef VBUS_SENSING_ENABLED
   intmsk.b.sessreqintr    = 1; 
   intmsk.b.otgintr    = 1;    

--- a/mchf-eclipse/usb/otg/src/usb_dcd_int.c
+++ b/mchf-eclipse/usb/otg/src/usb_dcd_int.c
@@ -674,7 +674,13 @@ static uint32_t DCD_WriteEmptyTxFifo(USB_OTG_CORE_HANDLE *pdev, uint32_t epnum)
     
     ep->xfer_buff  += len;
     ep->xfer_count += len;
-    
+
+    // https://gist.github.com/voidlizard/2282087
+    if( ep->xfer_count >= ep->xfer_len){
+        uint32_t fifoemptymsk = 1 << ep->num;
+        USB_OTG_MODIFY_REG32(&pdev->regs.DREGS->DIEPEMPMSK, fifoemptymsk, 0);
+        break;
+      }
     txstatus.d32 = USB_OTG_READ_REG32(&pdev->regs.INEP_REGS[epnum]->DTXFSTS);
   }
   

--- a/mchf-eclipse/usb/usb_conf.h
+++ b/mchf-eclipse/usb/usb_conf.h
@@ -174,10 +174,10 @@
 /****************** USB OTG FS CONFIGURATION **********************************/
 #ifdef USB_OTG_FS_CORE
  #define RX_FIFO_FS_SIZE                          128
- #define TX0_FIFO_FS_SIZE                          32
+ #define TX0_FIFO_FS_SIZE                         128
  #define TX1_FIFO_FS_SIZE                         128
- #define TX2_FIFO_FS_SIZE                          32 
- #define TX3_FIFO_FS_SIZE                           0
+ #define TX2_FIFO_FS_SIZE                         128
+ #define TX3_FIFO_FS_SIZE                         0
 
 // #define USB_OTG_FS_LOW_PWR_MGMT_SUPPORT
 // #define USB_OTG_FS_SOF_OUTPUT_ENABLED

--- a/mchf-eclipse/usb/usbd/class/audio/inc/usbd_audio_core.h
+++ b/mchf-eclipse/usb/usbd/class/audio/inc/usbd_audio_core.h
@@ -50,17 +50,27 @@
 /** @defgroup usbd_audio_Exported_Defines
   * @{
   */ 
-
+#define USBD_AUDIO_FREQ 48000
+#define USBD_IN_AUDIO_FREQ 16000
 /* AudioFreq * DataSize (2 bytes) * NumChannels (Stereo: 2) */
 #define AUDIO_OUT_PACKET                              (uint32_t)(((USBD_AUDIO_FREQ * 2 * 2) /1000)) 
+#define AUDIO_IN_PACKET                              (uint32_t)(((USBD_IN_AUDIO_FREQ * 1 * 2) /1000))
 
 /* Number of sub-packets in the audio transfer buffer. You can modify this value but always make sure
   that it is an even number and higher than 3 */
 #define OUT_PACKET_NUM                                   4
 /* Total size of the audio transfer buffer */
 #define TOTAL_OUT_BUF_SIZE                           ((uint32_t)(AUDIO_OUT_PACKET * OUT_PACKET_NUM))
-
-#define AUDIO_CONFIG_DESC_SIZE                        109
+#define AUDIO_IN
+#if  defined(AUDIO_BOTH)
+	#define AUDIO_IN
+	#define AUDIO_OUT
+	#define AUDIO_CONFIG_DESC_SIZE                        (109+52+21)
+#elif defined(AUDIO_OUT)
+	#define AUDIO_CONFIG_DESC_SIZE                        (109)
+#elif defined(AUDIO_IN)
+	#define AUDIO_CONFIG_DESC_SIZE                        (100)
+#endif
 #define AUDIO_INTERFACE_DESC_SIZE                     9
 #define USB_AUDIO_DESC_SIZ                            0x09
 #define AUDIO_STANDARD_ENDPOINT_DESC_SIZE             0x09

--- a/mchf-eclipse/usb/usbd/class/audio/src/usbd_audio_out_if.c
+++ b/mchf-eclipse/usb/usbd/class/audio/src/usbd_audio_out_if.c
@@ -255,12 +255,12 @@ return AUDIO_OK;
 static uint8_t  VolumeCtl    (uint8_t vol)
 {
   /* Call low layer volume setting function */  
-//  if (EVAL_AUDIO_VolumeCtl(vol) != 0)
+/* if (EVAL_AUDIO_VolumeCtl(vol) != 0)
   {
     AudioState = AUDIO_STATE_ERROR;
     return AUDIO_FAIL;
   }
-  
+*/
   return AUDIO_OK;
 }
 


### PR DESCRIPTION
connecting should provide a Soundcard showing up in the host.
The "microphone" should deliver a nice and clean sinus of 500 Hz,
i.e. half of a sinus wave per frame each 1ms. Disabled by
default. Does not have any impact if not enabled.
Only change not entirely local to the audio is the increased
USB tx fifo size.