### PR TITLE
USB Volume control and more volume control simplifications/extensions

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -1607,9 +1607,10 @@ static void audio_rx_processor(int16_t *src, int16_t *dst, int16_t size)
 		// Unless this is DIGITAL I/Q Mode, we sent processed audio
 		if (ts.tx_audio_source != TX_AUDIO_DIGIQ) {
 			if (i%USBD_AUDIO_IN_OUT_DIV == modulus) {
-				audio_in_put_buffer(ads.a_buffer[i]);
+				float32_t val = ads.a_buffer[i] * ts.rx_usb_gain/31.0;
+				audio_in_put_buffer(val);
 				if (USBD_AUDIO_IN_CHANNELS == 2) {
-					audio_in_put_buffer(ads.a_buffer[i]);
+					audio_in_put_buffer(val);
 				}
 			}
 		}

--- a/mchf-eclipse/drivers/audio/codec/codec.h
+++ b/mchf-eclipse/drivers/audio/codec/codec.h
@@ -97,6 +97,6 @@ void     Codec_Reset(uint32_t AudioFreq,ulong word_size);
 uint32_t Codec_WriteRegister(uint8_t RegisterAddr, uint16_t RegisterValue);
 void     Codec_GPIO_Init(void);
 void Codec_SidetoneSetgain(void);
-
+void Codec_MicBoostCheck();
 
 #endif

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -368,6 +368,25 @@ inline bool is_vfo_b() {
 	return (ts.vfo_mem_mode & VFO_MEM_MODE_VFO_B) != 0;
 }
 
+inline bool is_dsp_nb() {
+	return (ts.dsp_active & DSP_NB_ENABLE) != 0;
+}
+
+inline bool is_dsp_nr() {
+	return (ts.dsp_active & DSP_NR_ENABLE) != 0;
+}
+
+inline bool is_dsp_nr_postagc() {
+	return (ts.dsp_active & DSP_NR_POSTAGC_ENABLE) != 0;
+}
+
+
+inline bool is_dsp_notch() {
+	return (ts.dsp_active & DSP_NOTCH_ENABLE) != 0;
+}
+
+
+
 
 //*----------------------------------------------------------------------------
 //* Function Name       : ui_driver_init
