### PR TITLE
Improved CAT handling in DIG IQ mode:

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -51,6 +51,18 @@
 #include "filters/fir_rx_interpolate_16.h"	// filter for interpolate-by-16 operation
 #include "filters/fir_rx_interpolate_16_10kHz.h"	// This has relaxed LPF for the 10 kHz filter mode
 
+
+uint32_t audio_driver_xlate_freq() {
+  uint32_t fdelta = 0;
+  switch (ts.iq_freq_mode) {
+  case FREQ_IQ_CONV_P6KHZ: fdelta = 6000*4; break;
+  case FREQ_IQ_CONV_M6KHZ: fdelta = - 6000*4; break;
+  case FREQ_IQ_CONV_P12KHZ: fdelta = 12000*4; break;
+  case FREQ_IQ_CONV_M12KHZ: fdelta = -12000*4; break;
+  }
+  return fdelta;
+}
+
 static void Audio_Init(void);
 
 // ---------------------------------

--- a/mchf-eclipse/drivers/audio/audio_driver.h
+++ b/mchf-eclipse/drivers/audio/audio_driver.h
@@ -566,6 +566,7 @@ void audio_driver_stop(void);
 void audio_driver_set_rx_audio_filter(void);
 void audio_driver_thread(void);
 void Audio_TXFilter_Init(void);
+uint32_t audio_driver_xlate_freq();
 //uchar audio_check_nr_dsp_state(void);
 
 #ifdef USE_24_BITS


### PR DESCRIPTION
If in DIGITAL IQ mode, CAT interface reports base
frequency instead of translated frequency.