### PR TITLE
cleaning up void UiDriverChangeBandFilter(uchar band, uchar bpf_only);

### DIFF
--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -92,7 +92,6 @@ static void 	UiDriverProcessFunctionKeyClick(ulong id);
 //static void 	UiDriverShowMode(void);
 //static void 	UiDriverShowStep(ulong step);
 static void 	UiDriverShowBand(uchar band);
-//static void 	UiDriverChangeBandFilter(uchar band,uchar bpf_only);
 static void 	UiDriverCreateDesktop(void);
 static void 	UiDriverCreateFunctionButtons(bool full_repaint);
 //static void 	UiDriverCreateSpectrumScope(void);
@@ -2260,10 +2259,8 @@ static void UiDriverShowBand(uchar band)
 //
 // -------------------------------------------
 //
-void UiDriverChangeBandFilter(uchar band,uchar bpf_only)
+void UiDriverChangeBandFilter(uchar band)
 {
-	if(bpf_only)
-		goto do_bpf;
 
 	// ---------------------------------------------
 	// Set LPFs
@@ -2377,8 +2374,6 @@ void UiDriverChangeBandFilter(uchar band,uchar bpf_only)
 			break;
 	}
 
-do_bpf:
-
 	// ---------------------------------------------
 	// Set BPFs
 	// Constant line states for the BPF filter,
@@ -2474,7 +2469,7 @@ static void UiDriverCreateDesktop(void)
 	UiDriverShowBand(ts.band);
 
 	// Set filters
-	UiDriverChangeBandFilter(ts.band,0);
+	UiDriverChangeBandFilter(ts.band);
 
 	// Create Decode Mode (USB/LSB/AM/FM/CW)
 	UiDriverShowMode();
@@ -3371,43 +3366,43 @@ static void UiDriverCheckFilter(ulong freq)
 {
 	if(freq < BAND_FILTER_UPPER_160)	{	// are we low enough if frequency for the 160 meter filter?
 		if(ts.filter_band != FILTER_BAND_160)	{
-			UiDriverChangeBandFilter(BAND_MODE_160, 0);	// yes - set to 160 meters
+			UiDriverChangeBandFilter(BAND_MODE_160);	// yes - set to 160 meters
 			ts.filter_band = FILTER_BAND_160;
 		}
 	}
 	else if(freq < BAND_FILTER_UPPER_80)	{	// are we low enough if frequency for the 80 meter filter?
 		if(ts.filter_band != FILTER_BAND_80)	{
-			UiDriverChangeBandFilter(BAND_MODE_80, 0);	// yes - set to 80 meters
+			UiDriverChangeBandFilter(BAND_MODE_80);	// yes - set to 80 meters
 			ts.filter_band = FILTER_BAND_80;
 		}
 	}
 	else if(freq < BAND_FILTER_UPPER_40)	{
 		if(ts.filter_band != FILTER_BAND_40)	{
-			UiDriverChangeBandFilter(BAND_MODE_40, 0);	// yes - set to 40 meters
+			UiDriverChangeBandFilter(BAND_MODE_40);	// yes - set to 40 meters
 			ts.filter_band = FILTER_BAND_40;
 		}
 	}
 	else if(freq < BAND_FILTER_UPPER_20)	{
 		if(ts.filter_band != FILTER_BAND_20)	{
-			UiDriverChangeBandFilter(BAND_MODE_20, 0);	// yes - set to 20 meters
+			UiDriverChangeBandFilter(BAND_MODE_20);	// yes - set to 20 meters
 			ts.filter_band = FILTER_BAND_20;
 		}
 	}
 	else if(freq >= BAND_FILTER_UPPER_20)	{
 		if(ts.filter_band != FILTER_BAND_15)	{
-			UiDriverChangeBandFilter(BAND_MODE_10, 0);	// yes - set to 10 meters
+			UiDriverChangeBandFilter(BAND_MODE_10);	// yes - set to 10 meters
 			ts.filter_band = FILTER_BAND_15;
 		}
 	}
 	else if(freq < BAND_FILTER_UPPER_6)	{
 		if(ts.filter_band != FILTER_BAND_6)	{
-			UiDriverChangeBandFilter(BAND_MODE_6, 0);	// yes - set to 6 meters
+			UiDriverChangeBandFilter(BAND_MODE_6);	// yes - set to 6 meters
 			ts.filter_band = FILTER_BAND_6;
 		}
 	}
 	else if(freq < BAND_FILTER_UPPER_4)	{
 		if(ts.filter_band != FILTER_BAND_4)	{
-			UiDriverChangeBandFilter(BAND_MODE_4, 0);	// yes - set to 4 meters
+			UiDriverChangeBandFilter(BAND_MODE_4);	// yes - set to 4 meters
 			ts.filter_band = FILTER_BAND_4;
 		}
 	}
@@ -4479,7 +4474,7 @@ static void UiDriverChangeBand(uchar is_up)
 	UiDriverSetBandPowerFactor(new_band_index);
 
 	// Set filters
-	UiDriverChangeBandFilter(new_band_index,0);
+	UiDriverChangeBandFilter(new_band_index);
 
 	// Finally update public flag
 	ts.band = new_band_index;

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -2249,132 +2249,29 @@ static void UiDriverShowBand(uchar band)
 	}
 }
 