@@ -956,35 +975,35 @@ static void UiDriverProcessKeyboard(void)
 			case BUTTON_G2_PRESSED:		// BUTTON_G2
 			{
 				if(ts.dmod_mode != DEMOD_FM)	{ // allow selection/change of DSP only if NOT in FM
-					if((!(ts.dsp_active & 1)) && (!(ts.dsp_active & 4)))	// both NR and notch are inactive
+					if((!(is_dsp_nr())) && (!(is_dsp_notch())))	// both NR and notch are inactive
 					{
 						if(ts.dsp_enabled)
-							ts.dsp_active |= 1;					// turn on NR
+							ts.dsp_active |= DSP_NR_ENABLE;					// turn on NR
 						else
-							ts.dsp_active |= 4;
+							ts.dsp_active |= DSP_NOTCH_ENABLE;
 					}
-					else if((ts.dsp_active & 1) && (!(ts.dsp_active & 4))) {	// NR active, notch inactive
+					else if((is_dsp_nr()) && (!(is_dsp_notch()))) {	// NR active, notch inactive
 						if(ts.dmod_mode != DEMOD_CW)	{	// NOT in CW mode
-							ts.dsp_active |= 4;									// turn on notch
-							ts.dsp_active &= 0xfe;								// turn off NR
+							ts.dsp_active |= DSP_NOTCH_ENABLE;									// turn on notch
+							ts.dsp_active &= ~DSP_NR_ENABLE;								// turn off NR
 						}
 						else	{	// CW mode - do not select notches, skip directly to "off"
-							ts.dsp_active &= 0xfa;	// turn off NR and notch
+							ts.dsp_active &= ~(DSP_NR_ENABLE | DSP_NOTCH_ENABLE);	// turn off NR and notch
 						}
 					}
-					else if((!(ts.dsp_active & 1)) && (ts.dsp_active & 4))	//	NR inactive, notch active
+					else if((!(is_dsp_nr())) && (is_dsp_notch()))	//	NR inactive, notch active
 						if((ts.dmod_mode == DEMOD_AM) && (ts.filter_id == AUDIO_WIDE))		// was it AM with a wide filter selected?
-							ts.dsp_active &= 0xfa;			// it was AM + wide - turn off NR and notch
+							ts.dsp_active &= ~(DSP_NR_ENABLE | DSP_NOTCH_ENABLE);			// it was AM + wide - turn off NR and notch
 						else
 						{
 							if(ts.dsp_enabled)
-								ts.dsp_active |= 1;				// no - turn on NR
+								ts.dsp_active |= DSP_NR_ENABLE;				// no - turn on NR
 							else
-								ts.dsp_active &= 0xfa;				// no - turn off NR and NOTCH
+								ts.dsp_active &= ~(DSP_NR_ENABLE | DSP_NOTCH_ENABLE);				// no - turn off NR and NOTCH
 						}
 					//
 					else	{
-						ts.dsp_active &= 0xfa;								// turn off NR and notch
+						ts.dsp_active &= ~(DSP_NR_ENABLE | DSP_NOTCH_ENABLE);								// turn off NR and notch
 					}
 					//
 					ts.dsp_active_toggle = ts.dsp_active;	// save update in "toggle" variable
@@ -1268,9 +1287,9 @@ static void UiDriverProcessKeyboard(void)
 				//
 			case BUTTON_G2_PRESSED:		// Press and hold of BUTTON_G2 - turn DSP off/on
 				if(ts.dmod_mode != DEMOD_FM)	{		// do not allow change of mode when in FM
-					if(ts.dsp_active & 5)	{			// is DSP NR or NOTCH active?
+					if(is_dsp_nr()|| is_dsp_notch())	{			// is DSP NR or NOTCH active?
 						ts.dsp_active_toggle = ts.dsp_active;	// save setting for future toggling
-						ts.dsp_active &= 0xfa;				// turn off NR and notch
+						ts.dsp_active &= ~(DSP_NR_ENABLE | DSP_NOTCH_ENABLE);				// turn off NR and notch
 					}
 					else	{		// neither notch or NR was active
 						if(ts.dsp_active_toggle != 0xff)	{	// has this holder been used before?
@@ -1318,7 +1337,7 @@ static void UiDriverProcessKeyboard(void)
 				break;
 			}
 			case BUTTON_M2_PRESSED:	// Press-and-hold button M2:  Switch display between DSP "strength" setting and NB (noise blanker) mode
-				ts.dsp_active ^= 8;	// toggle whether or not DSP or NB is to be displayed
+				ts.dsp_active ^= DSP_NB_ENABLE;	// toggle whether or not DSP or NB is to be displayed
 				//
 				if(ts.enc_two_mode == ENC_TWO_MODE_RF_GAIN)
 					UiDriverChangeSigProc(0);
@@ -3436,7 +3455,7 @@ skip_check:
 				ts.rx_muting = 1;				// yes - mute audio output
 				ts.dsp_inhibit_mute = ts.dsp_inhibit;		// get current status of DSP muting and save for later restoration
 				ts.dsp_inhibit = 1;				// disable DSP during tuning to avoid disruption
-				if(ts.dsp_active & 1)	// is DSP active?
+				if(is_dsp_nr())	// is DSP active?
 					ts.rx_blanking_time = ts.sysclock + TUNING_LARGE_STEP_MUTING_TIME_DSP_ON;	// yes - schedule un-muting of audio when DSP is on
 				else
 					ts.rx_blanking_time = ts.sysclock + TUNING_LARGE_STEP_MUTING_TIME_DSP_OFF;	// no - schedule un-muting of audio when DSP is off
@@ -3987,7 +4006,7 @@ static void UiDriverTimeScheduler(void)
 	///
 	// DSP crash detection
 	//
-	if((ts.dsp_active & 1) && (!(ts.dsp_active & 2)) && (!ads.af_disabled) && (!ts.dsp_inhibit))	{	// Do this if enabled and "Pre-AGC" DSP NR enabled
+	if((is_dsp_nr()) && (!(is_dsp_nr_postagc())) && (!ads.af_disabled) && (!ts.dsp_inhibit))	{	// Do this if enabled and "Pre-AGC" DSP NR enabled
 		if((ads.dsp_nr_sample > DSP_HIGH_LEVEL)	|| (ads.dsp_nr_sample == -1)){		// is the DSP output very high, or wrapped around to -1?
 			dsp_crash_count+=2;			// yes - increase detect count quickly
 		}
@@ -4662,7 +4681,7 @@ static void UiDriverCheckEncoderTwo(void)
 			// Update DSP/NB setting
 			case ENC_TWO_MODE_SIG_PROC:
 			{
-				if(ts.dsp_active & 8)	{	// is it in noise blanker mode?
+				if(is_dsp_nb())	{	// is it in noise blanker mode?
 					// Convert to NB incr/decr
 					if(pot_diff < 0)
 					{
@@ -4676,7 +4695,7 @@ static void UiDriverCheckEncoderTwo(void)
 							ts.nb_setting = MAX_NB_SETTING;
 					}
 				}
-				else if(ts.dsp_active & 1)	{	// only allow adjustment if DSP NR is active
+				else if(is_dsp_nr())	{	// only allow adjustment if DSP NR is active
 					// Convert to NB incr/decr
 					if(pot_diff < 0)
 					{
@@ -5122,18 +5141,18 @@ static void UiDriverChangeDSPMode(void)
 	// Draw line for box
 	UiLcdHy28_DrawStraightLine(POS_DSPL_IND_X,(POS_DSPL_IND_Y - 1),56,LCD_DIR_HORIZONTAL,Grey);
 	//
-	if(((ts.dsp_active & 1) || (ts.dsp_active & 4))) {	// DSP active and NOT in FM mode?
+	if(((is_dsp_nr()) || (is_dsp_notch()))) {	// DSP active and NOT in FM mode?
 		color = White;
 	} else	// DSP not active
 		color = Grey2;
 	if(ts.dmod_mode == DEMOD_FM)	{		// Grey out and display "off" if in FM mode
 		txt = "DSP-OFF";
 		color = Grey2;
-	} else if((ts.dsp_active & 1) && (ts.dsp_active & 4) && (ts.dmod_mode != DEMOD_CW))	{
+	} else if((is_dsp_nr()) && (is_dsp_notch()) && (ts.dmod_mode != DEMOD_CW))	{
 		txt = "NR+NOTC";
-	} else if(ts.dsp_active & 1)	{
+	} else if(is_dsp_nr())	{
 		txt = "   NR  ";
-	} else if(ts.dsp_active & 4)	{
+	} else if(is_dsp_notch())	{
 		txt = " NOTCH ";
 		if(ts.dmod_mode == DEMOD_CW)
 			color = Grey2;
@@ -5151,79 +5170,45 @@ static void UiDriverChangeDSPMode(void)
 //* Output Parameters   :
 //* Functions called    :
 //*----------------------------------------------------------------------------
+typedef struct DigitalModeDescriptor_s {
+	const char* label;
+	const uint32_t enabled;
+} DigitalModeDescriptor;
+
+
+enum {
+		Digital = 0,
+		FreeDV1,
+		FreeDV2,
+		BPSK31,
+		RTTY,
+		SSTV,
+		WSPR_A,
+		WSPR_P,
+		DigitalModeMax
+};
+// The following descriptor table has to be in the order of the enum above
+// This table is stored in flash (due to const) and cannot be written to
+// for operational data per mode [r/w], use a different table with order of modes
+const DigitalModeDescriptor digimodes[DigitalModeMax] =
+{
+		{ "DIGITAL", false	},
+		{ "FREEDV1", false },
+		{ "FREEDV2", false },
+		{ "BPSK 31", false },
+		{ "  RTTY ", false },
+		{ "  SSTV ", false },
+		{ "WSPR  A", false },
+		{ "WSPR  P", false },
+};
+
 static void UiDriverChangeDigitalMode(void)
 {
-	ushort color = White;
-	const char* txt;
-	//	ulong	x_off = 0;
+	ushort color = digimodes[ts.digital_mode].enabled?White:Grey2;
+	const char* txt = digimodes[ts.digital_mode].label;
 
 	// Draw line for box
 	UiLcdHy28_DrawStraightLine(POS_DSPU_IND_X,(POS_DSPU_IND_Y - 1),56,LCD_DIR_HORIZONTAL,Grey);
-	//
-	switch(ts.digital_mode){
-	case 0:
-		txt = "DIGITAL";
-		color = Grey2;
-		break;
-	case 1:
-		txt = "FREEDV1";
-		color = Grey2;
-		break;
-	case 2:
-		txt = "FREEDV2";
-		color = Grey2;
-		break;
-	case 3:
-		txt = "BPSK 31";
-		color = Grey2;
-		break;
-	case 4:
-		txt = "  RTTY ";
-		color = Grey2;
-		break;
-	case 5:
-		txt = "  SSTV ";
-		color = Grey2;
-		break;
-	case 6:
-		txt = "WSPR  A";
-		color = Grey2;
-		break;
-	case 7:
-		txt = "WSPR  P";
-		color = Grey2;
-		break;
-	default:
-		txt = "       ";
-		break;
-	}
-
-
-	/*	if(((ts.dsp_active & 1) || (ts.dsp_active & 4)))	// DSP active and NOT in FM mode?
-		color = White;
-	else	// DSP not active
-		color = Grey2;
-
-	if(ts.dmod_mode == DEMOD_FM)	{		// Grey out and display "off" if in FM mode
-		sprintf(txt, "DIGITAL");
-		color = Grey2;
-	}
-	else if((ts.dsp_active & 1) && (ts.dsp_active & 4) && (ts.dmod_mode != DEMOD_CW))	{
-		sprintf(txt, "NR+NOT");
-		x_off = 4;
-	}
-	else if(ts.dsp_active & 1)	{
-		sprintf(txt, "  NR  ");
-		x_off = 4;
-	}
-	else if(ts.dsp_active & 4)	{
-		sprintf(txt, " NOTCH");
-		if(ts.dmod_mode == DEMOD_CW)
-			color = Grey2;
-	}
-	else
-		sprintf(txt, "DIGITAL"); */
-
 	UiLcdHy28_PrintText((POS_DSPU_IND_X),(POS_DSPU_IND_Y),txt,color,Blue,0);
 }
 //*----------------------------------------------------------------------------
@@ -5386,7 +5371,7 @@ static void UiDriverChangeSigProc(uchar enabled)
 	//
 	// Noise blanker settings display
 	//
-	if(ts.dsp_active & 8)	{	// is noise blanker to be displayed
+	if(is_dsp_nb())	{	// is noise blanker to be displayed
 		if(enabled)	{
 			if(ts.nb_setting >= NB_WARNING3_SETTING)
 				color = Red;		// above this value, make it red
@@ -5404,7 +5389,7 @@ static void UiDriverChangeSigProc(uchar enabled)
 	// DSP settings display
 	//
 	else	{			// DSP settings are to be displayed
-		if(enabled && (ts.dsp_active & 1))	{	// if this menu is enabled AND the DSP NR is also enabled...
+		if(enabled && (is_dsp_nr()))	{	// if this menu is enabled AND the DSP NR is also enabled...
 			color = White;		// Make it white by default
 			//
 			if(ts.dsp_nr_strength >= DSP_STRENGTH_RED)

--- a/mchf-eclipse/drivers/ui/ui_driver.h
+++ b/mchf-eclipse/drivers/ui/ui_driver.h
@@ -674,6 +674,7 @@ void UiDriverSetDemodMode(uint32_t new_mode); // switch to different demodulatio
 //
 #define	MAX_AUDIO_GAIN		30		// Maximum audio gain setting
 #define	DEFAULT_AUDIO_GAIN	16		// Default audio gain
+#define	DEFAULT_USB_GAIN	16		// Default audio gain
 //
 // The following are used in the max volume setting in the menu system
 //

--- a/mchf-eclipse/hardware/mchf_board.h
+++ b/mchf-eclipse/hardware/mchf_board.h
@@ -1402,6 +1402,13 @@ typedef struct TransceiverState
 	//
 	bool	nb_disable;					// TRUE if noise blanker is to be disabled
 	//
+
+	#define DSP_NR_ENABLE 	  0x01
+	#define DSP_NR_POSTAGC_ENABLE 	  0x02
+	#define DSP_NOTCH_ENABLE 0x04
+	#define DSP_NB_ENABLE 0x08
+
+
 	uchar	dsp_active;					// Used to hold various aspects of DSP mode selection
 										// LSB = 1 if DSP NR mode is on (| 1)
 										// LSB+1 = 1 if DSP NR is to occur post AGC (| 2)

--- a/mchf-eclipse/hardware/mchf_board.h
+++ b/mchf-eclipse/hardware/mchf_board.h
@@ -738,6 +738,7 @@ enum {
 #define TX_AUDIO_DIG			3
 #define TX_AUDIO_DIGIQ			4
 #define TX_AUDIO_MAX_ITEMS		4
+#define TX_AUDIO_NUM			(TX_AUDIO_MAX_ITEMS +1)
 //
 #define	LINE_GAIN_MIN			3
 #define	LINE_GAIN_MAX			31
@@ -1344,11 +1345,11 @@ typedef struct TransceiverState
 
 	uchar 	tx_audio_source;
 	uchar   tx_line_channel;  // 1 LEFT 2 RIGHT
-	uchar	tx_mic_gain;
 	ulong	tx_mic_gain_mult;
 	ulong	tx_mic_gain_mult_temp;	// used to temporarily hold the mic gain when going from RX to TX
-	uchar	tx_line_gain;
+	uchar	tx_gain[TX_AUDIO_NUM];
 	uchar	tx_comp_level;			// Used to hold compression level which is used to calculate other values for compression.  0 = manual.
+	uchar	rx_usb_gain;			// volume setting for usb audio out
 
 	// Microphone gain boost of +20dB via Codec command (TX)
 	uchar	mic_boost;
@@ -1391,43 +1392,6 @@ typedef struct TransceiverState
 #define ADJ_5W 0
 #define ADJ_FULL_POWER 1
 	uchar	pwr_adj[2][MAX_BAND_NUM];
-#if 0
-	uchar	pwr_80m_5w_adj;			// calibration adjust for 80 meters, 5 watts
-	uchar	pwr_60m_5w_adj;			// calibration adjust for 60 meters, 5 watts
-	uchar	pwr_40m_5w_adj;			// calibration adjust for 40 meters, 5 watts
-	uchar	pwr_30m_5w_adj;			// calibration adjust for 30 meters, 5 watts
-	uchar	pwr_20m_5w_adj;			// calibration adjust for 20 meters, 5 watts
-	uchar	pwr_17m_5w_adj;			// calibration adjust for 17 meters, 5 watts
-	uchar	pwr_15m_5w_adj;			// calibration adjust for 15 meters, 5 watts
-	uchar	pwr_12m_5w_adj;			// calibration adjust for 12 meters, 5 watts
-	uchar	pwr_10m_5w_adj;			// calibration adjust for 10 meters, 5 watts
-	uchar	pwr_6m_5w_adj;			// calibration adjust for 6 meters, 5 watts
-	uchar	pwr_4m_5w_adj;			// calibration adjust for 4 meters, 5 watts
-	uchar	pwr_2m_5w_adj;			// calibration adjust for 2 meters, 5 watts
-	uchar	pwr_70cm_5w_adj;		// calibration adjust for 70 centimeters, 5 watts
-	uchar	pwr_23cm_5w_adj;		// calibration adjust for 23 centimeters, 5 watts
-	uchar	pwr_2200m_5w_adj;		// calibration adjust for 2200 meters, 5 watts
-	uchar	pwr_630m_5w_adj;		// calibration adjust for 630 meters, 5 watts
-	uchar	pwr_160m_5w_adj;		// calibration adjust for 160 meters, 5 watts
-	//
-	uchar	pwr_80m_full_adj;			// calibration adjust for 80 meters, full power
-	uchar	pwr_60m_full_adj;			// calibration adjust for 60 meters, full power
-	uchar	pwr_40m_full_adj;			// calibration adjust for 40 meters, full power
-	uchar	pwr_30m_full_adj;			// calibration adjust for 30 meters, full power
-	uchar	pwr_20m_full_adj;			// calibration adjust for 20 meters, full power
-	uchar	pwr_17m_full_adj;			// calibration adjust for 17 meters, full power
-	uchar	pwr_15m_full_adj;			// calibration adjust for 15 meters, full power
-	uchar	pwr_12m_full_adj;			// calibration adjust for 12 meters, full power
-	uchar	pwr_10m_full_adj;			// calibration adjust for 10 meters, full power
-	uchar	pwr_6m_full_adj;			// calibration adjust for 6 meters, full power
-	uchar	pwr_4m_full_adj;			// calibration adjust for 4 meters, full power
-	uchar	pwr_2m_full_adj;			// calibration adjust for 2 meters, full power
-	uchar	pwr_70cm_full_adj;			// calibration adjust for 70 centimeters, full power
-	uchar	pwr_23cm_full_adj;			// calibration adjust for 23 centimeters, full power
-	uchar	pwr_2200m_full_adj;			// calibration adjust for 2200 meters, full power
-	uchar	pwr_630m_full_adj;			// calibration adjust for 630 meters, full power
-	uchar	pwr_160m_full_adj;			// calibration adjust for 160 meters, full power
-#endif
 	//
 	ulong	alc_decay;					// adjustable ALC release time - EEPROM read/write version
 	ulong	alc_decay_var;				// adjustable ALC release time - working variable version

--- a/mchf-eclipse/main.c
+++ b/mchf-eclipse/main.c
@@ -701,6 +701,7 @@ void TransceiverStateInit(void)
 	ts.filter_band		= 0;						// used to indicate the bpf filter selection for power detector coefficient selection
 	ts.dmod_mode 		= DEMOD_USB;				// demodulator mode
 	ts.audio_gain		= DEFAULT_AUDIO_GAIN;		// Set initial volume
+	ts.rx_usb_gain		= DEFAULT_USB_GAIN;
 	ts.audio_max_volume	= MAX_VOLUME_DEFAULT;		// Set max volume default
 	ts.audio_gain_active = 1;						// this variable is used in the active RX audio processing function
 	ts.rf_gain			= DEFAULT_RF_GAIN;			//
@@ -756,10 +757,13 @@ void TransceiverStateInit(void)
 	ts.buffer_clear		= 0;						// used on return from TX to purge the audio buffers
 
 	ts.tx_audio_source	= TX_AUDIO_MIC;				// default source is microphone
-	ts.tx_mic_gain		= MIC_GAIN_DEFAULT;			// default microphone gain
-	ts.tx_mic_gain_mult	= ts.tx_mic_gain;			// actual operating value for microphone gain
+	ts.tx_mic_gain_mult	= MIC_GAIN_DEFAULT;			// actual operating value for microphone gain
 	ts.mic_boost		= 0;
-	ts.tx_line_gain		= LINE_GAIN_DEFAULT;		// default line gain
+	ts.tx_gain[TX_AUDIO_MIC]		= MIC_GAIN_DEFAULT;		// default line gain
+	ts.tx_gain[TX_AUDIO_LINEIN_L]		= LINE_GAIN_DEFAULT;		// default line gain
+	ts.tx_gain[TX_AUDIO_LINEIN_R]		= LINE_GAIN_DEFAULT;		// default line gain
+	ts.tx_gain[TX_AUDIO_DIG]		= LINE_GAIN_DEFAULT;		// default line gain
+	ts.tx_gain[TX_AUDIO_DIGIQ]		= LINE_GAIN_DEFAULT;		// default line gain
 
 	ts.tune				= 0;						// reset tuning flag
 

--- a/mchf-eclipse/usb/usbd/class/audio/inc/usbd_audio_out_if.h
+++ b/mchf-eclipse/usb/usbd/class/audio/inc/usbd_audio_out_if.h
@@ -101,6 +101,7 @@ typedef enum
   */ 
 
 extern AUDIO_FOPS_TypeDef  AUDIO_OUT_fops;
+extern AUDIO_FOPS_TypeDef  AUDIO_IN_fops;
 
 /**
   * @}

--- a/mchf-eclipse/usb/usbd/class/audio/src/usbd_audio_core.c
+++ b/mchf-eclipse/usb/usbd/class/audio/src/usbd_audio_core.c
@@ -228,18 +228,18 @@ UsbAudioUnit usbUnits[UnitMax] =
 		{
 				.cs  = AUDIO_CONTROL_VOLUME,
 				.cn  = AUDIO_OUT_STREAMING_CTRL,
-				.min = -40 * 0x100,
-				.max = 0,
+				.min = -31 * 0x100,
+				.max = 0 * 0x100,
 				.res = 0x100,
-				.cur = -20* 0x100
+				.cur = -16* 0x100
 		},
 		{
 				.cs  = AUDIO_CONTROL_VOLUME,
 				.cn  = 0x06,
-				.min = -40 * 0x100,
-				.max = 0,
+				.min = -31 * 0x100,
+				.max = 0 * 0x100,
 				.res = 0x100,
-				.cur = -20* 0x100
+				.cur = -16* 0x100
 		}
 
 };
@@ -834,15 +834,14 @@ static uint8_t  usbd_audio_EP0_RxReady (void  *pdev)
 		if (AudioCtlUnit == AUDIO_OUT_STREAMING_CTRL)
 		{/* In this driver, to simplify code, only one unit is manage */
 			/* Call the audio interface mute function */
-			retval = AUDIO_OUT_fops.MuteCtl(AudioCtl[0]);
-
+			int16_t val = *((int16_t*)&AudioCtl[0]);
+			retval = AUDIO_OUT_fops.VolumeCtl((val/0x100)+31);
+			usbUnits[UnitVolumeTX].cur = val;
 			/* Reset the AudioCtlCmd variable to prevent re-entering this function */
-			AudioCtlCmd = 0;
-			AudioCtlLen = 0;
-			AudioCtlCS = 0;
-			AudioCtlCN = 0;
-			AudioCtlIf = 0;
-
+		} else {
+			int16_t val = *((int16_t*)&AudioCtl[0]);
+			retval = AUDIO_IN_fops.VolumeCtl((val/0x100)+31);
+			usbUnits[UnitVolumeRX].cur = val;
 		}
 		/* Reset the AudioCtlCmd variable to prevent re-entering this function */
 		AudioCtlCmd = 0;

--- a/mchf-eclipse/usb/usbd/class/audio/src/usbd_audio_out_if.c
+++ b/mchf-eclipse/usb/usbd/class/audio/src/usbd_audio_out_if.c
@@ -107,6 +107,15 @@ static uint8_t  MuteCtl      (uint8_t cmd);
 static uint8_t  PeriodicTC   (uint8_t cmd);
 static uint8_t  GetState     (void);
 
+
+static uint8_t  InInit         (uint32_t  AudioFreq, uint32_t Volume, uint32_t options);
+static uint8_t  InDeInit       (uint32_t options);
+static uint8_t  InAudioCmd     (uint8_t* pbuf, uint32_t size, uint8_t cmd);
+static uint8_t  InVolumeCtl    (uint8_t vol);
+static uint8_t  InMuteCtl      (uint8_t cmd);
+static uint8_t  InPeriodicTC   (uint8_t cmd);
+static uint8_t  INGetState     (void);
+
 /**
   * @}
   */ 
@@ -124,6 +133,18 @@ AUDIO_FOPS_TypeDef  AUDIO_OUT_fops =
   PeriodicTC,
   GetState
 };
+
+AUDIO_FOPS_TypeDef  AUDIO_IN_fops =
+{
+  Init,
+  DeInit,
+  AudioCmd,
+  InVolumeCtl,
+  MuteCtl,
+  PeriodicTC,
+  GetState
+};
+
 
 static uint8_t AudioState = AUDIO_STATE_INACTIVE;
 
@@ -382,6 +403,20 @@ static uint8_t  VolumeCtl    (uint8_t vol)
 */
   return AUDIO_OK;
 }
+static uint8_t  InVolumeCtl    (uint8_t vol)
+{
+  /* Call low layer volume setting function */
+/* if (EVAL_AUDIO_VolumeCtl(vol) != 0)
+  {
+    AudioState = AUDIO_STATE_ERROR;
+    return AUDIO_FAIL;
+  }
+*/
+  ts.rx_usb_gain = vol;
+  return AUDIO_OK;
+}
+
+
 
 /**
   * @brief  MuteCtl


### PR DESCRIPTION
This a hell of a commit. Had to add different tx_audio_source handling 
this is very much streamlined now. Allowed to add settings for TX gains for
all different tx sources individually. Added rx_usb_gain to control digital
line out (indepent from audio gain and tx gain).
Right now only the ts.rx_usb_gain is connected to the USB volume control.
I.e. in Windows you can now control the input volume using the
controls slider. Not yet a proper mapping of volume value and gain
(linear value used instead of logarithm, but that is a piece of cake).
Because of the changes, please test especially transmitting with all
different audio sources (mic, line in left, right, digital)...

There will be issues here most likely as I tested only very little.