### PR TITLE
Linux Audio Improvements  and more

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -2051,7 +2051,7 @@ static void audio_tx_processor(int16_t *src, int16_t *dst, int16_t size)
 		if(ts.iq_freq_mode)	{		// is transmit frequency conversion to be done?
 
 			bool swap = ts.dmod_mode == DEMOD_LSB && (ts.iq_freq_mode == FREQ_IQ_CONV_M6KHZ || ts.iq_freq_mode == FREQ_IQ_CONV_M12KHZ);
-			swap |= DEMOD_USB && (ts.iq_freq_mode == FREQ_IQ_CONV_P6KHZ || ts.iq_freq_mode == FREQ_IQ_CONV_P12KHZ);
+			swap = swap || ((ts.dmod_mode == DEMOD_USB) && (ts.iq_freq_mode == FREQ_IQ_CONV_P6KHZ || ts.iq_freq_mode == FREQ_IQ_CONV_P12KHZ));
 			audio_rx_freq_conv(size, swap);
 		}
 		//

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -7410,28 +7410,9 @@ static void UiDriverHandlePowerSupply(void)
 	//
 	if(pwmt.voltage != val_p)	{	// Time to update - or was this the first time it was called?
 		char digits[6];
-		int idx;
-		int dot = 0;
-		char digit[2];
-
-		digit[1] = 0;
-		snprintf(digits,6,"%5ld",val_p);
-		for (idx = 0; idx < 4; idx++)
-		{
-			if (digits[idx] != pwmt.digits[idx]) {
-				digit[0] = digits[idx];
-				if (dot && digits[idx] == ' ') {
-					digits[idx] = '0'; // zeros after dot are print always
-				}
-				UiLcdHy28_PrintText((POS_PWR_IND_X + SMALL_FONT_WIDTH*(idx+dot)),POS_PWR_IND_Y,digit,col,Black,0);
-				pwmt.digits[idx] = digits[idx];
-				if (idx == 1) {
-					// now place dot on screen
-					UiLcdHy28_PrintText((POS_PWR_IND_X + SMALL_FONT_WIDTH*2),POS_PWR_IND_Y,".",col,Black,0);
-					dot = 1;
-				}
-			}
-		}
+		val_p /= 10;
+		snprintf(digits,6,"%2ld.%02ld",val_p/100,val_p%100);
+		UiLcdHy28_PrintText(POS_PWR_IND_X,POS_PWR_IND_Y,digits,col,Black,0);
 	}
 	// Reset accumulator
 	pwmt.p_curr 	= 0;

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -871,7 +871,7 @@ void UiDriverEncoderDisplaySimple(const uint8_t column, const uint8_t row, const
 	char temp[5];
 	uint32_t color = enabled?White:Grey;
 
-	snprintf(temp,5,"%2d",value);
+	snprintf(temp,5,"%2lu",value);
 	UiDriverEncoderDisplay(column, row, label, enabled,
 	                            temp, color);
 }
@@ -5468,7 +5468,7 @@ void UiDriverChangeRfGain(uchar enabled)
 		value = ts.fm_sql_threshold;
 	}
 
-	sprintf(temp," %02d",value);
+	sprintf(temp," %02ld",value);
 
 	UiDriverEncoderDisplay(0,1,label, enabled, temp, color);
 
@@ -5531,7 +5531,7 @@ static void UiDriverChangeSigProc(uchar enabled)
 	//
 	// display numerical value
 	//
-	sprintf(temp,"%02d",value);
+	sprintf(temp,"%02ld",value);
 
 	UiDriverEncoderDisplay(1,1,label, enabled, temp, color);
 }
@@ -7415,7 +7415,7 @@ static void UiDriverHandlePowerSupply(void)
 		char digit[2];
 
 		digit[1] = 0;