-// -------------------------------------------
-// 	 BAND		BAND0		BAND1		BAND2
-//
-//	 80m		1			1			x
-//	 40m		1			0			x
-//	 20/30m		0			0			x
-//	 15-10m		0			1			x
-//
-// -------------------------------------------
-//
+void UiDriverChangeBandFilterPulseRelays() {
+	BAND2_PIO->BSRRH = BAND2;
+	non_os_delay();
+	BAND2_PIO->BSRRL = BAND2;
+}
+
 void UiDriverChangeBandFilter(uchar band)
 {
-
+	// -------------------------------------------
+	// 	 BAND		BAND0		BAND1		BAND2
+	//
+	//	 80m		1			1			x
+	//	 40m		1			0			x
+	//	 20/30m		0			0			x
+	//	 15-10m		0			1			x
+	//
 	// ---------------------------------------------
-	// Set LPFs
+	// Set LPFs:
 	// Set relays in groups, internal first, then external group
 	// state change via two pulses on BAND2 line, then idle
-	switch(band)
-	{
-		case BAND_MODE_2200:
-		case BAND_MODE_630:
-		case BAND_MODE_160:
-		case BAND_MODE_80:
-		{
-			// Internal group - Set(High/Low)
-			BAND0_PIO->BSRRL = BAND0;
-			BAND1_PIO->BSRRH = BAND1;
-
-			// Pulse relays
-			BAND2_PIO->BSRRH = BAND2;
-			non_os_delay();
-			BAND2_PIO->BSRRL = BAND2;
-
-			// External group -Set(High/High)
-			BAND0_PIO->BSRRL = BAND0;
-			BAND1_PIO->BSRRL = BAND1;
-
-			// Pulse relays
-			BAND2_PIO->BSRRH = BAND2;
-			non_os_delay();
-			BAND2_PIO->BSRRL = BAND2;
-
-			break;
-		}
-
-		case BAND_MODE_60:
-		case BAND_MODE_40:
-		{
-			// Internal group - Set(High/Low)
-			BAND0_PIO->BSRRL = BAND0;
-			BAND1_PIO->BSRRH = BAND1;
-
-			// Pulse relays
-			BAND2_PIO->BSRRH = BAND2;
-			non_os_delay();
-			BAND2_PIO->BSRRL = BAND2;
-
-			// External group - Reset(Low/High)
-			BAND0_PIO->BSRRH = BAND0;
-			BAND1_PIO->BSRRL = BAND1;
-
-			// Pulse relays
-			BAND2_PIO->BSRRH = BAND2;
-			non_os_delay();
-			BAND2_PIO->BSRRL = BAND2;
-
-			break;
-		}
-
-		case BAND_MODE_30:
-		case BAND_MODE_20:
-		{
-			// Internal group - Reset(Low/Low)
-			BAND0_PIO->BSRRH = BAND0;
-			BAND1_PIO->BSRRH = BAND1;
-
-			// Pulse relays
-			BAND2_PIO->BSRRH = BAND2;
-			non_os_delay();
-			BAND2_PIO->BSRRL = BAND2;
-
-			// External group - Reset(Low/High)
-			BAND0_PIO->BSRRH = BAND0;
-			BAND1_PIO->BSRRL = BAND1;
-
-			// Pulse relays
-			BAND2_PIO->BSRRH = BAND2;
-			non_os_delay();
-			BAND2_PIO->BSRRL = BAND2;
-
-			break;
-		}
-
-		case BAND_MODE_17:
-		case BAND_MODE_15:
-		case BAND_MODE_12:
-		case BAND_MODE_10:
-		case BAND_MODE_6:
-		case BAND_MODE_4:
-		{
-			// Internal group - Reset(Low/Low)
-			BAND0_PIO->BSRRH = BAND0;
-			BAND1_PIO->BSRRH = BAND1;
-
-			// Pulse relays
-			BAND2_PIO->BSRRH = BAND2;
-			non_os_delay();
-			BAND2_PIO->BSRRL = BAND2;
-
-			// External group - Set(High/High)
-			BAND0_PIO->BSRRL = BAND0;
-			BAND1_PIO->BSRRL = BAND1;
-
-			// Pulse relays
-			BAND2_PIO->BSRRH = BAND2;
-			non_os_delay();
-			BAND2_PIO->BSRRL = BAND2;
-
-			break;
-		}
-
-		default:
-			break;
-	}
-
-	// ---------------------------------------------
+	//
+	// then
+	//
 	// Set BPFs
 	// Constant line states for the BPF filter,
 	// always last - after LPF change
@@ -2385,24 +2282,66 @@ void UiDriverChangeBandFilter(uchar band)
 		case BAND_MODE_160:
 		case BAND_MODE_80:
 		{
+			// Internal group - Set(High/Low)
+			BAND0_PIO->BSRRL = BAND0;
+			BAND1_PIO->BSRRH = BAND1;
+
+			UiDriverChangeBandFilterPulseRelays();
+
+			// External group -Set(High/High)
 			BAND0_PIO->BSRRL = BAND0;
 			BAND1_PIO->BSRRL = BAND1;
+
+			UiDriverChangeBandFilterPulseRelays();
+
+			// BPF
+			BAND0_PIO->BSRRL = BAND0;
+			BAND1_PIO->BSRRL = BAND1;
+
 			break;
 		}
 
 		case BAND_MODE_60:
 		case BAND_MODE_40:
 		{
+			// Internal group - Set(High/Low)
 			BAND0_PIO->BSRRL = BAND0;
 			BAND1_PIO->BSRRH = BAND1;
+
+			UiDriverChangeBandFilterPulseRelays();
+
+			// External group - Reset(Low/High)
+			BAND0_PIO->BSRRH = BAND0;
+			BAND1_PIO->BSRRL = BAND1;
+
+			UiDriverChangeBandFilterPulseRelays();
+
+			// BPF
+			BAND0_PIO->BSRRL = BAND0;
+			BAND1_PIO->BSRRH = BAND1;
+
 			break;
 		}
 
 		case BAND_MODE_30:
 		case BAND_MODE_20:
 		{
+			// Internal group - Reset(Low/Low)
 			BAND0_PIO->BSRRH = BAND0;
 			BAND1_PIO->BSRRH = BAND1;
+
+			UiDriverChangeBandFilterPulseRelays();
+
+			// External group - Reset(Low/High)
+			BAND0_PIO->BSRRH = BAND0;
+			BAND1_PIO->BSRRL = BAND1;
+
+			UiDriverChangeBandFilterPulseRelays();
+
+			// BPF
+			BAND0_PIO->BSRRH = BAND0;
+			BAND1_PIO->BSRRH = BAND1;
+
 			break;
 		}
 
@@ -2413,14 +2352,29 @@ void UiDriverChangeBandFilter(uchar band)
 		case BAND_MODE_6:
 		case BAND_MODE_4:
 		{
+			// Internal group - Reset(Low/Low)
+			BAND0_PIO->BSRRH = BAND0;
+			BAND1_PIO->BSRRH = BAND1;
+
+			UiDriverChangeBandFilterPulseRelays();
+
+			// External group - Set(High/High)
+			BAND0_PIO->BSRRL = BAND0;
+			BAND1_PIO->BSRRL = BAND1;
+
+			UiDriverChangeBandFilterPulseRelays();
+
+			// BPF
 			BAND0_PIO->BSRRH = BAND0;
 			BAND1_PIO->BSRRL = BAND1;
+
 			break;
 		}
 
 		default:
 			break;
 	}
