### PR TITLE
AUDIO OUT: Works much, much better now.

### DIFF
--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -1425,6 +1425,10 @@ static void UiDriverProcessKeyboard(void)
 							ts.tx_audio_source = TX_AUDIO_LINEIN_L;
 						else if (ts.tx_audio_source == TX_AUDIO_LINEIN_L)
 							ts.tx_audio_source = TX_AUDIO_LINEIN_R;
+						else if (ts.tx_audio_source == TX_AUDIO_LINEIN_R)
+							ts.tx_audio_source = TX_AUDIO_DIG;
+						else if (ts.tx_audio_source == TX_AUDIO_DIG)
+							ts.tx_audio_source = TX_AUDIO_DIGIQ;
 						else
 							ts.tx_audio_source = TX_AUDIO_MIC;
 						//
@@ -6203,18 +6207,20 @@ void UIDriverChangeAudioGain(uchar enabled)
 
 	UiLcdHy28_DrawEmptyRect( POS_KS_IND_X,POS_KS_IND_Y,13,49,Grey);
 
-	if(ts.tx_audio_source == TX_AUDIO_MIC)		// Microphone gain
+	if(ts.tx_audio_source == TX_AUDIO_MIC) {		// Microphone gain
 		strcpy(temp, "MIC");
-	else if (ts.tx_audio_source == TX_AUDIO_LINEIN_L)										// Line gain
+	} else if (ts.tx_audio_source == TX_AUDIO_LINEIN_L) {										// Line gain
 		strcpy(temp, "L>L");
-	else
+	}else if (ts.tx_audio_source == TX_AUDIO_LINEIN_R) {										// Line gain
 		strcpy(temp, "L>R");
-
-	if(enabled)
-		UiLcdHy28_PrintText((POS_KS_IND_X + 1), (POS_KS_IND_Y + 1),temp,Black,Grey,0);
-	else
-		UiLcdHy28_PrintText((POS_KS_IND_X + 1), (POS_KS_IND_Y + 1),temp,Grey1,Grey,0);
-
+	} else if (ts.tx_audio_source == TX_AUDIO_DIG) {										// Line gain
+		strcpy(temp, "DIG");
+	} else if (ts.tx_audio_source == TX_AUDIO_DIGIQ) {
+		strcpy(temp, "DIQ");
+	} else {
+		strcpy(temp, "???");
+	}
+	UiLcdHy28_PrintText((POS_KS_IND_X + 1), (POS_KS_IND_Y + 1),temp,enabled?Black:Grey1,Grey,0);
 	memset(temp,0,100);
 
 	if(ts.tx_audio_source == TX_AUDIO_MIC)		// Mic gain mode
@@ -6774,7 +6780,7 @@ static void UiDriverFFTWindowFunction(char mode)
 				sd.FFT_Windat[i] = arm_sin_f32((PI * (float32_t)i)/FFT_IQ_BUFF_LEN - 1) * sd.FFT_Samples[i];
 			}
 			break;
-		case FFT_WINDOW_BARTLETT:		// a.k.a. "Triangular" window - Bartlett (or Fejér) window is special case where demonimator is "N-1". Somewhat better-behaved than Rectangular
+		case FFT_WINDOW_BARTLETT:		// a.k.a. "Triangular" window - Bartlett (or Fejï¿½r) window is special case where demonimator is "N-1". Somewhat better-behaved than Rectangular
 			for(i = 0; i < FFT_IQ_BUFF_LEN; i++){
 				sd.FFT_Windat[i] = (1 - fabs(i - ((float32_t)FFT_IQ_BUFF_M1_HALF))/(float32_t)FFT_IQ_BUFF_M1_HALF) * sd.FFT_Samples[i];
 			}

--- a/mchf-eclipse/drivers/ui/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/ui_menu.c
@@ -1448,12 +1448,17 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode)
 						TX_AUDIO_MIC,
 						1
 						);
-		if(ts.tx_audio_source == TX_AUDIO_MIC)
-			strcpy(options, "   MIC");
-		else if(ts.tx_audio_source == TX_AUDIO_LINEIN_L)
-			strcpy(options, "LINE-L");
-		else if(ts.tx_audio_source == TX_AUDIO_LINEIN_R)
-			strcpy(options, "LINE-R");
+		if(ts.tx_audio_source == TX_AUDIO_MIC) {
+			strcpy(options, "    MIC");
+		} else if(ts.tx_audio_source == TX_AUDIO_LINEIN_L) {
+			strcpy(options, " LINE-L");
+		} else if(ts.tx_audio_source == TX_AUDIO_LINEIN_R) {
+			strcpy(options, " LINE-R");
+		} else if(ts.tx_audio_source == TX_AUDIO_DIG) {
+			strcpy(options, " DIGITAL");
+		} else if(ts.tx_audio_source == TX_AUDIO_DIGIQ) {
+			strcpy(options, " DIG I/Q");
+		}
 
 		if(fchange)	{		// if there was a change, do update of on-screen information
 			if(ts.dmod_mode == DEMOD_CW)
@@ -1461,6 +1466,12 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode)
 			else
 				UIDriverChangeAudioGain(0);
 		}
+
+		if((!ts.cat_mode_active) &&(ts.tx_audio_source == TX_AUDIO_DIG || ts.tx_audio_source == TX_AUDIO_DIG)) {
+			// RED if CAT is not enabled
+			clr = Red;
+		}
+
 		break;
 	//
 	case MENU_MIC_GAIN:	// Mic Gain setting
