### PR TITLE
Digital I/Q now also works in RX mode.

### DIFF
--- a/mchf-eclipse/support/MCHF.cfg
+++ b/mchf-eclipse/support/MCHF.cfg
@@ -7,7 +7,7 @@ set WORKAREASIZE 0x20000
 transport select "hla_swd"
 
 
-source [find target/stm32f4x_stlink.cfg]
+source [find target/stm32f4x.cfg]
 
 # use hardware reset, connect under reset
 reset_config none

--- a/mchf-eclipse/usb/usbd/class/audio/inc/usbd_audio_core.h
+++ b/mchf-eclipse/usb/usbd/class/audio/inc/usbd_audio_core.h
@@ -51,14 +51,22 @@
   * @{
   */ 
 #define USBD_AUDIO_FREQ 48000
-#define USBD_IN_AUDIO_FREQ 16000
+// this is fixed to match the I2S Frequency
+#define USBD_AUDIO_OUT_CHANNELS 2
+#define USBD_AUDIO_IN_OUT_DIV 1
+// USBD_IN_AUDIO_IN_OUT_DIV must be set to an integer number between 3 and 1
+// in order to keep within the limits of the existing code in audio_driver.c audio_rx_processor
+
+#define USBD_AUDIO_IN_CHANNELS 2
+#define USBD_AUDIO_IN_FREQ (USBD_AUDIO_FREQ/USBD_AUDIO_IN_OUT_DIV)
+
 
 
 
 
 /* AudioFreq * DataSize (2 bytes) * NumChannels (Stereo: 2) */
-#define AUDIO_OUT_PACKET                              (uint32_t)(((USBD_AUDIO_FREQ * 2 * 2) /1000)) 
-#define AUDIO_IN_PACKET                              (uint32_t)(((USBD_IN_AUDIO_FREQ * 1 * 2) /1000))
+#define AUDIO_OUT_PACKET                              (uint32_t)(((USBD_AUDIO_FREQ * USBD_AUDIO_OUT_CHANNELS * 2) /1000))
+#define AUDIO_IN_PACKET                              (uint32_t)(((USBD_AUDIO_IN_FREQ * USBD_AUDIO_IN_CHANNELS * 2) /1000))
 
 
 
@@ -143,8 +151,8 @@ typedef struct _Audio_Fops
   * @{
   */ 
 // this works only for 2channel 16 bit audio
-#define AUDIO_PACKET_SZE(frq)          (uint8_t)(((frq * 2 * 2)/1000) & 0xFF), \
-                                       (uint8_t)((((frq * 2 * 2)/1000) >> 8) & 0xFF)
+#define AUDIO_PACKET_SZE(frq,channels)          (uint8_t)(((frq * channels * 2)/1000) & 0xFF), \
+                                       (uint8_t)((((frq * channels * 2)/1000) >> 8) & 0xFF)
 #define SAMPLE_FREQ(frq)               (uint8_t)(frq), (uint8_t)((frq >> 8)), (uint8_t)((frq >> 16))
 
 extern void audio_in_put_buffer(int16_t sample);

--- a/mchf-eclipse/usb/usbd/class/audio/src/usbd_audio_core.c
+++ b/mchf-eclipse/usb/usbd/class/audio/src/usbd_audio_core.c
@@ -152,6 +152,7 @@ uint8_t* IsocOutRdPtr = IsocOutBuff;
 
 #define USB_AUDIO_IN_NUM_BUF 8
 #define USB_AUDIO_IN_PKT_SIZE   (AUDIO_IN_PACKET/2)
+// size in samples not size in bytes
 #define USB_AUDIO_IN_BUF_SIZE (USB_AUDIO_IN_NUM_BUF * USB_AUDIO_IN_PKT_SIZE)
 
 static volatile int16_t in_buffer[USB_AUDIO_IN_BUF_SIZE]; //buffer for filtered PCM data from Recv.
@@ -447,7 +448,7 @@ static uint8_t usbd_audio_CfgDesc[AUDIO_CONFIG_DESC_SIZE] =
 		0x04,                         // ID of this Terminal.
 		0x01,0x02,                    // Terminal is Microphone (0x01,0x02)
 		0x00,                         // No association
-		0x01,                         // One channel
+		USBD_AUDIO_IN_CHANNELS,                         // One or two channel
 		0x00,0x00,                    // Mono sets no position bits
 		0x00,                         // Unused.
 		0x00,                         // Unused.
@@ -480,7 +481,7 @@ static uint8_t usbd_audio_CfgDesc[AUDIO_CONFIG_DESC_SIZE] =
 		/* Interface 1, Alternate Setting 1                                           */
 		AUDIO_INTERFACE_DESC_SIZE,  /* bLength */
 		USB_INTERFACE_DESCRIPTOR_TYPE,        /* bDescriptorType */
-		AUDIO_OUT_IF,                                 /* bInterfaceNumber */
+		AUDIO_OUT_IF,                         /* bInterfaceNumber */
 		0x01,                                 /* bAlternateSetting */
 		0x01,                                 /* bNumEndpoints */
 		USB_DEVICE_CLASS_AUDIO,               /* bInterfaceClass */
@@ -516,7 +517,7 @@ static uint8_t usbd_audio_CfgDesc[AUDIO_CONFIG_DESC_SIZE] =
 		USB_ENDPOINT_DESCRIPTOR_TYPE,         /* bDescriptorType */
 		AUDIO_OUT_EP,                         /* bEndpointAddress 1 out endpoint*/
 		USB_ENDPOINT_TYPE_ISOCHRONOUS,        /* bmAttributes */
-		AUDIO_PACKET_SZE(USBD_AUDIO_FREQ),    /* wMaxPacketSize in Bytes (Freq(Samples)*2(Stereo)*2(HalfWord)) */
+		AUDIO_PACKET_SZE(USBD_AUDIO_FREQ,USBD_AUDIO_OUT_CHANNELS),    /* wMaxPacketSize in Bytes (Freq(Samples)*2(Stereo)*2(HalfWord)) */
 		0x01,                                 /* bInterval */
 		0x00,                                 /* bRefresh */
 		0x00,                                 /* bSynchAddress */
@@ -569,11 +570,11 @@ static uint8_t usbd_audio_CfgDesc[AUDIO_CONFIG_DESC_SIZE] =
 		AUDIO_INTERFACE_DESCRIPTOR_TYPE,// CS_INTERFACE Descriptor Type (bDescriptorType) 0x24
 		AUDIO_STREAMING_FORMAT_TYPE,   // FORMAT_TYPE subtype. (bDescriptorSubtype) 0x02
 		0x01,                        // FORMAT_TYPE_I. (bFormatType)
-		0x01,                        // One channel.(bNrChannels)
+		USBD_AUDIO_IN_CHANNELS,                        // One or two channel.(bNrChannels)
 		0x02,                        // Two bytes per audio subframe.(bSubFrameSize)
 		0x10,                        // 16 bits per sample.(bBitResolution)
 		0x01,                        // One frequency supported. (bSamFreqType)
-		(USBD_IN_AUDIO_FREQ&0xFF),((USBD_IN_AUDIO_FREQ>>8)&0xFF),0x00,  // 16000Hz. (tSamFreq) (NOT COMPLETE!!!)
+		(USBD_AUDIO_IN_FREQ&0xFF),((USBD_AUDIO_IN_FREQ>>8)&0xFF),0x00,  // (tSamFreq) (NOT COMPLETE!!!)
 
 		/*  USB Microphone Standard Endpoint Descriptor (CODE == 8)*/ //Standard AS Isochronous Audio Data Endpoint Descriptor
 		0x09,                       // Size of the descriptor, in bytes (bLength)


### PR DESCRIPTION
 Digital I/Q RX now works when in DIGITIAL IQ mode (DIQ).
WINDOWS USER: who used any previous build have to go to "Recording Devices", Advanced and have to set the Sample Rate to 48 Khz. I don't know why Windows is not changing it by itself as this is now the only rate offered by the device.

HD SDR, 48khz Sample Rate works very well.
Of course, no control of frequency on the mcHF as HDSDR does not know the FT817 directly but via Omnirig. Works without problems for RX. TX not tested, though.