+
 }
 
 

--- a/mchf-eclipse/drivers/ui/ui_driver.h
+++ b/mchf-eclipse/drivers/ui/ui_driver.h
@@ -583,7 +583,7 @@ void 	UiCalcTxPhaseAdj(void);
 void 	UiDriverLoadFilterValue(void);
 void 	UiDriverClearSpectrumDisplay(void);
 //
-void 	UiDriverChangeBandFilter(uchar band,uchar bpf_only);
+void 	UiDriverChangeBandFilter(uchar band);
 void 	UiDriverChangeFilter(uchar ui_only_update);
 void 	UiDriverCreateTemperatureDisplay(uchar enabled,uchar create);
 void 	UiDriverUpdateFrequency(char skip_encoder_check, uchar mode);
@@ -595,7 +595,6 @@ void 	UiDriverSetBandPowerFactor(uchar band);
 void 	UiDrawSpectrumScopeFrequencyBarText(void);
 void 	UiCheckForEEPROMLoadDefaultRequest(void);
 //
-void 	UiDriverChangeBandFilter(uchar band,uchar bpf_only);
 void 	UiDriverChangeFilter(uchar ui_only_update);
 void 	UiDriverSetBandPowerFactor(uchar band);
 void	UiCalcRxIqGainAdj(void);

--- a/mchf-eclipse/hardware/mchf_board.h
+++ b/mchf-eclipse/hardware/mchf_board.h
@@ -543,9 +543,9 @@ typedef struct ButtonMap
 //
 #define	BAND_FILTER_UPPER_20		16000000			// Upper limit for 20/30 meter filter
 //
-#define	BAND_FILTER_UPPER_6		4000000				// Upper limit for 4/6 meter filter
+#define	BAND_FILTER_UPPER_6		40000000			// Upper limit for 6 meter filter
 //
-#define	BAND_FILTER_UPPER_4		7000000				// Upper limit for 4/6 meter filter
+#define	BAND_FILTER_UPPER_4		70000000			// Upper limit for 4 meter filter
 //
 #define	DEFAULT_FREQ_OFFSET		4000				// Amount of offset (at LO freq) when loading "default" frequency
 //


### PR DESCRIPTION
Option to change only BPF filter was not used anywhere in code. Dropping this parameter makes possible incorporating BPF and LPF filters reconfiguration into the same switch statement.