-		snprintf(digits,6,"%5d",val_p);
+		snprintf(digits,6,"%5ld",val_p);
 		for (idx = 0; idx < 4; idx++)
 		{
 			if (digits[idx] != pwmt.digits[idx]) {

--- a/mchf-eclipse/drivers/ui/ui_driver.h
+++ b/mchf-eclipse/drivers/ui/ui_driver.h
@@ -558,7 +558,7 @@ typedef struct EepromSave
 // Supply Voltage indicator
 #define POS_PWRN_IND_X						0
 #define POS_PWRN_IND_Y						193
-#define POS_PWR_IND_X						5
+#define POS_PWR_IND_X						4
 #define POS_PWR_IND_Y						(POS_PWRN_IND_Y + 15)
 #define COL_PWR_IND							Grey2
 

--- a/mchf-eclipse/stdio/printf.c
+++ b/mchf-eclipse/stdio/printf.c
@@ -344,7 +344,12 @@ signed int vsnprintf(char *pStr, size_t length, const char *pFormat, va_list ap)
 
                 width = length - size;
             }
-        
+            // we ignore an 'l' since l equal 32 bits aka int
+            if (*pFormat == 'l') {
+                pFormat++;
+            }
+
+
             /* Parse type */
             switch (*pFormat) {
             case 'd': 

--- a/mchf-eclipse/usb/usbd/class/audio/inc/usbd_audio_core.h
+++ b/mchf-eclipse/usb/usbd/class/audio/inc/usbd_audio_core.h
@@ -79,7 +79,7 @@
 #if  defined(AUDIO_BOTH)
 	#define AUDIO_IN
 	#define AUDIO_OUT
-	#define AUDIO_CONFIG_DESC_SIZE                        (9+101+73 + 8 + 66 /*+ 9 +7 */)
+	#define AUDIO_CONFIG_DESC_SIZE                        (9+101+73 + 8 + 66 + 9 +7)
 #elif defined(AUDIO_OUT)
 	#define AUDIO_CONFIG_DESC_SIZE                        (109 + 8)
 #endif

--- a/mchf-eclipse/usb/usbd/class/audio/src/usbd_audio_core.c
+++ b/mchf-eclipse/usb/usbd/class/audio/src/usbd_audio_core.c
@@ -388,7 +388,7 @@ static uint8_t usbd_audio_CfgDesc[AUDIO_CONFIG_DESC_SIZE] =
 		0x00,          /* 1.00 */             /* bcdADC */
 		0x01,
 #ifdef AUDIO_IN
-		61 /* + 9 + 7 */,
+		61  + 9 + 7,
 #else
 		39,
 #endif
@@ -460,9 +460,9 @@ static uint8_t usbd_audio_CfgDesc[AUDIO_CONFIG_DESC_SIZE] =
 		0x05,                            // ID of this Terminal. (bTerminalID)
 		0x01, 0x01,                      // USB Streaming. (wTerminalType
 		0x00,                            // unused         (bAssocTerminal)
-		0x04,                            // From Input Terminal.(bSourceID)
+		0x07,                            // From Input Terminal.(bSourceID)
 		0x00,                            // unused  (iTerminal)
-#if 0
+
 		/* USB Speaker Audio Feature Unit Descriptor */
 		0x09,                                 /* bLength */
 		AUDIO_INTERFACE_DESCRIPTOR_TYPE,      /* bDescriptorType */
@@ -470,7 +470,7 @@ static uint8_t usbd_audio_CfgDesc[AUDIO_CONFIG_DESC_SIZE] =
 		0x06,             					  /* bUnitID */
 		0x04,                                 /* bSourceID */
 		0x01,                                 /* bControlSize */
-		0x00,                   			  /* bmaControls(0) */
+		AUDIO_CONTROL_MUTE,                   /* bmaControls(0) */
 		0x00,                                 /* bmaControls(1) */
 		0x00,                                 /* iTerminal */
 		/* 09 byte*/
@@ -483,7 +483,6 @@ static uint8_t usbd_audio_CfgDesc[AUDIO_CONFIG_DESC_SIZE] =
 		0x01, //	bBrInPins
 		0x06, //	baSourceID(1)
 		0x00, //	iSelector
-#endif
 #endif
 		// ========================================== END AudioControl
 		/* USB Speaker Standard AS Interface Descriptor - Audio Streaming Zero Bandwith */


### PR DESCRIPTION
Now recognized by Linux WSJTX using ALSA (my benchmark). However, it seems I broke Windows now on TX, sort of. WSJT-X on Windows complains about error on audio input the moment you press tune.
TX works okay, but you get this message everytime. I assume this has todo with  the faked "Mute". So I will look into this. Maybe the microphone gets a fake bass boost instead. Should do the job as well.

Pull Request also contains some more stuff regarding compiler settings in Eclipse and printf improvements.

Last commit fixes a regression in TX in SSB. Sometimes (depending on the transmission mode), wrong frequency translatation was executed, resulting in a TX on the wrong sideband.