@@ -1493,8 +1504,9 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode)
 				UIDriverChangeAudioGain(0);
 		}
 		//
-		if(ts.tx_audio_source != TX_AUDIO_MIC)	// Orange if not in MIC-IN mode
+		if(ts.tx_audio_source != TX_AUDIO_MIC) {	// Orange if not in MIC-IN mode
 			clr = Orange;
+		}
 		//
 		sprintf(options, "   %u", ts.tx_mic_gain);
 		break;

--- a/mchf-eclipse/hardware/mchf_board.h
+++ b/mchf-eclipse/hardware/mchf_board.h
@@ -714,7 +714,9 @@ enum {
 #define TX_AUDIO_MIC			0
 #define TX_AUDIO_LINEIN_L		1
 #define TX_AUDIO_LINEIN_R		2
-#define TX_AUDIO_MAX_ITEMS		2
+#define TX_AUDIO_DIG			3
+#define TX_AUDIO_DIGIQ			4
+#define TX_AUDIO_MAX_ITEMS		4
 //
 #define	LINE_GAIN_MIN			3
 #define	LINE_GAIN_MAX			31

--- a/mchf-eclipse/usb/usbd/class/audio/src/usbd_audio_out_if.c
+++ b/mchf-eclipse/usb/usbd/class/audio/src/usbd_audio_out_if.c
@@ -142,25 +142,23 @@ enum USB_DIG_AUDIO {
   * @{
   */ 
 
-#define USB_AUDIO_OUT_NUM_BUF 8
+#define USB_AUDIO_OUT_NUM_BUF 16
 #define USB_AUDIO_OUT_PKT_SIZE   (AUDIO_OUT_PACKET/2)
 #define USB_AUDIO_OUT_BUF_SIZE (USB_AUDIO_OUT_NUM_BUF * USB_AUDIO_OUT_PKT_SIZE)
 
 static volatile int16_t out_buffer[USB_AUDIO_OUT_BUF_SIZE]; //buffer for filtered PCM data from Recv.
-static int16_t Silence[USB_AUDIO_OUT_PKT_SIZE];
 static volatile uint16_t out_buffer_tail;
 static volatile uint16_t out_buffer_head;
 static volatile uint16_t out_buffer_overflow;
 
-uint32_t data_received;
-
 static void audio_out_put_buffer(int16_t sample) {
 
-	out_buffer[out_buffer_head] = sample;
-	data_received++;
-	out_buffer_head=  (out_buffer_head + 1) %USB_AUDIO_OUT_BUF_SIZE;
-	// now test buffer full
-	if (out_buffer_head == out_buffer_tail) {
+	uint32_t next_head = (out_buffer_head + 1) %USB_AUDIO_OUT_BUF_SIZE;
+
+	if (next_head != out_buffer_head) {
+		out_buffer[out_buffer_head] = sample;
+		out_buffer_head = next_head;
+	} else {
 		// ok. We loose data now, should never ever happen, but so what
 		// will cause minor distortion if only a few bytes.
 		out_buffer_overflow++;
@@ -187,18 +185,13 @@ static void audio_out_buffer_pop_pkt(volatile int16_t* ptr, uint32_t len) {
 }
 
 /* len is length in 16 bit samples */
-
-uint32_t silence_delivered;
-uint32_t data_delivered;
-uint32_t last_streak;
-
 void audio_out_fill_tx_buffer(int16_t *buffer, uint32_t len) {
 	volatile int16_t *pkt = audio_out_buffer_next_pkt(len);
 
 	static uint16_t fill_buffer = 1;
 	if (fill_buffer == 0 && pkt) {
-		data_delivered+=len;
-		for (;len;len--) {
+		uint32_t idx;
+		for (idx = len;idx;idx--) {
 			*buffer++ = *pkt++;
 		}
 		audio_out_buffer_pop_pkt(pkt,len);
@@ -206,12 +199,7 @@ void audio_out_fill_tx_buffer(int16_t *buffer, uint32_t len) {
 		if (fill_buffer == 0) {
 			fill_buffer = 1;
 		}
-		if (data_delivered) {
-			last_streak = data_delivered;
-			data_delivered = 0;
-		}
-		silence_delivered+=len;
-		if (audio_out_buffer_next_pkt(USB_AUDIO_OUT_BUF_SIZE/2) != NULL) {
+		if (audio_out_buffer_next_pkt((USB_AUDIO_OUT_BUF_SIZE*2)/3) != NULL) {
 			fill_buffer = 0;
 		}
 		// Deliver silence if not enough data is stored in buffer


### PR DESCRIPTION
Luckily it was bad weather today :-) 
See my last commit comment, there are some issues still but in general it works quite good.
Two new input modes have been added (switchable in Menu #060 and with long press on the button under encoder 3): DIGITAL (DIG) and DIG I/Q (DIQ).
Digital uses the audio from the left channel for modulation according to the set mode (SSB, AM, ... ).
Digital I/Q uses both channels to transmitt IQ data 48khz, 16 bit. The second choice is untested (which program could I use?) but should work (since it essentially just bypasses all (!) the processing).
Only when in DIG or DIG IQ the USB audio out channel is being used. Otherwise only the sound  is sent to PC and  of course CAT FT817 emulation is running all the time once CAT mode is enabled.
Overhead of the USB DIGITAL modes mode is roughly  1,5% (or 15uS each 1ms). So the device should be as responsive as ever.


 
