### PR TITLE
Code Restructuring: Spectrum and Waterfall

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.h
+++ b/mchf-eclipse/drivers/audio/audio_driver.h
@@ -16,8 +16,8 @@
 #define __AUDIO_DRIVER_H
 
 #include "arm_math.h"
-#include "ui_lcd_hy28.h"
-
+// #include "ui_lcd_hy28.h"
+#include "ui_spectrum.h"
 // 16 or 24 bits from Codec
 //
 //#define USE_24_BITS

--- a/mchf-eclipse/drivers/ui/lcd/ui_lcd_hy28.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_lcd_hy28.c
@@ -45,6 +45,7 @@ uint16_t display_use_spi;
 extern __IO OscillatorState os;		// oscillator values - including Si570 startup frequency, displayed on splash screen
 
 static void UiLcdHy28_Delay(ulong delay);
+static void UiLcdHy28_Test(void);
 
 //*----------------------------------------------------------------------------
 //* Function Name       : UiLcdHy28_BacklightInit
@@ -324,7 +325,7 @@ void UiLcdHy28_FSMCConfig(void)
 //* Output Parameters   :
 //* Functions called    :
 //*----------------------------------------------------------------------------
-void UiLcdHy28_SendByteSpi(uint8_t byte)
+static inline void UiLcdHy28_SendByteSpi(uint8_t byte)
 {
    // while ((SPI2>SR & (SPI_I2S_FLAG_TXE) == (uint16_t)RESET);
    // SPI2->DR = Data;
@@ -335,7 +336,7 @@ void UiLcdHy28_SendByteSpi(uint8_t byte)
    SPI_I2S_ReceiveData(SPI2);
 
 }
-void UiLcdHy28_SendByteSpiFast(uint8_t byte)
+static inline void UiLcdHy28_SendByteSpiFast(uint8_t byte)
 {
 
    while ((SPI2->SR & (SPI_I2S_FLAG_TXE)) == (uint16_t)RESET);
@@ -426,7 +427,7 @@ void UiLcdHy28_WriteDataSpi( unsigned short data)
 //* Output Parameters   :
 //* Functions called    :
 //*----------------------------------------------------------------------------
-void UiLcdHy28_WriteDataSpiStart(void)
+static inline void UiLcdHy28_WriteDataSpiStart()
 {
    UiLcdHy28_SendByteSpiFast(SPI_START | SPI_WR | SPI_DATA);    /* Write : RS = 1, RW = 0       */
 }
@@ -438,7 +439,7 @@ void UiLcdHy28_WriteDataSpiStart(void)
 //* Output Parameters   :
 //* Functions called    :
 //*----------------------------------------------------------------------------
-void UiLcdHy28_WriteDataOnly( unsigned short data)
+static inline void UiLcdHy28_WriteDataOnly( unsigned short data)
 {
    if(display_use_spi)
    {
@@ -535,7 +536,7 @@ unsigned short UiLcdHy28_ReadReg( unsigned short LCD_Reg)
 //* Output Parameters   :
 //* Functions called    :
 //*----------------------------------------------------------------------------
-void UiLcdHy28_SetCursorA( unsigned short Xpos, unsigned short Ypos )
+static void UiLcdHy28_SetCursorA( unsigned short Xpos, unsigned short Ypos )
 {
    UiLcdHy28_WriteReg(0x0020, Ypos );
    UiLcdHy28_WriteReg(0x0021, Xpos );
@@ -548,7 +549,7 @@ void UiLcdHy28_SetCursorA( unsigned short Xpos, unsigned short Ypos )
 //* Output Parameters   :
 //* Functions called    :
 //*----------------------------------------------------------------------------
-void UiLcdHy28_WriteRAM_Prepare(void)
+static void UiLcdHy28_WriteRAM_Prepare(void)
 {
    if(display_use_spi)
    {
@@ -560,7 +561,7 @@ void UiLcdHy28_WriteRAM_Prepare(void)
       LCD_REG = 0x22;
 }
 
-inline void UiLcdHy28_WriteRAM_Finish(void)
+static inline void UiLcdHy28_WriteRAM_Finish(void)
 {
    if(display_use_spi)
    {
@@ -1242,7 +1243,7 @@ uchar UiLcdHy28_InitA(void)
 //* Output Parameters   :
 //* Functions called    :
 //*----------------------------------------------------------------------------
-void UiLcdHy28_Test(void)
+static void UiLcdHy28_Test(void)
 {
    // Backlight on - only when all is drawn
    //LCD_BACKLIGHT_PIO->BSRRL = LCD_BACKLIGHT;

--- a/mchf-eclipse/drivers/ui/lcd/ui_lcd_hy28.h
+++ b/mchf-eclipse/drivers/ui/lcd/ui_lcd_hy28.h
@@ -67,24 +67,6 @@
 
 
 // ----------------------------------------------------------
-// Spectrum draw params
-//
-// WARNING:  Because the waterfall uses a "block write" which is, in effect, a "blind" writing of data to the LCD, the size of the graphic
-// block *MUST* exactly match the number of pixels within that block.
-//
-// Furthermore, the "SPECTRUM WIDTH" must match exactly with graphical width of the "X" size of each line to be written or skewing will result!
-//
-#define SPECTRUM_START_X		POS_SPECTRUM_IND_X
-//
-// Shift of whole spectrum in vertical direction
-#define SPECTRUM_START_Y		(POS_SPECTRUM_IND_Y - 10)
-//
-// Spectrum hight is bit lower that the whole control
-#define SPECTRUM_HEIGHT			(POS_SPECTRUM_IND_H - 10)
-//
-// Dependent on FFT samples,but should be less than control width!
-#define SPECTRUM_WIDTH			256
-// ----------------------------------------------------------
 
 #define LCD_REG      (*((volatile unsigned short *) 0x60000000))
 #define LCD_RAM      (*((volatile unsigned short *) 0x60020000))
@@ -96,8 +78,8 @@
 #define LCD_CS_PIO	         	LCD_CSA_PIO
 
 // ----------------------------------------------------------
-
 void 	UiLcdHy28_LcdClear(ushort Color);
+
 void 	UiLcdHy28_PrintText(ushort Xpos, ushort Ypos, const char *str,ushort Color, ushort bkColor, uchar font);
 void 	UiLcdHy28_PrintTextRight(ushort Xpos, ushort Ypos, const char *str,ushort Color, ushort bkColor, uchar font);
 uint16_t 	UiLcdHy28_TextWidth(const char *str, uchar font);
@@ -110,25 +92,15 @@ void 	UiLcdHy28_DrawHorizLineWithGrad(ushort Xpos, ushort Ypos, ushort Length,us
 void 	UiLcdHy28_DrawEmptyRect(ushort Xpos, ushort Ypos, ushort Height, ushort Width, ushort color);
 void 	UiLcdHy28_DrawBottomButton(ushort Xpos, ushort Ypos, ushort Height, ushort Width,ushort color);
 void 	UiLcdHy28_DrawFullRect (ushort Xpos, ushort Ypos, ushort Height, ushort Width, ushort color);
-void 	UiLcdHy28_DrawColorPoint(ushort x, ushort y, ushort color);
-void 	UiLcdHy28_OpenBulkWrite(ushort x, ushort width, ushort y, ushort height);
-void 	UiLcdHy28_SendByteSpi(uint8_t byte);
-uint8_t UiLcdHy28_ReadByteSpi(void);
-void 	UiLcdHy28_WriteDataOnly( unsigned short data);
 
+void 	UiLcdHy28_DrawColorPoint(ushort x, ushort y, ushort color);
+
+void 	UiLcdHy28_OpenBulkWrite(ushort x, ushort width, ushort y, ushort height);
 void 	UiLcdHy28_BulkPixel_Put(uint16_t pixel);
 void 	UiLcdHy28_BulkWrite(uint16_t* pixels, uint32_t len);
 void 	UiLcdHy28_BulkWriteColor(uint16_t color, uint32_t len);
 void 	UiLcdHy28_CloseBulkWrite(void);
 
-void	UiLcdHy28_WriteRAM_Prepare(void);
-void	UiLcdHy28_WriteRAM_Finish(void);
-void 	UiLcdHy28_SetCursorA( unsigned short Xpos, unsigned short Ypos );
-
-void 	UiLcdHy28_DrawSpectrum_Prepare(q15_t *fft_old, q15_t *fft_new, const ushort color_old, const ushort color_new, const ushort shift);
-void 	UiLcdHy28_DrawSpectrum_Interleaved(q15_t *fft_old, q15_t *fft_new, const ushort color_old, const ushort color_new, const ushort shift);
-
-void 	UiLcdHy28_Test(void);
 uchar 	UiLcdHy28_Init(void);
 
 void 	UiLcdHy28_ShowStartUpScreen(ulong hold_time);

--- a/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
@@ -15,12 +15,284 @@
 #include "ui_lcd_hy28.h"
 // For spectrum display struct
 #include "audio_driver.h"
-
+#include "ui_driver.h"
+#include "ui_rotary.h" // dial frequency df
+#include "waterfall_colours.h"
 // ------------------------------------------------
 // Spectrum display
 extern __IO   SpectrumDisplay      sd;
 
+static void 	UiDriverFFTWindowFunction(char mode);
 
+
+static void UiDriverFFTWindowFunction(char mode)
+{
+	ulong i;
+
+	// Information on these windowing functions may be found on the internet - check the Wikipedia article "Window Function"
+	// KA7OEI - 20150602
+
+	switch(mode)	{
+		case FFT_WINDOW_RECTANGULAR:	// No processing at all - copy from "Samples" buffer to "Windat" buffer
+			arm_copy_f32((float32_t *)sd.FFT_Samples, (float32_t *)sd.FFT_Windat,FFT_IQ_BUFF_LEN);	// use FFT data as-is
+			break;
+		case FFT_WINDOW_COSINE:			// Sine window function (a.k.a. "Cosine Window").  Kind of wide...
+			for(i = 0; i < FFT_IQ_BUFF_LEN; i++){
+				sd.FFT_Windat[i] = arm_sin_f32((PI * (float32_t)i)/FFT_IQ_BUFF_LEN - 1) * sd.FFT_Samples[i];
+			}
+			break;
+		case FFT_WINDOW_BARTLETT:		// a.k.a. "Triangular" window - Bartlett (or Fej?r) window is special case where demonimator is "N-1". Somewhat better-behaved than Rectangular
+			for(i = 0; i < FFT_IQ_BUFF_LEN; i++){
+				sd.FFT_Windat[i] = (1 - fabs(i - ((float32_t)FFT_IQ_BUFF_M1_HALF))/(float32_t)FFT_IQ_BUFF_M1_HALF) * sd.FFT_Samples[i];
+			}
+			break;
+		case FFT_WINDOW_WELCH:			// Parabolic window function, fairly wide, comparable to Bartlett
+			for(i = 0; i < FFT_IQ_BUFF_LEN; i++){
+				sd.FFT_Windat[i] = (1 - ((i - ((float32_t)FFT_IQ_BUFF_M1_HALF))/(float32_t)FFT_IQ_BUFF_M1_HALF)*((i - ((float32_t)FFT_IQ_BUFF_M1_HALF))/(float32_t)FFT_IQ_BUFF_M1_HALF)) * sd.FFT_Samples[i];
+			}
+			break;
+		case FFT_WINDOW_HANN:			// Raised Cosine Window (non zero-phase version) - This has the best sidelobe rejection of what is here, but not as narrow as Hamming.
+			for(i = 0; i < FFT_IQ_BUFF_LEN; i++){
+			    sd.FFT_Windat[i] = 0.5 * (float32_t)((1 - (arm_cos_f32(PI*2 * (float32_t)i / (float32_t)(FFT_IQ_BUFF_LEN-1)))) * sd.FFT_Samples[i]);
+			}
+			break;
+		case FFT_WINDOW_HAMMING:		// Another Raised Cosine window - This is the narrowest with reasonably good sidelobe rejection.
+			for(i = 0; i < FFT_IQ_BUFF_LEN; i++){
+			    sd.FFT_Windat[i] = (float32_t)((0.53836 - (0.46164 * arm_cos_f32(PI*2 * (float32_t)i / (float32_t)(FFT_IQ_BUFF_LEN-1)))) * sd.FFT_Samples[i]);
+			}
+			break;
+		case FFT_WINDOW_BLACKMAN:		// Approx. same "narrowness" as Hamming but not as good sidelobe rejection - probably best for "default" use.
+			for(i = 0; i < FFT_IQ_BUFF_LEN; i++){
+			    sd.FFT_Windat[i] = (0.42659 - (0.49656*arm_cos_f32((2*PI*(float32_t)i)/(float32_t)FFT_IQ_BUFF_LEN-1)) + (0.076849*arm_cos_f32((4*PI*(float32_t)i)/(float32_t)FFT_IQ_BUFF_LEN-1))) * sd.FFT_Samples[i];
+			}
+			break;
+		case FFT_WINDOW_NUTTALL:		// Slightly wider than Blackman, comparable sidelobe rejection.
+			for(i = 0; i < FFT_IQ_BUFF_LEN; i++){
+			    sd.FFT_Windat[i] = (0.355768 - (0.487396*arm_cos_f32((2*PI*(float32_t)i)/(float32_t)FFT_IQ_BUFF_LEN-1)) + (0.144232*arm_cos_f32((4*PI*(float32_t)i)/(float32_t)FFT_IQ_BUFF_LEN-1)) - (0.012604*arm_cos_f32((6*PI*(float32_t)i)/(float32_t)FFT_IQ_BUFF_LEN-1))) * sd.FFT_Samples[i];
+			}
+			break;
+	}
+	//
+	// used for debugging
+//		char txt[32];
+//		sprintf(txt, " %d    ", (int)(c1));
+//		UiLcdHy28_PrintText    ((POS_RIT_IND_X + 1), (POS_RIT_IND_Y + 20),txt,White,Grid,0);
+}
+//
+//
+//
+//
+
+
+
+//
+//*----------------------------------------------------------------------------
+//* Function Name       : UiDriverCreateSpectrumScope
+//* Object              : draw the spectrum scope control
+//* Input Parameters    :
+//* Output Parameters   :
+//* Functions called    :
+//*----------------------------------------------------------------------------
+void UiSpectrumCreateDrawArea(void)
+{
+	ulong i;
+	uint32_t clr;
+	char s[32];
+	ulong slen;
+
+	//
+	// get grid colour of all but center line
+	//
+	UiDriverMenuMapColors(ts.scope_grid_colour,NULL, &ts.scope_grid_colour_active);
+	if(ts.scope_grid_colour == SPEC_GREY) {
+		ts.scope_grid_colour_active = Grid;
+	} else {
+		UiDriverMenuMapColors(ts.scope_grid_colour,NULL, &ts.scope_grid_colour_active);
+	}
+	//
+	//
+	// Get color of center vertical line of spectrum scope
+	//
+	if(ts.scope_centre_grid_colour == SPEC_GREY) {
+		ts.scope_centre_grid_colour_active = Grid;
+	} else {
+		UiDriverMenuMapColors(ts.scope_centre_grid_colour,NULL, &ts.scope_centre_grid_colour_active);
+	}
+
+	// Clear screen where frequency information will be under graticule
+	//
+	UiLcdHy28_PrintText(POS_SPECTRUM_IND_X - 2, POS_SPECTRUM_IND_Y + 60, "                                 ", Black, Black, 0);
+
+	//
+	strcpy(s, "SPECTRUM SCOPE ");
+	slen = 0;	// init string length variable
+	//
+	switch(ts.spectrum_db_scale)	{	// convert variable to setting
+		case DB_DIV_5:
+			strcat(s, "(5dB/div)");
+			slen = 30;	// fine-tune horizontal position (not sure why this is needed - look at this later)
+			break;
+		case DB_DIV_7:
+			strcat(s, "(7.5dB/div)");
+			slen = 24;	// fine-tune horizontal position (not sure why this is needed - look at this later)
+			break;
+		case DB_DIV_15:
+			strcat(s, "(15dB/div)");
+			slen = 28;	// fine-tune horizontal position (not sure why this is needed - look at this later)
+			break;
+		case DB_DIV_20:
+			strcat(s, "(20dB/div)");
+			slen = 28;	// fine-tune horizontal position (not sure why this is needed - look at this later)
+			break;
+		case S_1_DIV:
+			strcat(s, "(1S-Unit/div)");
+			break;
+		case S_2_DIV:
+			strcat(s, "(2S-Unit/div)");
+			break;
+		case S_3_DIV:
+			strcat(s, "(3S-Unit/div)");
+			break;
+		case DB_DIV_10:
+		default:
+			strcat(s, "(10dB/div)");
+			slen = 28;	// fine-tune horizontal position (not sure why this is needed - look at this later)
+			break;
+	}
+	//
+	slen += strlen(s);				// get width of entire banner string
+	slen /= 2;						// scale it for half the width of the string
+
+	// Draw top band
+	for(i = 0; i < 16; i++)
+		UiLcdHy28_DrawHorizLineWithGrad(POS_SPECTRUM_IND_X,(POS_SPECTRUM_IND_Y - 20 + i),POS_SPECTRUM_IND_W,COL_SPECTRUM_GRAD);
+
+	if(!(ts.misc_flags1 & 128))	{	// Display Spectrum Scope banner if enabled
+
+	// Top band text - middle caption
+	UiLcdHy28_PrintText(			(POS_SPECTRUM_IND_X + slen),
+									(POS_SPECTRUM_IND_Y - 18),
+									s,
+									Grey,
+									RGB((COL_SPECTRUM_GRAD*2),(COL_SPECTRUM_GRAD*2),(COL_SPECTRUM_GRAD*2)),0);
+	}
+	else	{			// Waterfall Mode banner if that is enabled
+
+		// Top band text - middle caption
+		UiLcdHy28_PrintText(			(POS_SPECTRUM_IND_X + 68),
+										(POS_SPECTRUM_IND_Y - 18),
+										"WATERFALL DISPLAY",
+										Grey,
+										RGB((COL_SPECTRUM_GRAD*2),(COL_SPECTRUM_GRAD*2),(COL_SPECTRUM_GRAD*2)),0);
+	}
+	// Top band text - grid size
+	//UiLcdHy28_PrintText(			(POS_SPECTRUM_IND_X +  2),
+	//								(POS_SPECTRUM_IND_Y - 18),
+	//								"Grid 6k",
+	//								Grey,
+	//								RGB((COL_SPECTRUM_GRAD),(COL_SPECTRUM_GRAD),(COL_SPECTRUM_GRAD)),4);
+
+	// Draw control left and right border
+	for(i = 0; i < 2; i++)
+	{
+		UiLcdHy28_DrawStraightLine(	(POS_SPECTRUM_IND_X - 2 + i),
+									(POS_SPECTRUM_IND_Y - 20),
+									(POS_SPECTRUM_IND_H + 12),
+									LCD_DIR_VERTICAL,
+//									RGB(COL_SPECTRUM_GRAD,COL_SPECTRUM_GRAD,COL_SPECTRUM_GRAD));
+									ts.scope_grid_colour_active);
+
+		UiLcdHy28_DrawStraightLine(	(POS_SPECTRUM_IND_X + POS_SPECTRUM_IND_W - 2 + i),
+									(POS_SPECTRUM_IND_Y - 20),
+									(POS_SPECTRUM_IND_H + 12),
+									LCD_DIR_VERTICAL,
+//									RGB(COL_SPECTRUM_GRAD,COL_SPECTRUM_GRAD,COL_SPECTRUM_GRAD));
+									ts.scope_grid_colour_active);
+	}
+
+	// Frequency bar separator
+	UiLcdHy28_DrawHorizLineWithGrad(POS_SPECTRUM_IND_X,(POS_SPECTRUM_IND_Y + POS_SPECTRUM_IND_H - 20),POS_SPECTRUM_IND_W,COL_SPECTRUM_GRAD);
+
+	// Draw Frequency bar text
+	UiDrawSpectrumScopeFrequencyBarText();
+
+
+	// Horizontal grid lines
+	for(i = 1; i < 4; i++)
+	{
+		// Save y position for repaint
+		sd.horz_grid_id[i - 1] = (POS_SPECTRUM_IND_Y - 5 + i*16);
+
+		// Draw
+		UiLcdHy28_DrawStraightLine(	POS_SPECTRUM_IND_X,
+									sd.horz_grid_id[i - 1],
+									POS_SPECTRUM_IND_W,
+									LCD_DIR_HORIZONTAL,
+//									RGB((COL_SPECTRUM_GRAD),(COL_SPECTRUM_GRAD),(COL_SPECTRUM_GRAD)));
+									ts.scope_grid_colour_active);
+		//printf("vy: %d\n\r",sd.horz_grid_id[i - 1]);
+	}
+
+	// Vertical grid lines
+	for(i = 1; i < 8; i++)		{
+
+		// determine if we are drawing the "center" line on the spectrum  display
+		if(!sd.magnify)	{
+			if((ts.iq_freq_mode == FREQ_IQ_CONV_M6KHZ) && (i == 5))			// is it frequency translate RF LOW mode?  If so, shift right of center
+				clr = ts.scope_centre_grid_colour_active;
+			else if((ts.iq_freq_mode == FREQ_IQ_CONV_P6KHZ) && (i == 3))		// shift left of center if RF HIGH translate mode
+				clr = ts.scope_centre_grid_colour_active;
+			else if((ts.iq_freq_mode == FREQ_IQ_CONV_P12KHZ) && (i == 2))		// shift left of center if RF HIGH translate mode
+				clr = ts.scope_centre_grid_colour_active;
+			else if((ts.iq_freq_mode == FREQ_IQ_CONV_M12KHZ) && (i == 6))		// shift right of center if RF HIGH translate mode
+				clr = ts.scope_centre_grid_colour_active;
+			else if ((ts.iq_freq_mode == FREQ_IQ_CONV_MODE_OFF) && (i == 4))	// center if translate mode not active
+				clr = ts.scope_centre_grid_colour_active;
+	        else
+	     	   clr = ts.scope_grid_colour_active;								// normal color if other lines
+		}
+		else if(i == 4)
+			clr = ts.scope_centre_grid_colour_active;
+        else
+
+     	   clr = ts.scope_grid_colour_active;								// normal color if other lines
+
+		// Save x position for repaint
+		sd.vert_grid_id[i - 1] = (POS_SPECTRUM_IND_X + 32*i + 1);
+
+		// Draw
+		UiLcdHy28_DrawStraightLine(	sd.vert_grid_id[i - 1],
+									(POS_SPECTRUM_IND_Y -  4),
+									(POS_SPECTRUM_IND_H - 15),
+									LCD_DIR_VERTICAL,
+//									RGB((COL_SPECTRUM_GRAD),(COL_SPECTRUM_GRAD),(COL_SPECTRUM_GRAD)));
+									clr);
+
+		//printf("vx: %d\n\r",sd.vert_grid_id[i - 1]);
+	}
+
+	if (((ts.misc_flags1 & 128) && (!ts.waterfall_speed)) || (!(ts.misc_flags1 & 128) && (!ts.scope_speed)))	{
+			// print "disabled" in the middle of the screen if the waterfall or scope was disabled
+			UiLcdHy28_PrintText(			(POS_SPECTRUM_IND_X + 72),
+												(POS_SPECTRUM_IND_Y + 18),
+												"   DISABLED   ",
+												Grey,
+												RGB((COL_SPECTRUM_GRAD*2),(COL_SPECTRUM_GRAD*2),(COL_SPECTRUM_GRAD*2)),0);
+	}
+}
+
+//
+//*----------------------------------------------------------------------------
+//* Function Name       : UiDriverClearSpectrumDisplay
+//* Object              : Clears the spectrum display
+//* Input Parameters    :
+//* Output Parameters   :
+//* Functions called    :
+//*----------------------------------------------------------------------------
+void UiSpectrumClearDisplay(void)
+{
+	UiLcdHy28_DrawFullRect(POS_SPECTRUM_IND_X - 2, (POS_SPECTRUM_IND_Y - 22), 94, 264, Black);	// Clear screen under spectrum scope by drawing a single, black block (faster with SPI!)
+}
 
 
 
@@ -34,7 +306,7 @@ extern __IO   SpectrumDisplay      sd;
 //  This should reduce the amount of CGRAM access - especially via SPI mode - to a minimum.
 //
 
-static inline bool UiLcdHy28_DrawSpectrum_IsVgrid(const uint16_t x, const uint16_t color_new, uint16_t* clr_ptr, const uint16_t x_center_line) {
+static inline bool UiSpectrum_Draw_IsVgrid(const uint16_t x, const uint16_t color_new, uint16_t* clr_ptr, const uint16_t x_center_line) {
 	bool repaint_v_grid = false;
 
 	if (x == x_center_line) {
@@ -57,7 +329,7 @@ static inline bool UiLcdHy28_DrawSpectrum_IsVgrid(const uint16_t x, const uint16
 	return repaint_v_grid;
 }
 
-static uint16_t UiLcdHy28_DrawSpectrum_GetCenterLineX() {
+static uint16_t UiSpectrum_Draw_GetCenterLineX() {
 	static uint16_t idx;
 
 	static const uint16_t  center[FREQ_IQ_CONV_MODE_MAX+1] = { 3,2,4,1,5 };
@@ -81,16 +353,16 @@ static uint16_t UiLcdHy28_DrawSpectrum_GetCenterLineX() {
 //* Output Parameters   :
 //* Functions called    :
 //*----------------------------------------------------------------------------
-void    UiLcdHy28_DrawSpectrum_Interleaved(q15_t *fft_old, q15_t *fft_new, const ushort color_old, const ushort color_new, const ushort shift)
+void    UiSpectrumDrawSpectrum(q15_t *fft_old, q15_t *fft_new, const ushort color_old, const ushort color_new, const ushort shift)
 {
 	static uint16_t pixel_buf[SPECTRUM_HEIGHT];
 
-	uint16_t      i, k, x, y_old , y_new, y1_old, y1_new, len_old, len_new, sh, clr;
+	uint16_t      i, k, x, y_old , y_new, y1_old, y1_new, len_old, sh, clr;
 	uint16_t idx = 0;
 	bool      repaint_v_grid = false;
 	clr = color_new;
 
-	uint16_t x_center_line = UiLcdHy28_DrawSpectrum_GetCenterLineX();
+	uint16_t x_center_line = UiSpectrum_Draw_GetCenterLineX();
 
 
 	if(shift)
@@ -129,7 +401,6 @@ void    UiLcdHy28_DrawSpectrum_Interleaved(q15_t *fft_old, q15_t *fft_new, const
 			len_old = y_old;
 
 			y1_new  = (SPECTRUM_START_Y + SPECTRUM_HEIGHT - 1) - y_new;
-			len_new = y_new;
 
 
 			if(y_old <= y_new) {
@@ -146,7 +417,7 @@ void    UiLcdHy28_DrawSpectrum_Interleaved(q15_t *fft_old, q15_t *fft_new, const
 				// but during spectrum clear instead of masking
 				// grid lines with black - they are repainted
 				// TODO: This code is  always executed, since this function is always called with color_old == Black
-				repaint_v_grid = UiLcdHy28_DrawSpectrum_IsVgrid(x, color_new, &clr, x_center_line);
+				repaint_v_grid = UiSpectrum_Draw_IsVgrid(x, color_new, &clr, x_center_line);
 				//
 				UiLcdHy28_OpenBulkWrite(x, 1, y1_old, len_old);
 
@@ -190,3 +461,908 @@ void    UiLcdHy28_DrawSpectrum_Interleaved(q15_t *fft_old, q15_t *fft_new, const
 	}
 }
 
+static inline const uint32_t FftIdx2BufMap(const uint32_t idx) {
+return (FFT_IQ_BUFF_LEN/4 + idx)%(FFT_IQ_BUFF_LEN/2);
+}
+
+//*----------------------------------------------------------------------------
+//* Function Name       : UiDriverInitSpectrumDisplay - for both "Spectrum Display" and "Waterfall" Display
+//* Object              : FFT init
+//* Input Parameters    :
+//* Output Parameters   :
+//* Functions called    :
+//*----------------------------------------------------------------------------
+void UiDriverInitSpectrumDisplay()
+{
+	ulong i;
+	arm_status	a;
+
+	// Init publics
+	sd.state 		= 0;
+	sd.samp_ptr 	= 0;
+	sd.skip_process = 0;
+	sd.enabled		= 0;
+	sd.dial_moved	= 0;
+	//
+	sd.rescale_rate = (float)ts.scope_rescale_rate;	// load rescale rate
+	sd.rescale_rate = 1/sd.rescale_rate;				// actual rate is inverse of this setting
+	//
+	sd.agc_rate = (float)ts.scope_agc_rate;	// calculate agc rate
+	sd.agc_rate = sd.agc_rate/SPECTRUM_AGC_SCALING;
+	//
+	sd.mag_calc = 1;				// initial setting of spectrum display scaling factor
+	//
+	sd.wfall_line_update = 0;		// init count used for incrementing number of lines for each vertical waterfall screen update
+	//
+	// load buffer containing waterfall colours
+	//
+	for(i = 0; i < NUMBER_WATERFALL_COLOURS; i++)	{
+		switch(ts.waterfall_color_scheme)	{
+			case WFALL_HOT_COLD:
+				sd.waterfall_colours[i] = waterfall_cold_hot[i];
+				break;
+			case WFALL_RAINBOW:
+				sd.waterfall_colours[i] = waterfall_rainbow[i];
+				break;
+			case WFALL_BLUE:
+				sd.waterfall_colours[i] = waterfall_blue[i];
+				break;
+			case WFALL_GRAY_INVERSE:
+				sd.waterfall_colours[i] = waterfall_grey_inverse[i];
+				break;
+			case WFALL_GRAY:
+			default:
+				sd.waterfall_colours[i] = waterfall_grey[i];
+				break;
+		}
+	}
+	//
+	//
+	// Load "top" color of palette (the 65th) with that to be used for the center grid color
+	//
+	sd.waterfall_colours[NUMBER_WATERFALL_COLOURS] = (ushort)ts.scope_centre_grid_colour_active;
+	//
+	//
+/*
+	//
+	// Load waterfall data with "splash" showing palette
+	//
+	j = 0;					// init count of lines on display
+	k = sd.wfall_line;		// start with line currently displayed in buffer
+	while(j < SPECTRUM_HEIGHT)	{		// loop number of times of buffer
+		for(i = 0; i < FFT_IQ_BUFF_LEN/2; i++)	{		// do this all of the way across, horizonally
+			sd.waterfall[k][i] = (SPECTRUM_HEIGHT - j) % SPECTRUM_HEIGHT;	// place the color of the palette, indexed to vertical position
+		}
+		j++;		// update line count
+		k++;		// update position within circular buffer - which also is used to calculate color
+		k %= SPECTRUM_HEIGHT;	// limit to modulus count of circular buffer size
+	}
+	//
+*/
+	//
+	switch(ts.spectrum_db_scale)	{
+	case	DB_DIV_5:
+		sd.db_scale = DB_SCALING_5;
+		break;
+	case	DB_DIV_7:
+		sd.db_scale = DB_SCALING_7;
+		break;
+	case	DB_DIV_15:
+		sd.db_scale = DB_SCALING_15;
+		break;
+	case	DB_DIV_20:
+		sd.db_scale = DB_SCALING_20;
+		break;
+	case S_1_DIV:
+		sd.db_scale = DB_SCALING_S1;
+		break;
+	case S_2_DIV:
+		sd.db_scale = DB_SCALING_S2;
+		break;
+	case S_3_DIV:
+		sd.db_scale = DB_SCALING_S3;
+		break;
+	case	DB_DIV_10:
+	default:
+		sd.db_scale = DB_SCALING_10;
+		break;
+	}
+	//
+	if(ts.waterfall_size == WATERFALL_NORMAL)	{						// waterfall the same size as spectrum scope
+		sd.wfall_height = SPECTRUM_HEIGHT - SPECTRUM_SCOPE_TOP_LIMIT;
+		sd.wfall_ystart = SPECTRUM_START_Y + SPECTRUM_SCOPE_TOP_LIMIT;
+		sd.wfall_size = SPECTRUM_HEIGHT - SPECTRUM_SCOPE_TOP_LIMIT;
+	}																	// waterfall larger, covering the word "Waterfall Display"
+	else if(ts.waterfall_size == WATERFALL_MEDIUM)	{
+		sd.wfall_height = SPECTRUM_HEIGHT + WFALL_MEDIUM_ADDITIONAL;
+		sd.wfall_ystart = SPECTRUM_START_Y - WFALL_MEDIUM_ADDITIONAL;
+		sd.wfall_size = SPECTRUM_HEIGHT + WFALL_MEDIUM_ADDITIONAL;
+	}
+	//
+	//
+	sd.wfall_contrast = (float)ts.waterfall_contrast;		// calculate scaling for contrast
+	sd.wfall_contrast /= 100;
+
+	// Init FFT structures
+	a = arm_rfft_init_f32((arm_rfft_instance_f32 *)&sd.S,(arm_cfft_radix4_instance_f32 *)&sd.S_CFFT,FFT_IQ_BUFF_LEN,FFT_QUADRATURE_PROC,1);
+
+	if(a != ARM_MATH_SUCCESS)
+	{
+		return;
+	}
+
+	// Ready
+	sd.enabled		= 1;
+	sd.first_run 	= 2;
+}
+
+//
+//*----------------------------------------------------------------------------
+//* Function Name       : UiDriverReDrawSpectrumDisplay
+//* Object              : state machine implementation
+//* Input Parameters    :
+//* Output Parameters   :
+//* Functions called    :
+//*----------------------------------------------------------------------------
+//
+// Spectrum Display code rewritten by C. Turner, KA7OEI, September 2014, May 2015
+//
+void UiSpectrumReDrawSpectrumDisplay()
+{
+	ulong i, spec_width;
+	uint32_t	max_ptr;	// throw-away pointer for ARM maxval and minval functions
+	float32_t	gcalc;
+	//
+
+	// Only in RX mode and NOT while powering down or in menu mode or if displaying memory information
+	if((ts.txrx_mode != TRX_MODE_RX) || (ts.powering_down) || (ts.menu_mode) || (ts.mem_disp) || (ts.boot_halt_flag))
+		return;
+
+	if((ts.spectrum_scope_scheduler) || (!ts.scope_speed))	// is it time to update the scan, or is this scope to be disabled?
+		return;
+	else
+		ts.spectrum_scope_scheduler = (ts.scope_speed-1)*2;
+
+	// No spectrum display in DIGI modes
+	//if(ts.dmod_mode == DEMOD_DIGI)
+	//	return;
+
+	// Nothing to do here otherwise, or if scope is to be held off while other parts of the display are to be updated or the LCD is being blanked
+	if((!sd.enabled) || (ts.hold_off_spectrum_scope > ts.sysclock) || (ts.lcd_blanking_flag))
+		return;
+
+	// The state machine will rest
+	// in between states
+//	sd.skip_process++;
+//	if(sd.skip_process < 1000)
+//		return;
+
+//	sd.skip_process = 0;
+
+	gcalc = 1/ads.codec_gain_calc;				// Get gain setting of codec and convert to multiplier factor
+
+	// Process implemented as state machine
+	switch(sd.state)
+	{
+		//
+		// Apply gain to collected IQ samples and then do FFT
+		//
+
+		case 1:
+		{
+			arm_scale_f32((float32_t *)sd.FFT_Samples, (float32_t)(gcalc * SCOPE_PREAMP_GAIN), (float32_t *)sd.FFT_Samples, FFT_IQ_BUFF_LEN);	// scale input according to A/D gain
+			//
+			UiDriverFFTWindowFunction(ts.fft_window_type);		// do windowing function on input data to get less "Bin Leakage" on FFT data
+			//
+			arm_rfft_f32((arm_rfft_instance_f32 *)&sd.S,(float32_t *)(sd.FFT_Windat),(float32_t *)(sd.FFT_Samples));	// Do FFT
+			//
+		sd.state++;
+		break;
+		}
+		//
+		// Do magnitude processing and gain control (AGC) on input of FFT
+		//
+		case 2:
+		{
+			//
+			// Save old display data - we will use later to mask pixel on the control
+			//
+			arm_copy_q15((q15_t *)sd.FFT_DspData, (q15_t *)sd.FFT_BkpData, FFT_IQ_BUFF_LEN/2);
+			//
+			// Calculate magnitude
+			//
+			arm_cmplx_mag_f32((float32_t *)(sd.FFT_Samples),(float32_t *)(sd.FFT_MagData),(FFT_IQ_BUFF_LEN/2));
+			//
+		sd.state++;
+		break;
+		}
+		//
+		//  Low-pass filter amplitude magnitude data
+		//
+		case 3:
+		{
+			uint32_t i;
+			float32_t		filt_factor;
+			//
+			filt_factor = (float)ts.scope_filter;		// use stored filter setting
+			filt_factor = 1/filt_factor;		// invert filter factor to allow multiplication
+			//
+			if(sd.dial_moved)	{	// Clear filter data if dial was moved in steps greater than 1 kHz
+				sd.dial_moved = 0;	// Dial moved - reset indicator
+				if(df.tuning_step > 1000)	{	// was tuning step greater than 1kHz?
+					arm_copy_f32((float32_t *)sd.FFT_MagData, (float32_t *)sd.FFT_AVGData, FFT_IQ_BUFF_LEN/2);	// yes - copy current data into average buffer
+				}
+				//
+				UiDrawSpectrumScopeFrequencyBarText();	// redraw frequency bar on the bottom of the display
+				//
+			}
+			else	{	// dial was not moved - do normal IIR lowpass filtering to "smooth" display
+				arm_scale_f32((float32_t *)sd.FFT_AVGData, (float32_t)filt_factor, (float32_t *)sd.FFT_Samples, FFT_IQ_BUFF_LEN/2);	// get scaled version of previous data
+				arm_sub_f32((float32_t *)sd.FFT_AVGData, (float32_t *)sd.FFT_Samples, (float32_t *)sd.FFT_AVGData, FFT_IQ_BUFF_LEN/2);	// subtract scaled information from old, average data
+				arm_scale_f32((float32_t *)sd.FFT_MagData, (float32_t)filt_factor, (float32_t *)sd.FFT_Samples, FFT_IQ_BUFF_LEN/2);	// get scaled version of new, input data
+				arm_add_f32((float32_t *)sd.FFT_Samples, (float32_t *)sd.FFT_AVGData, (float32_t *)sd.FFT_AVGData, FFT_IQ_BUFF_LEN/2);	// add portion new, input data into average
+				//
+				for(i = 0; i < FFT_IQ_BUFF_LEN/2; i++)	{		//		// guarantee that the result will always be >= 0
+					if(sd.FFT_AVGData[i] < 1)
+						sd.FFT_AVGData[i] = 1;
+				}
+			}
+		sd.state++;
+		break;
+		}
+		//
+		// De-linearize and normalize display data and do AGC processing
+		//
+		case 4:
+		{
+			q15_t	max1, max2, max3, min1, min2, min3;
+			q15_t	mean1, mean2, mean3;
+			float32_t	sig;
+			//
+			// De-linearize data with dB/division
+			//
+			for(i = 0; i < (FFT_IQ_BUFF_LEN/2); i++)	{
+				sig = log10(sd.FFT_AVGData[i]) * sd.db_scale;		// take FFT data, do a log10 and multiply it to scale it to get desired dB/divistion
+				sig += sd.display_offset;							// apply "AGC", vertical "sliding" offset (or brightness for waterfall)
+				if(sig > 1)											// is the value greater than 1?
+					sd.FFT_DspData[i] = (q15_t)sig;					// it was a useful value - save it
+				else
+					sd.FFT_DspData[i] = 1;							// not greater than 1 - assign it to a base value of 1 for sanity's sake
+			}
+			//
+			arm_copy_q15((q15_t *)sd.FFT_DspData, (q15_t *)sd.FFT_TempData, FFT_IQ_BUFF_LEN/2);
+			//
+			// Find peak and average to vertically adjust display
+			//
+			if(sd.magnify)	{	// are we in magnify mode?  If so, find max/mean of only those portions of the spectrum magnified - which are NOT in the proper order, dammit!
+				//
+				if(!ts.iq_freq_mode)	{	// yes, are we NOT in translate mode?
+					arm_max_q15((q15_t *)&sd.FFT_TempData[192], 64, &max1, &max_ptr);		// find maximum element in center portion
+					arm_min_q15((q15_t *)&sd.FFT_TempData[192], 64, &min1, &max_ptr);		// find minimum element in center portion
+					arm_mean_q15((q15_t *)&sd.FFT_TempData[192], 64, &mean1);				// find mean value in center portion
+					//
+					arm_max_q15((q15_t *)sd.FFT_TempData, 64, &max2, &max_ptr);		// find maximum element in center portion
+					arm_min_q15((q15_t *)sd.FFT_TempData, 64, &min2, &max_ptr);		// find minimum element in center portion
+					arm_mean_q15((q15_t *)sd.FFT_TempData, 64, &mean2);				// find mean value in center portion
+					//
+					if(max2 > max1)
+						max1 = max2;
+					//
+					if(mean2 > mean1)
+						mean1 = mean2;
+					//
+					if(min2 < min1)
+						min1 = min2;
+				}
+				else if(ts.iq_freq_mode == FREQ_IQ_CONV_P6KHZ)	{	// we are in RF LO HIGH mode (tuning is below center of screen)
+					arm_max_q15((q15_t *)&sd.FFT_TempData[160], 64, &max1, &max_ptr);		// find maximum element in center portion
+					arm_min_q15((q15_t *)&sd.FFT_TempData[160], 64, &min1, &max_ptr);		// find minimum element in center portion
+					arm_mean_q15((q15_t *)&sd.FFT_TempData[160], 64, &mean1);				// find mean value in center portion
+					//
+					arm_max_q15((q15_t *)&sd.FFT_TempData[224], 32, &max2, &max_ptr);		// find maximum element in center portion
+					arm_min_q15((q15_t *)&sd.FFT_TempData[224], 32, &min2, &max_ptr);		// find minimum element in center portion
+					arm_mean_q15((q15_t *)&sd.FFT_TempData[224], 32, &mean2);				// find mean value in center portion
+					//
+					if(max2 > max1)
+						max1 = max2;
+					//
+					if(min2 < min1)
+						min1 = min2;
+					//
+					if(mean2 > mean1)
+						mean1 = mean2;
+					//
+					arm_max_q15((q15_t *)&sd.FFT_TempData[0], 32, &max3, &max_ptr);		// find maximum element in center portion
+					arm_min_q15((q15_t *)&sd.FFT_TempData[0], 32, &min3, &max_ptr);		// find minimum element in center portion
+					arm_mean_q15((q15_t *)&sd.FFT_TempData[0], 32, &mean3);				// find mean value in center portion
+					//
+					if(max3 > max1)
+						max1 = max3;
+					//
+					if(min3 < min1)
+						min1 = min3;
+					//
+					if(mean3 > mean1)
+						mean1 = mean3;
+				}
+				else if(ts.iq_freq_mode == FREQ_IQ_CONV_M6KHZ)	{	// we are in RF LO LOW mode (tuning is above center of screen)
+					arm_max_q15((q15_t *)&sd.FFT_TempData[224], 32, &max1, &max_ptr);		// find maximum element in center portion
+					arm_min_q15((q15_t *)&sd.FFT_TempData[224], 32, &min1, &max_ptr);		// find minimum element in center portion
+					arm_mean_q15((q15_t *)&sd.FFT_TempData[224], 32, &mean1);				// find mean value in center portion
+					//
+					arm_max_q15((q15_t *)&sd.FFT_TempData[0], 32, &max2, &max_ptr);		// find maximum element in center portion
+					arm_min_q15((q15_t *)&sd.FFT_TempData[0], 32, &min2, &max_ptr);		// find minimum element in center portion
+					arm_mean_q15((q15_t *)&sd.FFT_TempData[0], 32, &mean2);				// find mean value in center portion
+					//
+					if(max2 > max1)
+						max1 = max2;
+					//
+					if(min2 < min1)
+						min1 = min2;
+					//
+					if(mean2 > mean1)
+						mean1 = mean2;
+					//
+					arm_max_q15((q15_t *)&sd.FFT_TempData[32], 64, &max3, &max_ptr);		// find maximum element in center portion
+					arm_min_q15((q15_t *)&sd.FFT_TempData[32], 64, &min3, &max_ptr);		// find minimum element in center portion
+					arm_mean_q15((q15_t *)&sd.FFT_TempData[32], 64, &mean3);				// find mean value in center portion
+					//
+					if(max3 > max1)
+						max1 = max3;
+					//
+					if(min2 < min1)
+						min1 = min2;
+					//
+					if(mean3 > mean1)
+						mean1 = mean3;
+				}
+				else if(ts.iq_freq_mode == FREQ_IQ_CONV_P12KHZ)	{	// we are in RF LO HIGH mode (tuning is below center of screen)		// aaaaaaaaaaaaaaaaaaaaa
+					arm_max_q15((q15_t *)&sd.FFT_TempData[128], 64, &max1, &max_ptr);		// find maximum element in center portion
+					arm_min_q15((q15_t *)&sd.FFT_TempData[128], 64, &min1, &max_ptr);		// find minimum element in center portion
+					arm_mean_q15((q15_t *)&sd.FFT_TempData[128], 64, &mean1);				// find mean value in center portion
+					//
+					arm_max_q15((q15_t *)&sd.FFT_TempData[192], 32, &max2, &max_ptr);		// find maximum element in center portion
+					arm_min_q15((q15_t *)&sd.FFT_TempData[192], 32, &min2, &max_ptr);		// find minimum element in center portion
+					arm_mean_q15((q15_t *)&sd.FFT_TempData[192], 32, &mean2);				// find mean value in center portion
+					//
+					if(max2 > max1)
+						max1 = max2;
+					//
+					if(min2 < min1)
+						min1 = min2;
+					//
+					if(mean2 > mean1)
+						mean1 = mean2;
+					//
+					arm_max_q15((q15_t *)&sd.FFT_TempData[0], 32, &max3, &max_ptr);		// find maximum element in center portion
+					arm_min_q15((q15_t *)&sd.FFT_TempData[0], 32, &min3, &max_ptr);		// find minimum element in center portion
+					arm_mean_q15((q15_t *)&sd.FFT_TempData[0], 32, &mean3);				// find mean value in center portion
+					//
+					if(max3 > max1)
+						max1 = max3;
+					//
+					if(min3 < min1)
+						min1 = min3;
+					//
+					if(mean3 > mean1)
+						mean1 = mean3;
+				}
+				else if(ts.iq_freq_mode == FREQ_IQ_CONV_M12KHZ)	{	// we are in RF LO LOW mode (tuning is above center of screen)
+					arm_max_q15((q15_t *)&sd.FFT_TempData[0], 32, &max1, &max_ptr);		// find maximum element in center portion
+					arm_min_q15((q15_t *)&sd.FFT_TempData[0], 32, &min1, &max_ptr);		// find minimum element in center portion
+					arm_mean_q15((q15_t *)&sd.FFT_TempData[0], 32, &mean1);				// find mean value in center portion
+					//
+					arm_max_q15((q15_t *)&sd.FFT_TempData[32], 32, &max2, &max_ptr);		// find maximum element in center portion
+					arm_min_q15((q15_t *)&sd.FFT_TempData[32], 32, &min2, &max_ptr);		// find minimum element in center portion
+					arm_mean_q15((q15_t *)&sd.FFT_TempData[32], 32, &mean2);				// find mean value in center portion
+					//
+					if(max2 > max1)
+						max1 = max2;
+					//
+					if(min2 < min1)
+						min1 = min2;
+					//
+					if(mean2 > mean1)
+						mean1 = mean2;
+					//
+					arm_max_q15((q15_t *)&sd.FFT_TempData[64], 64, &max3, &max_ptr);		// find maximum element in center portion
+					arm_min_q15((q15_t *)&sd.FFT_TempData[64], 64, &min3, &max_ptr);		// find minimum element in center portion
+					arm_mean_q15((q15_t *)&sd.FFT_TempData[64], 64, &mean3);				// find mean value in center portion
+					//
+					if(max3 > max1)
+						max1 = max3;
+					//
+					if(min2 < min1)
+						min1 = min2;
+					//
+					if(mean3 > mean1)
+						mean1 = mean3;
+				}
+			}
+			else	{
+				spec_width = FFT_IQ_BUFF_LEN/2;
+				arm_max_q15((q15_t *)sd.FFT_TempData, spec_width, &max1, &max_ptr);		// find maximum element
+				arm_min_q15((q15_t *)sd.FFT_TempData, spec_width, &min1, &max_ptr);		// find minimum element
+				arm_mean_q15((q15_t *)sd.FFT_TempData, spec_width, &mean1);				// find mean value
+			}
+
+			//
+			// Vertically adjust spectrum scope so that the strongest signals are adjusted to the top
+			//
+			if(max1 > SPECTRUM_HEIGHT) {	// is result higher than display
+				sd.display_offset -= sd.agc_rate;	// yes, adjust downwards quickly
+//				if(max1 > SPECTRUM_HEIGHT+(SPECTRUM_HEIGHT/2))			// is it WAY above top of screen?
+//					sd.display_offset -= sd.agc_rate*3;	// yes, adjust downwards REALLY quickly
+			}
+			//
+			// Prevent "empty" spectrum display from filling with "noise" by checking the peak/average of what was found
+			//
+			else if(((max1*10/mean1) <= (q15_t)ts.spectrum_scope_nosig_adjust) && (max1 < SPECTRUM_HEIGHT+(SPECTRUM_HEIGHT/2)))	{	// was "average" signal ratio below set threshold and average is not insanely strong??
+				if((min1 > 2) && (max1 > 2))	{		// prevent the adjustment from going downwards, "into the weeds"
+					sd.display_offset -= sd.agc_rate;	// yes, adjust downwards
+		            if(sd.display_offset < (-(SPECTRUM_HEIGHT + SPECTRUM_SCOPE_ADJUST_OFFSET)))
+		               sd.display_offset = (-(SPECTRUM_HEIGHT + SPECTRUM_SCOPE_ADJUST_OFFSET));
+				}
+			}
+			else
+				sd.display_offset += (sd.agc_rate/3);	// no, adjust upwards more slowly
+			//
+			//
+			if((min1 <= 2) && (max1 <= 2))	{	// ARGH - We must already be in the weeds, below the bottom - let's adjust upwards quickly to get it back onto the display!
+				sd.display_offset += sd.agc_rate*10;
+			}
+			//
+			// used for debugging
+//				char txt[32];
+//				sprintf(txt, " %d,%d,%d,%d ", (int)(max1*100/mean1), (int)(min1), (int)(max1),(int)mean1);
+//				sprintf(txt, " %d,%d,%d,%d ", (int)sd.display_offset*100, (int)min1*100,(int)max1*100,(int)SPECTRUM_HEIGHT);
+//				UiLcdHy28_PrintText    ((POS_RIT_IND_X + 1), (POS_RIT_IND_Y + 20),txt,White,Grid,0);
+
+			//
+			//
+			ushort ptr;
+			//
+			// Now, re-arrange the spectrum for the various magnify modes so that they display properly!
+			//
+			// we can calculate any position in the spectrum by using the
+			// following thinking
+			// the spectrum is 256 entries wide == FFT_IQ_BUFF_LEN/2
+			// the begin of the spectrum (== -24khz) is in the middle of the buffer
+			// i.e. 0 == FFT_IQ_BUFF_LEN/2/2 == 128
+			// that means (FFT_IQ_BUFF_LEN/4 + idx)%FFT_IQ_BUFF_LEN/2 == (128+idx)%256
+			// gives us the index in the buffer.
+			// we use this  knowledge to simplify the magnification code
+			// compiler can heavily optimize this since we  all these values being power of 2 value
+			if(sd.magnify)	{	// is magnify mode on?
+				uint32_t end_range;
+				switch(ts.iq_freq_mode) {
+				break;
+				case FREQ_IQ_CONV_P6KHZ:	// frequency translate mode is in "RF LO HIGH" mode - tune below center of screen
+					ptr = FFT_IQ_BUFF_LEN/16 ; // FFT_IQ_BUFF_LEN/8 + FFT_IQ_BUFF_LEN/16  = -12khz + 6khz = -6khz <-> + 18khz
+					break;
+				case FREQ_IQ_CONV_M6KHZ: // frequency translate mode is in "RF LO HIGH" mode - tune below center of screen
+					ptr = 3* FFT_IQ_BUFF_LEN/16 ; // FFT_IQ_BUFF_LEN/8 - FFT_IQ_BUFF_LEN/16  = -12khz - 6khz = -18khz <-> + 6khz
+					break;
+				case FREQ_IQ_CONV_P12KHZ: // frequency translate mode is in "RF LO HIGH" mode - tune below center of screen
+					ptr = 0; // FFT_IQ_BUFF_LEN/8 + FFT_IQ_BUFF_LEN/8  = -12khz + 12khz = 0khz <-> + 24khz
+					break;
+				case FREQ_IQ_CONV_M12KHZ:	// frequency translate mode is in "RF LO HIGH" mode - tune below center of screen
+					ptr = FFT_IQ_BUFF_LEN/4 ; // FFT_IQ_BUFF_LEN/8 - FFT_IQ_BUFF_LEN/8  = -12khz - 12khz = -24khz <-> 0khz
+					break;
+				default:	// yes - frequency translate mode is off
+					ptr = FFT_IQ_BUFF_LEN/8; // FFT_IQ_BUFF_LEN/8  = -12khz = -12khz <-> + 12khz
+				}
+				end_range = ptr+FFT_IQ_BUFF_LEN/4; // exclusive
+				for(i=0; ptr < end_range; ptr++)	{	// expand data to fill entire screen - get lower half
+					sd.FFT_DspData[FftIdx2BufMap(i++)] = sd.FFT_TempData[FftIdx2BufMap(ptr)]; /* each entry from fft is used twice */
+					sd.FFT_DspData[FftIdx2BufMap(i++)] = sd.FFT_TempData[FftIdx2BufMap(ptr)]; /* each entry from fft is used twice */
+				}
+			}
+			else
+				arm_copy_q15((q15_t *)sd.FFT_DspData, (q15_t *)sd.FFT_TempData, FFT_IQ_BUFF_LEN/2);
+			//
+			// After the above manipulation, clip the result to make sure that it is within the range of the palette table
+			//
+			for(i = 0; i < FFT_IQ_BUFF_LEN/2; i++)	{
+				if(sd.FFT_DspData[i] >= SPECTRUM_HEIGHT)	// is there an illegal height value?
+					sd.FFT_DspData[i] = SPECTRUM_HEIGHT - 1;	// yes - clip it
+
+			}
+			//
+			//
+		sd.state++;
+		break;
+
+		}
+		//
+		//  update LCD control
+		//
+		case 5:
+		{
+		uint32_t	clr;
+		UiDriverMenuMapColors(ts.scope_trace_colour,NULL, &clr);
+        // Left part of screen(mask and update in one operation to minimize flicker)
+        UiSpectrumDrawSpectrum((q15_t *)(sd.FFT_BkpData + FFT_IQ_BUFF_LEN/4), (q15_t *)(sd.FFT_DspData + FFT_IQ_BUFF_LEN/4), Black, clr,0);
+        // Right part of the screen (mask and update) left part of screen is stored in the first quarter [0...127]
+        UiSpectrumDrawSpectrum((q15_t *)(sd.FFT_BkpData), (q15_t *)(sd.FFT_DspData), Black, clr,1);
+        sd.state = 0;   // Stage 0 - collection of data by the Audio driver
+		break;
+		}
+		default:
+			sd.state = 0;
+			break;
+	}
+}
+//
+//
+//*----------------------------------------------------------------------------
+//* Function Name       : UiDriverReDrawWaterfallDisplay
+//* Object              : state machine implementation
+//* Input Parameters    :
+//* Output Parameters   :
+//* Functions called    :
+//*----------------------------------------------------------------------------
+//
+// Waterfall Display code written by C. Turner, KA7OEI, May 2015 entirely from "scratch" - which is to say that I did not borrow any of it
+// from anywhere else, aside from keeping some of the general functions found in "Case 1".
+//
+void UiSpectrumReDrawWaterfall()
+{
+	ulong i, spec_width;
+	uint32_t	max_ptr;	// throw-away pointer for ARM maxval AND minval functions
+	float32_t	gcalc;
+	//
+
+	// Only in RX mode and NOT while powering down or in menu mode or if displaying memory information
+	if((ts.txrx_mode != TRX_MODE_RX) || (ts.powering_down) || (ts.menu_mode) || (ts.mem_disp) || (ts.boot_halt_flag))
+		return;
+
+	if((ts.spectrum_scope_scheduler) || (!ts.waterfall_speed))	// is it time to update the scan, or is this scope to be disabled?
+		return;
+	else
+		ts.spectrum_scope_scheduler = (ts.waterfall_speed-1)*2;
+
+
+	// No spectrum display in DIGI modes
+	//if(ts.dmod_mode == DEMOD_DIGI)
+	//	return;
+
+	// Nothing to do here otherwise, or if scope is to be held off while other parts of the display are to be updated or the LCD is being blanked
+	if((!sd.enabled) || (ts.hold_off_spectrum_scope > ts.sysclock) || (ts.lcd_blanking_flag))
+		return;
+
+	// The state machine will rest
+	// in between states
+//	sd.skip_process++;
+//	if(sd.skip_process < 1000)
+//		return;
+
+//	sd.skip_process = 0;
+
+	gcalc = 1/ads.codec_gain_calc;				// Get gain setting of codec and convert to multiplier factor
+
+	// Process implemented as state machine
+	switch(sd.state)
+	{
+		//
+		// Apply gain to collected IQ samples and then do FFT
+		//
+		case 1:		// Scale input according to A/D gain and apply Window function
+		{
+			arm_scale_f32((float32_t *)sd.FFT_Samples, (float32_t)(gcalc * SCOPE_PREAMP_GAIN), (float32_t *)sd.FFT_Samples, FFT_IQ_BUFF_LEN);	// scale input according to A/D gain
+			//
+			UiDriverFFTWindowFunction(ts.fft_window_type);		// do windowing function on input data to get less "Bin Leakage" on FFT data
+			//
+		sd.state++;
+		break;
+		}
+		case 2:		// Do FFT and calculate complex magnitude
+		{
+			arm_rfft_f32((arm_rfft_instance_f32 *)&sd.S,(float32_t *)(sd.FFT_Windat),(float32_t *)(sd.FFT_Samples));	// Do FFT
+			//
+			// Calculate magnitude
+			//
+			arm_cmplx_mag_f32((float32_t *)(sd.FFT_Samples),(float32_t *)(sd.FFT_MagData),(FFT_IQ_BUFF_LEN/2));
+			//
+		sd.state++;
+		break;
+		}
+		//
+		//  Low-pass filter amplitude magnitude data
+		//
+		case 3:
+		{	uint32_t i;
+			float32_t		filt_factor;
+			//
+			filt_factor = (float)ts.scope_filter;		// use stored filter setting
+			filt_factor = 1/filt_factor;		// invert filter factor to allow multiplication
+			//
+			if(sd.dial_moved)	{	// Clear filter data if dial was moved in steps greater than 1 kHz
+				sd.dial_moved = 0;	// Dial moved - reset indicator
+				if(df.tuning_step > 1000)	{	// was tuning step greater than 1kHz
+					arm_copy_f32((float32_t *)sd.FFT_MagData,(float32_t *)sd.FFT_AVGData, FFT_IQ_BUFF_LEN/2);	// copy current data into average buffer
+				}
+				//
+				UiDrawSpectrumScopeFrequencyBarText();	// redraw frequency bar on the bottom of the display
+				//
+			}
+			else	{	// dial was not moved - do IIR lowpass filtering to "smooth" display
+				arm_scale_f32((float32_t *)sd.FFT_AVGData, (float32_t)filt_factor, (float32_t *)sd.FFT_Samples, FFT_IQ_BUFF_LEN/2);	// get scaled version of previous data
+				arm_sub_f32((float32_t *)sd.FFT_AVGData, (float32_t *)sd.FFT_Samples, (float32_t *)sd.FFT_AVGData, FFT_IQ_BUFF_LEN/2);	// subtract scaled information from old, average data
+				arm_scale_f32((float32_t *)sd.FFT_MagData, (float32_t)filt_factor, (float32_t *)sd.FFT_Samples, FFT_IQ_BUFF_LEN/2);	// get scaled version of new, input data
+				arm_add_f32((float32_t *)sd.FFT_Samples, (float32_t *)sd.FFT_AVGData, (float32_t *)sd.FFT_AVGData, FFT_IQ_BUFF_LEN/2);	// add portion new, input data into average
+				//
+				for(i = 0; i < FFT_IQ_BUFF_LEN/2; i++)	{		//		// guarantee that the result will always be >= 0
+					if(sd.FFT_AVGData[i] < 1)
+						sd.FFT_AVGData[i] = 1;
+				}
+			}
+		sd.state++;
+		break;
+		}
+		//
+		// De-linearize and normalize display data and do AGC processing
+		//
+		case 4:
+		{
+			float32_t	max, min, mean, offset;
+			float32_t	sig;
+			//
+			// De-linearize data with dB/division
+			//
+			for(i = 0; i < (FFT_IQ_BUFF_LEN/2); i++)	{
+				sig = log10(sd.FFT_AVGData[i]) * DB_SCALING_10;		// take FFT data, do a log10 and multiply it to scale 10dB (fixed)
+				sig += sd.display_offset;							// apply "AGC", vertical "sliding" offset (or brightness for waterfall)
+				if(sig > 1)											// is the value greater than 1?
+					sd.FFT_DspData[i] = (q15_t)sig;					// it was a useful value - save it
+				else
+					sd.FFT_DspData[i] = 1;							// not greater than 1 - assign it to a base value of 1 for sanity's sake
+			}
+			//
+			// Transfer data to the waterfall display circular buffer, putting the bins in frequency-sequential order!
+			//
+			for(i = 0; i < (FFT_IQ_BUFF_LEN/2); i++)	{
+				if(i < (SPECTRUM_WIDTH/2))	{		// build left half of spectrum data
+					sd.FFT_Samples[i] = sd.FFT_DspData[i + FFT_IQ_BUFF_LEN/4];	// get data
+				}
+				else	{							// build right half of spectrum data
+					sd.FFT_Samples[i] = sd.FFT_DspData[i - FFT_IQ_BUFF_LEN/4];	// get data
+				}
+			}
+			//
+			// Find peak and average to vertically adjust display
+			//
+			if(sd.magnify)	{	// are we in magnify mode?
+				spec_width = FFT_IQ_BUFF_LEN/4;	// yes - define new spectrum width
+				//
+				if(!ts.iq_freq_mode)	{	// yes, are we NOT in translate mode?
+					arm_max_f32((float32_t *)&sd.FFT_Samples[FFT_IQ_BUFF_LEN/8], spec_width, &max, &max_ptr);		// find maximum element in center portion
+					arm_min_f32((float32_t *)&sd.FFT_Samples[FFT_IQ_BUFF_LEN/8], spec_width, &min, &max_ptr);		// find minimum element in center portion
+					arm_mean_f32((float32_t *)&sd.FFT_Samples[FFT_IQ_BUFF_LEN/8], spec_width, &mean);				// find mean value in center portion
+				}
+				else if(ts.iq_freq_mode == FREQ_IQ_CONV_P6KHZ)	{	// we are in RF LO HIGH mode (tuning is below center of screen)
+					arm_max_f32((float32_t *)&sd.FFT_Samples[FFT_IQ_BUFF_LEN/8 - 32], spec_width, &max, &max_ptr);		// find maximum element in center portion
+					arm_min_f32((float32_t *)&sd.FFT_Samples[FFT_IQ_BUFF_LEN/8 - 32], spec_width, &min, &max_ptr);		// find minimum element in center portion
+					arm_mean_f32((float32_t *)&sd.FFT_Samples[FFT_IQ_BUFF_LEN/8 - 32], spec_width, &mean);				// find mean value in center portion
+				}
+				else if(ts.iq_freq_mode == FREQ_IQ_CONV_M6KHZ)	{	// we are in RF LO LOW mode (tuning is above center of screen)
+					arm_max_f32((float32_t *)&sd.FFT_Samples[FFT_IQ_BUFF_LEN/8 + 32], spec_width, &max, &max_ptr);		// find maximum element in center portion
+					arm_min_f32((float32_t *)&sd.FFT_Samples[FFT_IQ_BUFF_LEN/8 + 32], spec_width, &min, &max_ptr);		// find minimum element in center portion
+					arm_mean_f32((float32_t *)&sd.FFT_Samples[FFT_IQ_BUFF_LEN/8 + 32], spec_width, &mean);				// find mean value in center portion
+				}
+				else if(ts.iq_freq_mode == FREQ_IQ_CONV_P12KHZ)	{	// we are in RF LO HIGH mode (tuning is below center of screen)		// aaaaaaaaaaaaaaaaaaaaaaaaa
+					arm_max_f32((float32_t *)&sd.FFT_Samples[FFT_IQ_BUFF_LEN/8 - 64], spec_width, &max, &max_ptr);		// find maximum element in center portion
+					arm_min_f32((float32_t *)&sd.FFT_Samples[FFT_IQ_BUFF_LEN/8 - 64], spec_width, &min, &max_ptr);		// find minimum element in center portion
+					arm_mean_f32((float32_t *)&sd.FFT_Samples[FFT_IQ_BUFF_LEN/8 - 64], spec_width, &mean);				// find mean value in center portion
+				}
+				else if(ts.iq_freq_mode == FREQ_IQ_CONV_M12KHZ)	{	// we are in RF LO LOW mode (tuning is above center of screen)
+					arm_max_f32((float32_t *)&sd.FFT_Samples[FFT_IQ_BUFF_LEN/8 + 64], spec_width, &max, &max_ptr);		// find maximum element in center portion
+					arm_min_f32((float32_t *)&sd.FFT_Samples[FFT_IQ_BUFF_LEN/8 + 64], spec_width, &min, &max_ptr);		// find minimum element in center portion
+					arm_mean_f32((float32_t *)&sd.FFT_Samples[FFT_IQ_BUFF_LEN/8 + 64], spec_width, &mean);				// find mean value in center portion
+				}
+			}
+			else	{
+				spec_width = FFT_IQ_BUFF_LEN/2;
+				arm_max_f32((float32_t *)sd.FFT_Samples, spec_width, &max, &max_ptr);		// find maximum element
+				arm_min_f32((float32_t *)sd.FFT_Samples, spec_width, &min, &max_ptr);		// find minimum element
+				arm_mean_f32((float32_t *)sd.FFT_Samples, spec_width, &mean);				// find mean value
+			}
+			//
+			// Calculate "brightness" offset for amplitude value
+			//
+			offset = (float)ts.waterfall_offset;
+			offset -= 100;
+			//
+			//
+			// Vertically adjust spectrum scope so that the strongest signals are adjusted to the top
+			//
+			if((max - offset) >= NUMBER_WATERFALL_COLOURS - 1)	{	// is result higher than display brightness
+				sd.display_offset -= sd.agc_rate;	// yes, adjust downwards quickly
+//				if(max1 > SPECTRUM_HEIGHT+(SPECTRUM_HEIGHT/2))			// is it WAY above top of screen?
+//					sd.display_offset -= sd.agc_rate*3;	// yes, adjust downwards REALLY quickly
+			}
+			//
+			// Prevent "empty" spectrum display from filling with "noise" by checking the peak/average of what was found
+			//
+			else if(((max*10/mean) <= (q15_t)ts.waterfall_nosig_adjust) && (max < SPECTRUM_HEIGHT+(SPECTRUM_HEIGHT/2)))	{	// was "average" signal ratio below set threshold and average is not insanely strong??
+				if((min > 2) && (max > 2))	{		// prevent the adjustment from going downwards, "into the weeds"
+					sd.display_offset -= sd.agc_rate;	// yes, adjust downwards
+		            if(sd.display_offset < (-(SPECTRUM_HEIGHT + SPECTRUM_SCOPE_ADJUST_OFFSET)))
+		               sd.display_offset = (-(SPECTRUM_HEIGHT + SPECTRUM_SCOPE_ADJUST_OFFSET));
+				}
+			}
+			else
+				sd.display_offset += (sd.agc_rate/3);	// no, adjust upwards more slowly
+			//
+			//
+			if((min <= 2) && (max <= 2))	{	// ARGH - We must already be in the weeds, below the bottom - let's adjust upwards quickly to get it back onto the display!
+				sd.display_offset += sd.agc_rate*10;
+			}
+			//
+			// used for debugging
+			//	char txt[32];
+			//	sprintf(txt, " %d,%d,%d ", (int)sd.display_offset*100, (int)min*100,(int)max*100);
+			//	UiLcdHy28_PrintText    ((POS_RIT_IND_X + 1), (POS_RIT_IND_Y + 20),txt,White,Grid,0);
+			//
+			// Copy to holder for the waterfall buffer
+			sd.state++;
+			break;
+		}
+		case 5:	// rescale waterfall horizontally, apply brightness/contrast, process pallate and put vertical line on screen, if enabled.
+		{
+			//
+			sd.wfall_line %= sd.wfall_size;	// make sure that the circular buffer is clipped to the size of the display area
+			//
+			//
+			// Contrast:  100 = 1.00 multiply factor:  125 = multiply by 1.25 - "sd.wfall_contrast" already converted to 100=1.00
+			//
+			arm_scale_f32((float32_t *)sd.FFT_Samples, (float32_t)sd.wfall_contrast, (float32_t *)sd.FFT_Samples, FFT_IQ_BUFF_LEN/2);
+			//
+			ushort ptr;
+			//
+			if(sd.magnify)	{	// is magnify mode on?
+				if(!ts.iq_freq_mode)	{	// yes - frequency translate mode is off
+					for(i = 0; i < FFT_IQ_BUFF_LEN/2; i++)	{	// expand data to fill entire screen - get lower half
+						ptr = (i/2)+64;
+						if(ptr < FFT_IQ_BUFF_LEN/2)	{
+							sd.wfall_temp[i] = sd.FFT_Samples[ptr];
+						}
+					}
+				}
+				else if(ts.iq_freq_mode == FREQ_IQ_CONV_P6KHZ)	{	// frequency translate mode is in "RF LO HIGH" mode - tune below center of screen
+					for(i = 0; i < FFT_IQ_BUFF_LEN/2; i++)	{	// expand data to fill entire screen - get lower half
+						ptr = (i/2)+32;
+						if(ptr < FFT_IQ_BUFF_LEN/2)	{
+							sd.wfall_temp[i] = sd.FFT_Samples[ptr];
+						}
+					}
+				}
+				else if(ts.iq_freq_mode == FREQ_IQ_CONV_M6KHZ)	{	// frequency translate mode is in "RF LO LOW" mode - tune below center of screen
+					for(i = 0; i < FFT_IQ_BUFF_LEN/2; i++)	{	// expand data to fill entire screen - get lower half
+						ptr = (i/2)+96;
+						if(ptr < FFT_IQ_BUFF_LEN/2)	{
+							sd.wfall_temp[i] = sd.FFT_Samples[ptr];
+						}
+					}
+				}
+				else if(ts.iq_freq_mode == FREQ_IQ_CONV_P12KHZ)	{	// frequency translate mode is in "RF LO HIGH" mode - tune below center of screen       aaaaaaaaaaaaaaaaaaaaaa
+					for(i = 0; i < FFT_IQ_BUFF_LEN/2; i++)	{	// expand data to fill entire screen - get lower half
+						ptr = (i/2);
+						if(ptr < FFT_IQ_BUFF_LEN/2)	{
+							sd.wfall_temp[i] = sd.FFT_Samples[ptr];
+						}
+					}
+				}
+				else if(ts.iq_freq_mode == FREQ_IQ_CONV_M12KHZ)	{	// frequency translate mode is in "RF LO LOW" mode - tune below center of screen
+					for(i = 0; i < FFT_IQ_BUFF_LEN/2; i++)	{	// expand data to fill entire screen - get lower half
+						ptr = (i/2)+128;
+						if(ptr < FFT_IQ_BUFF_LEN/2)	{
+							sd.wfall_temp[i] = sd.FFT_Samples[ptr];
+						}
+					}
+				}
+				arm_copy_f32((float32_t *)sd.wfall_temp, (float32_t *)sd.FFT_Samples, FFT_IQ_BUFF_LEN/2);		// copy the rescaled/shifted data into the main buffer
+			}
+			//
+			// After the above manipulation, clip the result to make sure that it is within the range of the palette table
+			//
+			for(i = 0; i < FFT_IQ_BUFF_LEN/2; i++)	{
+				if(sd.FFT_Samples[i] >= NUMBER_WATERFALL_COLOURS)	// is there an illegal color value?
+					sd.FFT_Samples[i] = NUMBER_WATERFALL_COLOURS - 1;	// yes - clip it
+				//
+				sd.waterfall[sd.wfall_line][i] = (ushort)sd.FFT_Samples[i];	// save the manipulated value in the circular waterfall buffer
+			}
+			//
+			// Place center line marker on screen:  Location [64] (the 65th) of the palette is reserved is a special color reserved for this
+			//
+			if(sd.magnify)	{
+				sd.waterfall_colours[NUMBER_WATERFALL_COLOURS] = (ushort)ts.scope_centre_grid_colour_active;	// for some reason it is necessary to reload this entry of the palette!
+				sd.waterfall[sd.wfall_line][128] = NUMBER_WATERFALL_COLOURS;	// set graticule in the middle
+			}
+			else if(!ts.iq_freq_mode)	// is frequency translate off OR magnification mode on
+				sd.waterfall[sd.wfall_line][128] = NUMBER_WATERFALL_COLOURS;	// set graticule in the middle
+			else if(ts.iq_freq_mode == FREQ_IQ_CONV_P6KHZ)			// LO HIGH - set graticule below center
+				sd.waterfall[sd.wfall_line][96] = NUMBER_WATERFALL_COLOURS;
+			else if(ts.iq_freq_mode == FREQ_IQ_CONV_M6KHZ)			// LO LOW - set graticule above center
+				sd.waterfall[sd.wfall_line][160] = NUMBER_WATERFALL_COLOURS;
+			else if(ts.iq_freq_mode == FREQ_IQ_CONV_P12KHZ)			// LO HIGH - set graticule below center
+				sd.waterfall[sd.wfall_line][64] = NUMBER_WATERFALL_COLOURS;
+			else if(ts.iq_freq_mode == FREQ_IQ_CONV_M12KHZ)			// LO LOW - set graticule above center
+				sd.waterfall[sd.wfall_line][192] = NUMBER_WATERFALL_COLOURS;
+
+			//
+			sd.wfall_line++;		// bump to the next line in the circular buffer for next go-around
+			//
+			// scan_top is used to limit AGC action to "magnified" portion
+			//
+		sd.state++;
+		break;
+		}
+		//
+		//  update LCD control
+		//
+		case 6:
+		{
+			uchar lptr = sd.wfall_line;		// get current line of "bottom" of waterfall in circular buffer
+			uchar lcnt = 0;					// initialize count of number of lines of display
+
+			//
+			sd.wfall_line_update++;									// update waterfall line count
+			sd.wfall_line_update %= ts.waterfall_vert_step_size;	// clip it to number of lines per iteration
+
+			if(!sd.wfall_line_update)	{							// if it's count is zero, it's time to move the waterfall up
+				//
+				lptr %= sd.wfall_size;		// do modulus limit of spectrum high
+				//
+				// set up LCD for bulk write, limited only to area of screen with waterfall display.  This allow data to start from the
+				// bottom-left corner and advance to the right and up to the next line automatically without ever needing to address
+				// the location of any of the display data - as long as we "blindly" write precisely the correct number of pixels per
+				// line and the number of lines.
+				//
+				UiLcdHy28_OpenBulkWrite(SPECTRUM_START_X, SPECTRUM_WIDTH, (sd.wfall_ystart + 1), sd.wfall_height);
+				//
+				ushort spectrumLine[SPECTRUM_WIDTH];
+
+				while(lcnt < sd.wfall_size)	{				// set up counter for number of lines defining height of waterfall
+					for(i = 0; i < (SPECTRUM_WIDTH); i++)	{	// scan to copy one line of spectral data - "unroll" to optimize for ARM processor
+						spectrumLine[i] = sd.waterfall_colours[sd.waterfall[lptr][i]];	// write to memory using waterfall color from palette
+					}
+
+					UiLcdHy28_BulkWrite(spectrumLine,SPECTRUM_WIDTH);
+
+					lcnt++;									// update count of lines we have done
+					lptr++;									// point to next line in circular display buffer
+					lptr %= sd.wfall_size;				// clip to display height
+				}
+				//
+				UiLcdHy28_CloseBulkWrite();					// we are done updating the display - return to normal full-screen mode
+				}
+				sd.state = 0;	// Stage 0 - collection of data by the Audio driver
+				break;
+		}
+		default:
+			sd.state = 0;
+			break;
+	}
+}
+//
+//
+//
+//*----------------------------------------------------------------------------
+//* Function Name       : UiInitSpectrumScopeWaterfall
+//* Object              : Does all steps for clearing screen and initializing spectrum scope and waterfall
+//* Input Parameters    :
+//* Output Parameters   :
+//* Functions called    :
+//*----------------------------------------------------------------------------
+//
+void UiSpectrumInitWaterfallDisplay()
+{
+	if(ts.boot_halt_flag)			// do not build spectrum display/waterfall if we are loading EEPROM defaults!
+		return;
+
+	UiSpectrumClearDisplay();			// clear display under spectrum scope
+	UiSpectrumCreateDrawArea();
+	UiDriverInitSpectrumDisplay();
+	UiDriverDisplayFilterBW();	// Update on-screen indicator of filter bandwidth
+}

--- a/mchf-eclipse/drivers/ui/lcd/ui_spectrum.h
+++ b/mchf-eclipse/drivers/ui/lcd/ui_spectrum.h
@@ -14,4 +14,93 @@
 ************************************************************************************/
 
 
+void UiSpectrumInitSpectrumDisplay();
+void UiSpectrumInitWaterfallDisplay();
+void UiSpectrumClearDisplay();
+void UiSpectrumReDrawWaterfall();
+void UiSpectrumReDrawSpectrumDisplay();
+
+
+// Spectrum scope operational constants
+//
+#define	SPECTRUM_SCOPE_TOP_LIMIT			5	// Top limit of spectrum scope magnitude
+//
+#define SPECTRUM_SCOPE_AGC_THRESHOLD		2000//400	// AGC "Knee" above which output from spectrum scope FFT  AGC will cause action
+#define SPECTRUM_SCOPE_MAX_FFT_VAL			8192//16384 // Value above which input to spectrum scope FFT will cause AGC action
+#define SPECTRUM_SCOPE_MIN_GAIN				0.001//0.1	// Minimum gain for spectrum scope FFT AGC loop
+#define SPECTRUM_SCOPE_MAX_GAIN				140	// Maximum gain for spectrum scope FFT AGC loop
+#define	SPECTRUM_SCOPE_AGC_ATTACK			0.5//0.1	// Attack rate for spectrum scope FFT AGC/gain
+#define	SPECTRUM_SCOPE_AGC_DECAY			0.166//0.1	// Decay rate for spectrum scope FFT AGC/gain
+//
+#define	SPECTRUM_SCOPE_LPF_FACTOR			4	// IIR Factor for spectrum scope low-pass filtering
+	// Higher = slower response.  3 = 33% input; 66% feedback, 4 = 25% input, 75% feedback, 5 = 20% input, 80% feedback
+#define	SPECTRUM_SCOPE_LPF_FACTOR_SPI		2	// IIR Factor for spectrum scope low-pass filtering using SPI display (update rate is slower, use faster filter)
+//
+#define PK_AVG_RESCALE_THRESH		3		// This sets the minimum peak-to-average ratio of the spectrum display before it starts to rescale the peak
+		// value from the top.  This prevents it from going completely "white" on noise/no-signal conditions.
+//
+#define	SPECTRUM_SCOPE_RESCALE_ATTACK_RATE	0.1	// Rate at which scaling of spectrum scope adapts to strong signals within its passband
+#define	SPECTRUM_SCOPE_RESCALE_DECAY_RATE	0.033	// Rate at which scaling of spectrum scope decays after strong signals disappear from its passband
+//
+#define SPECTRUM_SCOPE_SPEED_MIN			1	// minimum spectrum scope speed
+#define SPECTRUM_SCOPE_SPEED_MAX			25	// maximum spectrum scope speed
+#define SPECTRUM_SCOPE_SPEED_DEFAULT		5
+//
+#define SPECTRUM_SCOPE_FILTER_MIN			1	// minimum filter setting
+#define	SPECTRUM_SCOPE_FILTER_MAX			10	// maximum filter setting
+#define SPECTRUM_SCOPE_FILTER_DEFAULT		4	// default filter setting
+//
+#define	SPECTRUM_SCOPE_AGC_MIN				1	// minimum spectrum scope AGC rate setting
+#define	SPECTRUM_SCOPE_AGC_MAX				50	// maximum spectrum scope AGC rate setting
+#define	SPECTRUM_SCOPE_AGC_DEFAULT			25	// default spectrum scope AGC rate setting
+//
+#define SPECTRUM_SCOPE_NOSIG_ADJUST_MIN		10
+#define SPECTRUM_SCOPE_NOSIG_ADJUST_MAX		30
+#define	SPECTRUM_SCOPE_NOSIG_ADJUST_DEFAULT		20
+//
+#define	SPECTRUM_SCOPE_ADJUST_OFFSET	100
+//
+//
+#define	SPECTRUM_AGC_SCALING				25	// scaling factor by which the on-screen Spec. AGC Adj. is divided for adjustment.
+//
+#define	SCOPE_PREAMP_GAIN					1000//200	// amount of "amplification" in front of the FFT used for the Spectrum Scope and Waterfall used to overcome mathematical "noise floor"
+//
+#define INIT_SPEC_AGC_LEVEL					-80	// Initial offset for AGC level for spectrum/waterfall display
+//
+#define SPECTRUM_SCOPE_SPI_HOLDOFF_TIME_TUNE	25	// time, in 100's of second to inhibit spectrum scope update after adjusting tuning while in SPI mode
+//
+#define	NUMBER_WATERFALL_COLOURS			64		// number of colors in the waterfall table
+
+// ----------------------------------------------------------
+// Spectrum draw params
+//
+// Spectrum display
+#define POS_SPECTRUM_IND_X					60
+#define POS_SPECTRUM_IND_Y					150
+#define POS_SPECTRUM_IND_H					80
+#define	POS_SPECTRUM_FREQ_BAR_Y				64	// reducing value moves upwards
+#define	POS_SPECTRUM_FILTER_WIDTH_BAR_Y		61
+#define POS_SPECTRUM_IND_W					258
+#define COL_SPECTRUM_GRAD					0x40
+
+#define	WFALL_MEDIUM_ADDITIONAL	12					// additional vertical height in pixels of "medium" waterfall
+
+// WARNING:  Because the waterfall uses a "block write" which is, in effect, a "blind" writing of data to the LCD, the size of the graphic
+// block *MUST* exactly match the number of pixels within that block.
+//
+// Furthermore, the "SPECTRUM WIDTH" must match exactly with graphical width of the "X" size of each line to be written or skewing will result!
+//
+#define SPECTRUM_START_X		POS_SPECTRUM_IND_X
+//
+// Shift of whole spectrum in vertical direction
+#define SPECTRUM_START_Y		(POS_SPECTRUM_IND_Y - 10)
+//
+// Spectrum hight is bit lower that the whole control
+#define SPECTRUM_HEIGHT			(POS_SPECTRUM_IND_H - 10)
+//
+// Dependent on FFT samples,but should be less than control width!
+#define SPECTRUM_WIDTH			256
+
+
+
 #endif

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -21,12 +21,12 @@
 #include "codec.h"
 #include "ui_menu.h"
 #include "mchf_hw_i2c2.h"
-#include "waterfall_colours.h"
 //
 //
 #include "ui.h"
 // LCD
 #include "ui_lcd_hy28.h"
+#include "ui_spectrum.h"
 
 // serial EEPROM driver
 #include "mchf_hw_i2c2.h"
@@ -138,12 +138,7 @@ static void 	UiDriverChangeDSPMode(void);
 static void 	UiDriverChangeDigitalMode(void);
 static void 	UiDriverChangePowerLevel(void);
 //static void 	UiDrawSpectrumScopeFrequencyBarText(void);
-static void 	UiDriverFFTWindowFunction(char mode);
-static void 	UiInitSpectrumScopeWaterfall();			// init spectrum scope FFT variables, clear screen, start up all-in-one
-static void 	UiDriverInitSpectrumDisplay(void);
 //static void 	UiDriverClearSpectrumDisplay(void);
-static void 	UiDriverReDrawSpectrumDisplay(void);
-static void 	UiDriverReDrawWaterfallDisplay(void);
 // static ulong 	UiDriverGetScopeTraceColour(void);
 //static void 	UiDriverUpdateEthernetStatus(void);
 //static void 	UiDriverUpdateUsbKeyboardStatus(void);
@@ -508,9 +503,9 @@ void ui_driver_thread(void)
 //char txt[32];
 
 if(ts.misc_flags1 & 128)	// is waterfall mode enabled?
-		UiDriverReDrawWaterfallDisplay();	// yes - call waterfall update instead
+		UiSpectrumReDrawWaterfall();	// yes - call waterfall update instead
 	else
-		UiDriverReDrawSpectrumDisplay();	// Spectrum Display enabled - do that!
+		UiSpectrumReDrawSpectrumDisplay();	// Spectrum Display enabled - do that!
 
 	if(ts.thread_timer)			// bail out if it is not time to do this task
 		return;
@@ -858,12 +853,12 @@ static void UiDriverProcessKeyboard(void)
 							if(ts.misc_flags1 & 128)
 							{		// is the waterfall mode active?
 								ts.misc_flags1 &=  0x7f;	// yes, turn it off
-								UiInitSpectrumScopeWaterfall();			// init spectrum scope
+								UiSpectrumInitWaterfallDisplay();			// init spectrum scope
 							}
 							else
 							{	// waterfall mode was turned off
 								ts.misc_flags1 |=  128;	// turn it on
-								UiInitSpectrumScopeWaterfall();			// init spectrum scope
+								UiSpectrumInitWaterfallDisplay();			// init spectrum scope
 							}
 							UiDriverDisplayFilterBW();	// Update on-screen indicator of filter bandwidth
 						}
@@ -871,7 +866,7 @@ static void UiDriverProcessKeyboard(void)
 						{
 							sd.magnify = !sd.magnify;
 							ts.menu_var_changed = 1;
-							UiInitSpectrumScopeWaterfall();			// init spectrum scope
+							UiSpectrumInitWaterfallDisplay();			// init spectrum scope
 						}
 						if(check_tp_coordinates(0x67,0x0d,0x0f,0x2d) && !ts.frequency_lock)	// wf/scope frequency dial
 						{
@@ -1155,7 +1150,7 @@ static void UiDriverProcessKeyboard(void)
 			case BUTTON_F1_PRESSED:	// Press-and-hold button F1:  Write settings to EEPROM
 				if(ts.txrx_mode == TRX_MODE_RX)	{				// only allow EEPROM write in receive mode
 					if(!ts.menu_mode)	{						// not in menu mode
-						UiDriverClearSpectrumDisplay();			// clear display under spectrum scope
+						UiSpectrumClearDisplay();			// clear display under spectrum scope
 						if(ts.ser_eeprom_in_use == 0xFF)
 							UiLcdHy28_PrintText(60,160,"Saving settings to virt. EEPROM",Cyan,Black,0);
 						if(ts.ser_eeprom_in_use == 0x00)
@@ -1164,7 +1159,7 @@ static void UiDriverProcessKeyboard(void)
 						for(temp = 0; temp < 6; temp++)			// delay so that it may be read
 							non_os_delay();
 						//
-						UiInitSpectrumScopeWaterfall();			// init spectrum scope
+						UiSpectrumInitWaterfallDisplay();			// init spectrum scope
 						ts.menu_mode = 0;
 					}
 					else	// If in menu mode, just save data, but don't clear screen area
@@ -1255,12 +1250,12 @@ static void UiDriverProcessKeyboard(void)
 						UiDriverUpdateFrequency(1,2);	// Update receive frequency
 						ts.refresh_freq_disp = 0;	// disable refresh all digits flag
 					}
-					UiDriverClearSpectrumDisplay();			// clear display under spectrum scope
+					UiSpectrumClearDisplay();			// clear display under spectrum scope
 					UiLcdHy28_PrintText(80,160,is_vfo_b()?"VFO B -> VFO A":"VFO A -> VFO B",Cyan,Black,1);
 					for(temp = 0; temp < 18; temp++)			// delay so that it may be read
 						non_os_delay();
 					//
-					UiInitSpectrumScopeWaterfall();			// init spectrum scope
+					UiSpectrumInitWaterfallDisplay();			// init spectrum scope
 				}
 				break;
 			case BUTTON_F5_PRESSED:			// Button F5 was pressed-and-held - Toggle TX Disable
@@ -1385,11 +1380,11 @@ static void UiDriverProcessKeyboard(void)
 					if(!ts.menu_mode)	{			// do not do this in menu mode!
 						if(ts.misc_flags1 & 128)	{		// is the waterfall mode active?
 							ts.misc_flags1 &=  0x7f;	// yes, turn it off
-							UiInitSpectrumScopeWaterfall();			// init spectrum scope
+							UiSpectrumInitWaterfallDisplay();			// init spectrum scope
 						}
 						else	{	// waterfall mode was turned off
 							ts.misc_flags1 |=  128;	// turn it on
-							UiInitSpectrumScopeWaterfall();			// init spectrum scope
+							UiSpectrumInitWaterfallDisplay();			// init spectrum scope
 						}
 						UiDriverDisplayFilterBW();	// Update on-screen indicator of filter bandwidth
 					}
@@ -1400,11 +1395,11 @@ static void UiDriverProcessKeyboard(void)
 					if(!ts.menu_mode)	{		// do not do this if in menu mode!
 						if(ts.misc_flags1 & 128)	{		// is the waterfall mode active?
 							ts.misc_flags1 &=  0x7f;	// yes, turn it off
-							UiInitSpectrumScopeWaterfall();			// init spectrum scope
+							UiSpectrumInitWaterfallDisplay();			// init spectrum scope
 						}
 						else	{	// waterfall mode was turned off
 							ts.misc_flags1 |=  128;	// turn it on
-							UiInitSpectrumScopeWaterfall();			// init spectrum scope
+							UiSpectrumInitWaterfallDisplay();			// init spectrum scope
 						}
 						UiDriverDisplayFilterBW();	// Update on-screen indicator of filter bandwidth
 					}
@@ -1682,7 +1677,7 @@ static void UiDriverProcessFunctionKeyClick(ulong id)
 			if((!ts.menu_mode) && (!ts.boot_halt_flag))	{	// go into menu mode if NOT already in menu mode and not to halt on startup
 				ts.menu_mode = 1;
 				is_last_menu_item = 0;	// clear last screen detect flag
-				UiDriverClearSpectrumDisplay();
+				UiSpectrumClearDisplay();
                 UiDriverFButtonLabel(1," EXIT  ", Yellow);
                 UiDriverFButtonLabel(2," DEFLT",Yellow);
                 UiDriverFButtonLabel(3,"  PREV",Yellow);
@@ -1716,7 +1711,7 @@ static void UiDriverProcessFunctionKeyClick(ulong id)
 			}
 			else	{	// already in menu mode - we now exit
 				ts.menu_mode = 0;
-				UiInitSpectrumScopeWaterfall();			// init spectrum scope
+				UiSpectrumInitWaterfallDisplay();			// init spectrum scope
 				//
 				// Restore encoder displays to previous modes
 				UiDriverChangeEncoderOneMode(0);
@@ -1846,13 +1841,13 @@ static void UiDriverProcessFunctionKeyClick(ulong id)
 				}
 			}
 			else	{		// in memory mode
-				UiDriverClearSpectrumDisplay();		// always clear displayclear display
+				UiSpectrumClearDisplay();		// always clear displayclear display
 				if(!ts.mem_disp)	{	// are we NOT in memory display mode at this moment?
 					ts.mem_disp = 1;	// we are not - turn it on
 				}
 				else	{				// we are in memory display mode
 					ts.mem_disp = 0;	// turn it off
-					UiInitSpectrumScopeWaterfall();			// init spectrum scope
+					UiSpectrumInitWaterfallDisplay();			// init spectrum scope
 				}
 			}
 		}
@@ -2406,7 +2401,7 @@ static void UiDriverCreateDesktop(void)
 	UiDriverCreateSMeter();
 
 	// Spectrum scope
-	UiInitSpectrumScopeWaterfall();
+	UiSpectrumInitWaterfallDisplay();
 //	UiDriverCreateSpectrumScope();
 //	UiDriverInitSpectrumDisplay();
 
@@ -2967,214 +2962,6 @@ void UiDrawSpectrumScopeFrequencyBarText(void)
 
 }
 
-//
-//*----------------------------------------------------------------------------
-//* Function Name       : UiDriverCreateSpectrumScope
-//* Object              : draw the spectrum scope control
-//* Input Parameters    :
-//* Output Parameters   :
-//* Functions called    :
-//*----------------------------------------------------------------------------
-void UiDriverCreateSpectrumScope(void)
-{
-	ulong i;
-	uint32_t clr;
-	char s[32];
-	ulong slen;
-
-	//
-	// get grid colour of all but center line
-	//
-	UiDriverMenuMapColors(ts.scope_grid_colour,NULL, &ts.scope_grid_colour_active);
-	if(ts.scope_grid_colour == SPEC_GREY) {
-		ts.scope_grid_colour_active = Grid;
-	} else {
-		UiDriverMenuMapColors(ts.scope_grid_colour,NULL, &ts.scope_grid_colour_active);
-	}
-	//
-	//
-	// Get color of center vertical line of spectrum scope
-	//
-	if(ts.scope_centre_grid_colour == SPEC_GREY) {
-		ts.scope_centre_grid_colour_active = Grid;
-	} else {
-		UiDriverMenuMapColors(ts.scope_centre_grid_colour,NULL, &ts.scope_centre_grid_colour_active);
-	}
-
-	// Clear screen where frequency information will be under graticule
-	//
-	UiLcdHy28_PrintText(POS_SPECTRUM_IND_X - 2, POS_SPECTRUM_IND_Y + 60, "                                 ", Black, Black, 0);
-
-	//
-	strcpy(s, "SPECTRUM SCOPE ");
-	slen = 0;	// init string length variable
-	//
-	switch(ts.spectrum_db_scale)	{	// convert variable to setting
-		case DB_DIV_5:
-			strcat(s, "(5dB/div)");
-			slen = 30;	// fine-tune horizontal position (not sure why this is needed - look at this later)
-			break;
-		case DB_DIV_7:
-			strcat(s, "(7.5dB/div)");
-			slen = 24;	// fine-tune horizontal position (not sure why this is needed - look at this later)
-			break;
-		case DB_DIV_15:
-			strcat(s, "(15dB/div)");
-			slen = 28;	// fine-tune horizontal position (not sure why this is needed - look at this later)
-			break;
-		case DB_DIV_20:
-			strcat(s, "(20dB/div)");
-			slen = 28;	// fine-tune horizontal position (not sure why this is needed - look at this later)
-			break;
-		case S_1_DIV:
-			strcat(s, "(1S-Unit/div)");
-			break;
-		case S_2_DIV:
-			strcat(s, "(2S-Unit/div)");
-			break;
-		case S_3_DIV:
-			strcat(s, "(3S-Unit/div)");
-			break;
-		case DB_DIV_10:
-		default:
-			strcat(s, "(10dB/div)");
-			slen = 28;	// fine-tune horizontal position (not sure why this is needed - look at this later)
-			break;
-	}
-	//
-	slen += strlen(s);				// get width of entire banner string
-	slen /= 2;						// scale it for half the width of the string
-
-	// Draw top band
-	for(i = 0; i < 16; i++)
-		UiLcdHy28_DrawHorizLineWithGrad(POS_SPECTRUM_IND_X,(POS_SPECTRUM_IND_Y - 20 + i),POS_SPECTRUM_IND_W,COL_SPECTRUM_GRAD);
-
-	if(!(ts.misc_flags1 & 128))	{	// Display Spectrum Scope banner if enabled
-
-	// Top band text - middle caption
-	UiLcdHy28_PrintText(			(POS_SPECTRUM_IND_X + slen),
-									(POS_SPECTRUM_IND_Y - 18),
-									s,
-									Grey,
-									RGB((COL_SPECTRUM_GRAD*2),(COL_SPECTRUM_GRAD*2),(COL_SPECTRUM_GRAD*2)),0);
-	}
-	else	{			// Waterfall Mode banner if that is enabled
-
-		// Top band text - middle caption
-		UiLcdHy28_PrintText(			(POS_SPECTRUM_IND_X + 68),
-										(POS_SPECTRUM_IND_Y - 18),
-										"WATERFALL DISPLAY",
-										Grey,
-										RGB((COL_SPECTRUM_GRAD*2),(COL_SPECTRUM_GRAD*2),(COL_SPECTRUM_GRAD*2)),0);
-	}
-	// Top band text - grid size
-	//UiLcdHy28_PrintText(			(POS_SPECTRUM_IND_X +  2),
-	//								(POS_SPECTRUM_IND_Y - 18),
-	//								"Grid 6k",
-	//								Grey,
-	//								RGB((COL_SPECTRUM_GRAD),(COL_SPECTRUM_GRAD),(COL_SPECTRUM_GRAD)),4);
-
-	// Draw control left and right border
-	for(i = 0; i < 2; i++)
-	{
-		UiLcdHy28_DrawStraightLine(	(POS_SPECTRUM_IND_X - 2 + i),
-									(POS_SPECTRUM_IND_Y - 20),
-									(POS_SPECTRUM_IND_H + 12),
-									LCD_DIR_VERTICAL,
-//									RGB(COL_SPECTRUM_GRAD,COL_SPECTRUM_GRAD,COL_SPECTRUM_GRAD));
-									ts.scope_grid_colour_active);
-
-		UiLcdHy28_DrawStraightLine(	(POS_SPECTRUM_IND_X + POS_SPECTRUM_IND_W - 2 + i),
-									(POS_SPECTRUM_IND_Y - 20),
-									(POS_SPECTRUM_IND_H + 12),
-									LCD_DIR_VERTICAL,
-//									RGB(COL_SPECTRUM_GRAD,COL_SPECTRUM_GRAD,COL_SPECTRUM_GRAD));
-									ts.scope_grid_colour_active);
-	}
-
-	// Frequency bar separator
-	UiLcdHy28_DrawHorizLineWithGrad(POS_SPECTRUM_IND_X,(POS_SPECTRUM_IND_Y + POS_SPECTRUM_IND_H - 20),POS_SPECTRUM_IND_W,COL_SPECTRUM_GRAD);
-
-	// Draw Frequency bar text
-	UiDrawSpectrumScopeFrequencyBarText();
-
-
-	// Horizontal grid lines
-	for(i = 1; i < 4; i++)
-	{
-		// Save y position for repaint
-		sd.horz_grid_id[i - 1] = (POS_SPECTRUM_IND_Y - 5 + i*16);
-
-		// Draw
-		UiLcdHy28_DrawStraightLine(	POS_SPECTRUM_IND_X,
-									sd.horz_grid_id[i - 1],
-									POS_SPECTRUM_IND_W,
-									LCD_DIR_HORIZONTAL,
-//									RGB((COL_SPECTRUM_GRAD),(COL_SPECTRUM_GRAD),(COL_SPECTRUM_GRAD)));
-									ts.scope_grid_colour_active);
-		//printf("vy: %d\n\r",sd.horz_grid_id[i - 1]);
-	}
-
-	// Vertical grid lines
-	for(i = 1; i < 8; i++)		{
-
-		// determine if we are drawing the "center" line on the spectrum  display
-		if(!sd.magnify)	{
-			if((ts.iq_freq_mode == FREQ_IQ_CONV_M6KHZ) && (i == 5))			// is it frequency translate RF LOW mode?  If so, shift right of center
-				clr = ts.scope_centre_grid_colour_active;
-			else if((ts.iq_freq_mode == FREQ_IQ_CONV_P6KHZ) && (i == 3))		// shift left of center if RF HIGH translate mode
-				clr = ts.scope_centre_grid_colour_active;
-			else if((ts.iq_freq_mode == FREQ_IQ_CONV_P12KHZ) && (i == 2))		// shift left of center if RF HIGH translate mode
-				clr = ts.scope_centre_grid_colour_active;
-			else if((ts.iq_freq_mode == FREQ_IQ_CONV_M12KHZ) && (i == 6))		// shift right of center if RF HIGH translate mode
-				clr = ts.scope_centre_grid_colour_active;
-			else if ((ts.iq_freq_mode == FREQ_IQ_CONV_MODE_OFF) && (i == 4))	// center if translate mode not active
-				clr = ts.scope_centre_grid_colour_active;
-	        else
-	     	   clr = ts.scope_grid_colour_active;								// normal color if other lines
-		}
-		else if(i == 4)
-			clr = ts.scope_centre_grid_colour_active;
-        else
-        
-     	   clr = ts.scope_grid_colour_active;								// normal color if other lines
-
-		// Save x position for repaint
-		sd.vert_grid_id[i - 1] = (POS_SPECTRUM_IND_X + 32*i + 1);
-
-		// Draw
-		UiLcdHy28_DrawStraightLine(	sd.vert_grid_id[i - 1],
-									(POS_SPECTRUM_IND_Y -  4),
-									(POS_SPECTRUM_IND_H - 15),
-									LCD_DIR_VERTICAL,
-//									RGB((COL_SPECTRUM_GRAD),(COL_SPECTRUM_GRAD),(COL_SPECTRUM_GRAD)));
-									clr);
-
-		//printf("vx: %d\n\r",sd.vert_grid_id[i - 1]);
-	}
-
-	if (((ts.misc_flags1 & 128) && (!ts.waterfall_speed)) || (!(ts.misc_flags1 & 128) && (!ts.scope_speed)))	{
-			// print "disabled" in the middle of the screen if the waterfall or scope was disabled
-			UiLcdHy28_PrintText(			(POS_SPECTRUM_IND_X + 72),
-												(POS_SPECTRUM_IND_Y + 18),
-												"   DISABLED   ",
-												Grey,
-												RGB((COL_SPECTRUM_GRAD*2),(COL_SPECTRUM_GRAD*2),(COL_SPECTRUM_GRAD*2)),0);
-	}
-}
-
-//
-//*----------------------------------------------------------------------------
-//* Function Name       : UiDriverClearSpectrumDisplay
-//* Object              : Clears the spectrum display
-//* Input Parameters    :
-//* Output Parameters   :
-//* Functions called    :
-//*----------------------------------------------------------------------------
-void UiDriverClearSpectrumDisplay(void)
-{
-	UiLcdHy28_DrawFullRect(POS_SPECTRUM_IND_X - 2, (POS_SPECTRUM_IND_Y - 22), 94, 264, Black);	// Clear screen under spectrum scope by drawing a single, black block (faster with SPI!)
-}
 //
 //*----------------------------------------------------------------------------
 //* Function Name       : UiDriverCreateDigiPanel
@@ -4023,7 +3810,7 @@ static void UiDriverTimeScheduler(void)
 			ts.version_number_build = TRX4M_VER_BUILD;	// save new F/W version
 			ts.version_number_release = TRX4M_VER_RELEASE;
 			ts.version_number_minor = TRX4M_VER_MINOR;
-			UiDriverClearSpectrumDisplay();			// clear display under spectrum scope
+			UiSpectrumClearDisplay();			// clear display under spectrum scope
 			UiLcdHy28_PrintText(110,156,"- New F/W detected -",Cyan,Black,0);
 			UiLcdHy28_PrintText(110,168," Preparing EEPROM ",Cyan,Black,0);
 			UiDriverSaveEepromValuesPowerDown();	// rewrite EEPROM values
@@ -4036,7 +3823,7 @@ static void UiDriverTimeScheduler(void)
 			for(i = 0; i < 6; i++)			// delay so that it may be read
 				non_os_delay();
 			//
-			UiInitSpectrumScopeWaterfall();			// init spectrum scope
+			UiSpectrumInitWaterfallDisplay();			// init spectrum scope
 		}
 		//
 		ts.dsp_inhibit = 0;					// allow DSP to function
@@ -5806,971 +5593,6 @@ void UiDriverDisplayFilterBW(void)
 //* Output Parameters   : array "sd.FFT_Windat" - processed output to RFFT
 //* Functions called    : none
 //*----------------------------------------------------------------------------
-static void UiDriverFFTWindowFunction(char mode)
-{
-	ulong i;
-
-	// Information on these windowing functions may be found on the internet - check the Wikipedia article "Window Function"
-	// KA7OEI - 20150602
-
-	switch(mode)	{
-		case FFT_WINDOW_RECTANGULAR:	// No processing at all - copy from "Samples" buffer to "Windat" buffer
-			arm_copy_f32((float32_t *)sd.FFT_Samples, (float32_t *)sd.FFT_Windat,FFT_IQ_BUFF_LEN);	// use FFT data as-is
-			break;
-		case FFT_WINDOW_COSINE:			// Sine window function (a.k.a. "Cosine Window").  Kind of wide...
-			for(i = 0; i < FFT_IQ_BUFF_LEN; i++){
-				sd.FFT_Windat[i] = arm_sin_f32((PI * (float32_t)i)/FFT_IQ_BUFF_LEN - 1) * sd.FFT_Samples[i];
-			}
-			break;
-		case FFT_WINDOW_BARTLETT:		// a.k.a. "Triangular" window - Bartlett (or Fej?r) window is special case where demonimator is "N-1". Somewhat better-behaved than Rectangular
-			for(i = 0; i < FFT_IQ_BUFF_LEN; i++){
-				sd.FFT_Windat[i] = (1 - fabs(i - ((float32_t)FFT_IQ_BUFF_M1_HALF))/(float32_t)FFT_IQ_BUFF_M1_HALF) * sd.FFT_Samples[i];
-			}
-			break;
-		case FFT_WINDOW_WELCH:			// Parabolic window function, fairly wide, comparable to Bartlett
-			for(i = 0; i < FFT_IQ_BUFF_LEN; i++){
-				sd.FFT_Windat[i] = (1 - ((i - ((float32_t)FFT_IQ_BUFF_M1_HALF))/(float32_t)FFT_IQ_BUFF_M1_HALF)*((i - ((float32_t)FFT_IQ_BUFF_M1_HALF))/(float32_t)FFT_IQ_BUFF_M1_HALF)) * sd.FFT_Samples[i];
-			}
-			break;
-		case FFT_WINDOW_HANN:			// Raised Cosine Window (non zero-phase version) - This has the best sidelobe rejection of what is here, but not as narrow as Hamming.
-			for(i = 0; i < FFT_IQ_BUFF_LEN; i++){
-			    sd.FFT_Windat[i] = 0.5 * (float32_t)((1 - (arm_cos_f32(PI*2 * (float32_t)i / (float32_t)(FFT_IQ_BUFF_LEN-1)))) * sd.FFT_Samples[i]);
-			}
-			break;
-		case FFT_WINDOW_HAMMING:		// Another Raised Cosine window - This is the narrowest with reasonably good sidelobe rejection.
-			for(i = 0; i < FFT_IQ_BUFF_LEN; i++){
-			    sd.FFT_Windat[i] = (float32_t)((0.53836 - (0.46164 * arm_cos_f32(PI*2 * (float32_t)i / (float32_t)(FFT_IQ_BUFF_LEN-1)))) * sd.FFT_Samples[i]);
-			}
-			break;
-		case FFT_WINDOW_BLACKMAN:		// Approx. same "narrowness" as Hamming but not as good sidelobe rejection - probably best for "default" use.
-			for(i = 0; i < FFT_IQ_BUFF_LEN; i++){
-			    sd.FFT_Windat[i] = (0.42659 - (0.49656*arm_cos_f32((2*PI*(float32_t)i)/(float32_t)FFT_IQ_BUFF_LEN-1)) + (0.076849*arm_cos_f32((4*PI*(float32_t)i)/(float32_t)FFT_IQ_BUFF_LEN-1))) * sd.FFT_Samples[i];
-			}
-			break;
-		case FFT_WINDOW_NUTTALL:		// Slightly wider than Blackman, comparable sidelobe rejection.
-			for(i = 0; i < FFT_IQ_BUFF_LEN; i++){
-			    sd.FFT_Windat[i] = (0.355768 - (0.487396*arm_cos_f32((2*PI*(float32_t)i)/(float32_t)FFT_IQ_BUFF_LEN-1)) + (0.144232*arm_cos_f32((4*PI*(float32_t)i)/(float32_t)FFT_IQ_BUFF_LEN-1)) - (0.012604*arm_cos_f32((6*PI*(float32_t)i)/(float32_t)FFT_IQ_BUFF_LEN-1))) * sd.FFT_Samples[i];
-			}
-			break;
-	}
-	//
-	// used for debugging
-//		char txt[32];
-//		sprintf(txt, " %d    ", (int)(c1));
-//		UiLcdHy28_PrintText    ((POS_RIT_IND_X + 1), (POS_RIT_IND_Y + 20),txt,White,Grid,0);
-}
-//
-//
-//
-//
-
-static inline const uint32_t FftIdx2BufMap(const uint32_t idx) {
-return (FFT_IQ_BUFF_LEN/4 + idx)%(FFT_IQ_BUFF_LEN/2);
-}
-
-//*----------------------------------------------------------------------------
-//* Function Name       : UiDriverInitSpectrumDisplay - for both "Spectrum Display" and "Waterfall" Display
-//* Object              : FFT init
-//* Input Parameters    :
-//* Output Parameters   :
-//* Functions called    :
-//*----------------------------------------------------------------------------
-static void UiDriverInitSpectrumDisplay(void)
-{
-	ulong i;
-	arm_status	a;
-
-	// Init publics
-	sd.state 		= 0;
-	sd.samp_ptr 	= 0;
-	sd.skip_process = 0;
-	sd.enabled		= 0;
-	sd.dial_moved	= 0;
-	//
-	sd.rescale_rate = (float)ts.scope_rescale_rate;	// load rescale rate
-	sd.rescale_rate = 1/sd.rescale_rate;				// actual rate is inverse of this setting
-	//
-	sd.agc_rate = (float)ts.scope_agc_rate;	// calculate agc rate
-	sd.agc_rate = sd.agc_rate/SPECTRUM_AGC_SCALING;
-	//
-	sd.mag_calc = 1;				// initial setting of spectrum display scaling factor
-	//
-	sd.wfall_line_update = 0;		// init count used for incrementing number of lines for each vertical waterfall screen update
-	//
-	// load buffer containing waterfall colours
-	//
-	for(i = 0; i < NUMBER_WATERFALL_COLOURS; i++)	{
-		switch(ts.waterfall_color_scheme)	{
-			case WFALL_HOT_COLD:
-				sd.waterfall_colours[i] = waterfall_cold_hot[i];
-				break;
-			case WFALL_RAINBOW:
-				sd.waterfall_colours[i] = waterfall_rainbow[i];
-				break;
-			case WFALL_BLUE:
-				sd.waterfall_colours[i] = waterfall_blue[i];
-				break;
-			case WFALL_GRAY_INVERSE:
-				sd.waterfall_colours[i] = waterfall_grey_inverse[i];
-				break;
-			case WFALL_GRAY:
-			default:
-				sd.waterfall_colours[i] = waterfall_grey[i];
-				break;
-		}
-	}
-	//
-	//
-	// Load "top" color of palette (the 65th) with that to be used for the center grid color
-	//
-	sd.waterfall_colours[NUMBER_WATERFALL_COLOURS] = (ushort)ts.scope_centre_grid_colour_active;
-	//
-	//
-/*
-	//
-	// Load waterfall data with "splash" showing palette
-	//
-	j = 0;					// init count of lines on display
-	k = sd.wfall_line;		// start with line currently displayed in buffer
-	while(j < SPECTRUM_HEIGHT)	{		// loop number of times of buffer
-		for(i = 0; i < FFT_IQ_BUFF_LEN/2; i++)	{		// do this all of the way across, horizonally
-			sd.waterfall[k][i] = (SPECTRUM_HEIGHT - j) % SPECTRUM_HEIGHT;	// place the color of the palette, indexed to vertical position
-		}
-		j++;		// update line count
-		k++;		// update position within circular buffer - which also is used to calculate color
-		k %= SPECTRUM_HEIGHT;	// limit to modulus count of circular buffer size
-	}
-	//
-*/
-	//
-	switch(ts.spectrum_db_scale)	{
-	case	DB_DIV_5:
-		sd.db_scale = DB_SCALING_5;
-		break;
-	case	DB_DIV_7:
-		sd.db_scale = DB_SCALING_7;
-		break;
-	case	DB_DIV_15:
-		sd.db_scale = DB_SCALING_15;
-		break;
-	case	DB_DIV_20:
-		sd.db_scale = DB_SCALING_20;
-		break;
-	case S_1_DIV:
-		sd.db_scale = DB_SCALING_S1;
-		break;
-	case S_2_DIV:
-		sd.db_scale = DB_SCALING_S2;
-		break;
-	case S_3_DIV:
-		sd.db_scale = DB_SCALING_S3;
-		break;
-	case	DB_DIV_10:
-	default:
-		sd.db_scale = DB_SCALING_10;
-		break;
-	}
-	//
-	if(ts.waterfall_size == WATERFALL_NORMAL)	{						// waterfall the same size as spectrum scope
-		sd.wfall_height = SPECTRUM_HEIGHT - SPECTRUM_SCOPE_TOP_LIMIT;
-		sd.wfall_ystart = SPECTRUM_START_Y + SPECTRUM_SCOPE_TOP_LIMIT;
-		sd.wfall_size = SPECTRUM_HEIGHT - SPECTRUM_SCOPE_TOP_LIMIT;
-	}																	// waterfall larger, covering the word "Waterfall Display"
-	else if(ts.waterfall_size == WATERFALL_MEDIUM)	{
-		sd.wfall_height = SPECTRUM_HEIGHT + WFALL_MEDIUM_ADDITIONAL;
-		sd.wfall_ystart = SPECTRUM_START_Y - WFALL_MEDIUM_ADDITIONAL;
-		sd.wfall_size = SPECTRUM_HEIGHT + WFALL_MEDIUM_ADDITIONAL;
-	}
-	//
-	//
-	sd.wfall_contrast = (float)ts.waterfall_contrast;		// calculate scaling for contrast
-	sd.wfall_contrast /= 100;
-
-	// Init FFT structures
-	a = arm_rfft_init_f32((arm_rfft_instance_f32 *)&sd.S,(arm_cfft_radix4_instance_f32 *)&sd.S_CFFT,FFT_IQ_BUFF_LEN,FFT_QUADRATURE_PROC,1);
-
-	if(a != ARM_MATH_SUCCESS)
-	{
-		printf("fft init err: %d\n\r",a);
-		return;
-	}
-
-	// Ready
-	sd.enabled		= 1;
-	sd.first_run 	= 2;
-}
-
-//
-//*----------------------------------------------------------------------------
-//* Function Name       : UiDriverReDrawSpectrumDisplay
-//* Object              : state machine implementation
-//* Input Parameters    :
-//* Output Parameters   :
-//* Functions called    :
-//*----------------------------------------------------------------------------
-//
-// Spectrum Display code rewritten by C. Turner, KA7OEI, September 2014, May 2015
-//
-static void UiDriverReDrawSpectrumDisplay(void)
-{
-	ulong i, spec_width;
-	uint32_t	max_ptr;	// throw-away pointer for ARM maxval and minval functions
-	float32_t	gcalc;
-	//
-
-	// Only in RX mode and NOT while powering down or in menu mode or if displaying memory information
-	if((ts.txrx_mode != TRX_MODE_RX) || (ts.powering_down) || (ts.menu_mode) || (ts.mem_disp) || (ts.boot_halt_flag))
-		return;
-
-	if((ts.spectrum_scope_scheduler) || (!ts.scope_speed))	// is it time to update the scan, or is this scope to be disabled?
-		return;
-	else
-		ts.spectrum_scope_scheduler = (ts.scope_speed-1)*2;
-
-	// No spectrum display in DIGI modes
-	//if(ts.dmod_mode == DEMOD_DIGI)
-	//	return;
-
-	// Nothing to do here otherwise, or if scope is to be held off while other parts of the display are to be updated or the LCD is being blanked
-	if((!sd.enabled) || (ts.hold_off_spectrum_scope > ts.sysclock) || (ts.lcd_blanking_flag))
-		return;
-
-	// The state machine will rest
-	// in between states
-//	sd.skip_process++;
-//	if(sd.skip_process < 1000)
-//		return;
-
-//	sd.skip_process = 0;
-
-	gcalc = 1/ads.codec_gain_calc;				// Get gain setting of codec and convert to multiplier factor
-
-	// Process implemented as state machine
-	switch(sd.state)
-	{
-		//
-		// Apply gain to collected IQ samples and then do FFT
-		//
-
-		case 1:
-		{
-			arm_scale_f32((float32_t *)sd.FFT_Samples, (float32_t)(gcalc * SCOPE_PREAMP_GAIN), (float32_t *)sd.FFT_Samples, FFT_IQ_BUFF_LEN);	// scale input according to A/D gain
-			//
-			UiDriverFFTWindowFunction(ts.fft_window_type);		// do windowing function on input data to get less "Bin Leakage" on FFT data
-			//
-			arm_rfft_f32((arm_rfft_instance_f32 *)&sd.S,(float32_t *)(sd.FFT_Windat),(float32_t *)(sd.FFT_Samples));	// Do FFT
-			//
-		sd.state++;
-		break;
-		}
-		//
-		// Do magnitude processing and gain control (AGC) on input of FFT
-		//
-		case 2:
-		{
-			//
-			// Save old display data - we will use later to mask pixel on the control
-			//
-			arm_copy_q15((q15_t *)sd.FFT_DspData, (q15_t *)sd.FFT_BkpData, FFT_IQ_BUFF_LEN/2);
-			//
-			// Calculate magnitude
-			//
-			arm_cmplx_mag_f32((float32_t *)(sd.FFT_Samples),(float32_t *)(sd.FFT_MagData),(FFT_IQ_BUFF_LEN/2));
-			//
-		sd.state++;
-		break;
-		}
-		//
-		//  Low-pass filter amplitude magnitude data
-		//
-		case 3:
-		{
-			uint32_t i;
-			float32_t		filt_factor;
-			//
-			filt_factor = (float)ts.scope_filter;		// use stored filter setting
-			filt_factor = 1/filt_factor;		// invert filter factor to allow multiplication
-			//
-			if(sd.dial_moved)	{	// Clear filter data if dial was moved in steps greater than 1 kHz
-				sd.dial_moved = 0;	// Dial moved - reset indicator
-				if(df.tuning_step > 1000)	{	// was tuning step greater than 1kHz?
-					arm_copy_f32((float32_t *)sd.FFT_MagData, (float32_t *)sd.FFT_AVGData, FFT_IQ_BUFF_LEN/2);	// yes - copy current data into average buffer
-				}
-				//
-				UiDrawSpectrumScopeFrequencyBarText();	// redraw frequency bar on the bottom of the display
-				//
-			}
-			else	{	// dial was not moved - do normal IIR lowpass filtering to "smooth" display
-				arm_scale_f32((float32_t *)sd.FFT_AVGData, (float32_t)filt_factor, (float32_t *)sd.FFT_Samples, FFT_IQ_BUFF_LEN/2);	// get scaled version of previous data
-				arm_sub_f32((float32_t *)sd.FFT_AVGData, (float32_t *)sd.FFT_Samples, (float32_t *)sd.FFT_AVGData, FFT_IQ_BUFF_LEN/2);	// subtract scaled information from old, average data
-				arm_scale_f32((float32_t *)sd.FFT_MagData, (float32_t)filt_factor, (float32_t *)sd.FFT_Samples, FFT_IQ_BUFF_LEN/2);	// get scaled version of new, input data
-				arm_add_f32((float32_t *)sd.FFT_Samples, (float32_t *)sd.FFT_AVGData, (float32_t *)sd.FFT_AVGData, FFT_IQ_BUFF_LEN/2);	// add portion new, input data into average
-				//
-				for(i = 0; i < FFT_IQ_BUFF_LEN/2; i++)	{		//		// guarantee that the result will always be >= 0
-					if(sd.FFT_AVGData[i] < 1)
-						sd.FFT_AVGData[i] = 1;
-				}
-			}
-		sd.state++;
-		break;
-		}
-		//
-		// De-linearize and normalize display data and do AGC processing
-		//
-		case 4:
-		{
-			q15_t	max1, max2, max3, min1, min2, min3;
-			q15_t	mean1, mean2, mean3;
-			float32_t	sig;
-			//
-			// De-linearize data with dB/division
-			//
-			for(i = 0; i < (FFT_IQ_BUFF_LEN/2); i++)	{
-				sig = log10(sd.FFT_AVGData[i]) * sd.db_scale;		// take FFT data, do a log10 and multiply it to scale it to get desired dB/divistion
-				sig += sd.display_offset;							// apply "AGC", vertical "sliding" offset (or brightness for waterfall)
-				if(sig > 1)											// is the value greater than 1?
-					sd.FFT_DspData[i] = (q15_t)sig;					// it was a useful value - save it
-				else
-					sd.FFT_DspData[i] = 1;							// not greater than 1 - assign it to a base value of 1 for sanity's sake
-			}
-			//
-			arm_copy_q15((q15_t *)sd.FFT_DspData, (q15_t *)sd.FFT_TempData, FFT_IQ_BUFF_LEN/2);
-			//
-			// Find peak and average to vertically adjust display
-			//
-			if(sd.magnify)	{	// are we in magnify mode?  If so, find max/mean of only those portions of the spectrum magnified - which are NOT in the proper order, dammit!
-				//
-				if(!ts.iq_freq_mode)	{	// yes, are we NOT in translate mode?
-					arm_max_q15((q15_t *)&sd.FFT_TempData[192], 64, &max1, &max_ptr);		// find maximum element in center portion
-					arm_min_q15((q15_t *)&sd.FFT_TempData[192], 64, &min1, &max_ptr);		// find minimum element in center portion
-					arm_mean_q15((q15_t *)&sd.FFT_TempData[192], 64, &mean1);				// find mean value in center portion
-					//
-					arm_max_q15((q15_t *)sd.FFT_TempData, 64, &max2, &max_ptr);		// find maximum element in center portion
-					arm_min_q15((q15_t *)sd.FFT_TempData, 64, &min2, &max_ptr);		// find minimum element in center portion
-					arm_mean_q15((q15_t *)sd.FFT_TempData, 64, &mean2);				// find mean value in center portion
-					//
-					if(max2 > max1)
-						max1 = max2;
-					//
-					if(mean2 > mean1)
-						mean1 = mean2;
-					//
-					if(min2 < min1)
-						min1 = min2;
-				}
-				else if(ts.iq_freq_mode == FREQ_IQ_CONV_P6KHZ)	{	// we are in RF LO HIGH mode (tuning is below center of screen)
-					arm_max_q15((q15_t *)&sd.FFT_TempData[160], 64, &max1, &max_ptr);		// find maximum element in center portion
-					arm_min_q15((q15_t *)&sd.FFT_TempData[160], 64, &min1, &max_ptr);		// find minimum element in center portion
-					arm_mean_q15((q15_t *)&sd.FFT_TempData[160], 64, &mean1);				// find mean value in center portion
-					//
-					arm_max_q15((q15_t *)&sd.FFT_TempData[224], 32, &max2, &max_ptr);		// find maximum element in center portion
-					arm_min_q15((q15_t *)&sd.FFT_TempData[224], 32, &min2, &max_ptr);		// find minimum element in center portion
-					arm_mean_q15((q15_t *)&sd.FFT_TempData[224], 32, &mean2);				// find mean value in center portion
-					//
-					if(max2 > max1)
-						max1 = max2;
-					//
-					if(min2 < min1)
-						min1 = min2;
-					//
-					if(mean2 > mean1)
-						mean1 = mean2;
-					//
-					arm_max_q15((q15_t *)&sd.FFT_TempData[0], 32, &max3, &max_ptr);		// find maximum element in center portion
-					arm_min_q15((q15_t *)&sd.FFT_TempData[0], 32, &min3, &max_ptr);		// find minimum element in center portion
-					arm_mean_q15((q15_t *)&sd.FFT_TempData[0], 32, &mean3);				// find mean value in center portion
-					//
-					if(max3 > max1)
-						max1 = max3;
-					//
-					if(min3 < min1)
-						min1 = min3;
-					//
-					if(mean3 > mean1)
-						mean1 = mean3;
-				}
-				else if(ts.iq_freq_mode == FREQ_IQ_CONV_M6KHZ)	{	// we are in RF LO LOW mode (tuning is above center of screen)
-					arm_max_q15((q15_t *)&sd.FFT_TempData[224], 32, &max1, &max_ptr);		// find maximum element in center portion
-					arm_min_q15((q15_t *)&sd.FFT_TempData[224], 32, &min1, &max_ptr);		// find minimum element in center portion
-					arm_mean_q15((q15_t *)&sd.FFT_TempData[224], 32, &mean1);				// find mean value in center portion
-					//
-					arm_max_q15((q15_t *)&sd.FFT_TempData[0], 32, &max2, &max_ptr);		// find maximum element in center portion
-					arm_min_q15((q15_t *)&sd.FFT_TempData[0], 32, &min2, &max_ptr);		// find minimum element in center portion
-					arm_mean_q15((q15_t *)&sd.FFT_TempData[0], 32, &mean2);				// find mean value in center portion
-					//
-					if(max2 > max1)
-						max1 = max2;
-					//
-					if(min2 < min1)
-						min1 = min2;
-					//
-					if(mean2 > mean1)
-						mean1 = mean2;
-					//
-					arm_max_q15((q15_t *)&sd.FFT_TempData[32], 64, &max3, &max_ptr);		// find maximum element in center portion
-					arm_min_q15((q15_t *)&sd.FFT_TempData[32], 64, &min3, &max_ptr);		// find minimum element in center portion
-					arm_mean_q15((q15_t *)&sd.FFT_TempData[32], 64, &mean3);				// find mean value in center portion
-					//
-					if(max3 > max1)
-						max1 = max3;
-					//
-					if(min2 < min1)
-						min1 = min2;
-					//
-					if(mean3 > mean1)
-						mean1 = mean3;
-				}
-				else if(ts.iq_freq_mode == FREQ_IQ_CONV_P12KHZ)	{	// we are in RF LO HIGH mode (tuning is below center of screen)		// aaaaaaaaaaaaaaaaaaaaa
-					arm_max_q15((q15_t *)&sd.FFT_TempData[128], 64, &max1, &max_ptr);		// find maximum element in center portion
-					arm_min_q15((q15_t *)&sd.FFT_TempData[128], 64, &min1, &max_ptr);		// find minimum element in center portion
-					arm_mean_q15((q15_t *)&sd.FFT_TempData[128], 64, &mean1);				// find mean value in center portion
-					//
-					arm_max_q15((q15_t *)&sd.FFT_TempData[192], 32, &max2, &max_ptr);		// find maximum element in center portion
-					arm_min_q15((q15_t *)&sd.FFT_TempData[192], 32, &min2, &max_ptr);		// find minimum element in center portion
-					arm_mean_q15((q15_t *)&sd.FFT_TempData[192], 32, &mean2);				// find mean value in center portion
-					//
-					if(max2 > max1)
-						max1 = max2;
-					//
-					if(min2 < min1)
-						min1 = min2;
-					//
-					if(mean2 > mean1)
-						mean1 = mean2;
-					//
-					arm_max_q15((q15_t *)&sd.FFT_TempData[0], 32, &max3, &max_ptr);		// find maximum element in center portion
-					arm_min_q15((q15_t *)&sd.FFT_TempData[0], 32, &min3, &max_ptr);		// find minimum element in center portion
-					arm_mean_q15((q15_t *)&sd.FFT_TempData[0], 32, &mean3);				// find mean value in center portion
-					//
-					if(max3 > max1)
-						max1 = max3;
-					//
-					if(min3 < min1)
-						min1 = min3;
-					//
-					if(mean3 > mean1)
-						mean1 = mean3;
-				}
-				else if(ts.iq_freq_mode == FREQ_IQ_CONV_M12KHZ)	{	// we are in RF LO LOW mode (tuning is above center of screen)
-					arm_max_q15((q15_t *)&sd.FFT_TempData[0], 32, &max1, &max_ptr);		// find maximum element in center portion
-					arm_min_q15((q15_t *)&sd.FFT_TempData[0], 32, &min1, &max_ptr);		// find minimum element in center portion
-					arm_mean_q15((q15_t *)&sd.FFT_TempData[0], 32, &mean1);				// find mean value in center portion
-					//
-					arm_max_q15((q15_t *)&sd.FFT_TempData[32], 32, &max2, &max_ptr);		// find maximum element in center portion
-					arm_min_q15((q15_t *)&sd.FFT_TempData[32], 32, &min2, &max_ptr);		// find minimum element in center portion
-					arm_mean_q15((q15_t *)&sd.FFT_TempData[32], 32, &mean2);				// find mean value in center portion
-					//
-					if(max2 > max1)
-						max1 = max2;
-					//
-					if(min2 < min1)
-						min1 = min2;
-					//
-					if(mean2 > mean1)
-						mean1 = mean2;
-					//
-					arm_max_q15((q15_t *)&sd.FFT_TempData[64], 64, &max3, &max_ptr);		// find maximum element in center portion
-					arm_min_q15((q15_t *)&sd.FFT_TempData[64], 64, &min3, &max_ptr);		// find minimum element in center portion
-					arm_mean_q15((q15_t *)&sd.FFT_TempData[64], 64, &mean3);				// find mean value in center portion
-					//
-					if(max3 > max1)
-						max1 = max3;
-					//
-					if(min2 < min1)
-						min1 = min2;
-					//
-					if(mean3 > mean1)
-						mean1 = mean3;
-				}
-			}
-			else	{
-				spec_width = FFT_IQ_BUFF_LEN/2;
-				arm_max_q15((q15_t *)sd.FFT_TempData, spec_width, &max1, &max_ptr);		// find maximum element
-				arm_min_q15((q15_t *)sd.FFT_TempData, spec_width, &min1, &max_ptr);		// find minimum element
-				arm_mean_q15((q15_t *)sd.FFT_TempData, spec_width, &mean1);				// find mean value
-			}
-
-			//
-			// Vertically adjust spectrum scope so that the strongest signals are adjusted to the top
-			//
-			if(max1 > SPECTRUM_HEIGHT) {	// is result higher than display
-				sd.display_offset -= sd.agc_rate;	// yes, adjust downwards quickly
-//				if(max1 > SPECTRUM_HEIGHT+(SPECTRUM_HEIGHT/2))			// is it WAY above top of screen?
-//					sd.display_offset -= sd.agc_rate*3;	// yes, adjust downwards REALLY quickly
-			}
-			//
-			// Prevent "empty" spectrum display from filling with "noise" by checking the peak/average of what was found
-			//
-			else if(((max1*10/mean1) <= (q15_t)ts.spectrum_scope_nosig_adjust) && (max1 < SPECTRUM_HEIGHT+(SPECTRUM_HEIGHT/2)))	{	// was "average" signal ratio below set threshold and average is not insanely strong??
-				if((min1 > 2) && (max1 > 2))	{		// prevent the adjustment from going downwards, "into the weeds"
-					sd.display_offset -= sd.agc_rate;	// yes, adjust downwards
-		            if(sd.display_offset < (-(SPECTRUM_HEIGHT + SPECTRUM_SCOPE_ADJUST_OFFSET)))
-		               sd.display_offset = (-(SPECTRUM_HEIGHT + SPECTRUM_SCOPE_ADJUST_OFFSET));
-				}
-			}
-			else
-				sd.display_offset += (sd.agc_rate/3);	// no, adjust upwards more slowly
-			//
-			//
-			if((min1 <= 2) && (max1 <= 2))	{	// ARGH - We must already be in the weeds, below the bottom - let's adjust upwards quickly to get it back onto the display!
-				sd.display_offset += sd.agc_rate*10;
-			}
-			//
-			// used for debugging
-//				char txt[32];
-//				sprintf(txt, " %d,%d,%d,%d ", (int)(max1*100/mean1), (int)(min1), (int)(max1),(int)mean1);
-//				sprintf(txt, " %d,%d,%d,%d ", (int)sd.display_offset*100, (int)min1*100,(int)max1*100,(int)SPECTRUM_HEIGHT);
-//				UiLcdHy28_PrintText    ((POS_RIT_IND_X + 1), (POS_RIT_IND_Y + 20),txt,White,Grid,0);
-
-			//
-			//
-			ushort ptr;
-			//
-			// Now, re-arrange the spectrum for the various magnify modes so that they display properly!
-			//
-			// we can calculate any position in the spectrum by using the
-			// following thinking
-			// the spectrum is 256 entries wide == FFT_IQ_BUFF_LEN/2
-			// the begin of the spectrum (== -24khz) is in the middle of the buffer
-			// i.e. 0 == FFT_IQ_BUFF_LEN/2/2 == 128
-			// that means (FFT_IQ_BUFF_LEN/4 + idx)%FFT_IQ_BUFF_LEN/2 == (128+idx)%256
-			// gives us the index in the buffer.
-			// we use this  knowledge to simplify the magnification code
-			// compiler can heavily optimize this since we  all these values being power of 2 value
-			if(sd.magnify)	{	// is magnify mode on?
-				uint32_t end_range;
-				switch(ts.iq_freq_mode) {
-				break;
-				case FREQ_IQ_CONV_P6KHZ:	// frequency translate mode is in "RF LO HIGH" mode - tune below center of screen
-					ptr = FFT_IQ_BUFF_LEN/16 ; // FFT_IQ_BUFF_LEN/8 + FFT_IQ_BUFF_LEN/16  = -12khz + 6khz = -6khz <-> + 18khz
-					break;
-				case FREQ_IQ_CONV_M6KHZ: // frequency translate mode is in "RF LO HIGH" mode - tune below center of screen
-					ptr = 3* FFT_IQ_BUFF_LEN/16 ; // FFT_IQ_BUFF_LEN/8 - FFT_IQ_BUFF_LEN/16  = -12khz - 6khz = -18khz <-> + 6khz
-					break;
-				case FREQ_IQ_CONV_P12KHZ: // frequency translate mode is in "RF LO HIGH" mode - tune below center of screen
-					ptr = 0; // FFT_IQ_BUFF_LEN/8 + FFT_IQ_BUFF_LEN/8  = -12khz + 12khz = 0khz <-> + 24khz
-					break;
-				case FREQ_IQ_CONV_M12KHZ:	// frequency translate mode is in "RF LO HIGH" mode - tune below center of screen
-					ptr = FFT_IQ_BUFF_LEN/4 ; // FFT_IQ_BUFF_LEN/8 - FFT_IQ_BUFF_LEN/8  = -12khz - 12khz = -24khz <-> 0khz
-					break;
-				default:	// yes - frequency translate mode is off
-					ptr = FFT_IQ_BUFF_LEN/8; // FFT_IQ_BUFF_LEN/8  = -12khz = -12khz <-> + 12khz
-				}
-				end_range = ptr+FFT_IQ_BUFF_LEN/4; // exclusive
-				for(i=0; ptr < end_range; ptr++)	{	// expand data to fill entire screen - get lower half
-					sd.FFT_DspData[FftIdx2BufMap(i++)] = sd.FFT_TempData[FftIdx2BufMap(ptr)]; /* each entry from fft is used twice */
-					sd.FFT_DspData[FftIdx2BufMap(i++)] = sd.FFT_TempData[FftIdx2BufMap(ptr)]; /* each entry from fft is used twice */
-				}
-			}
-			else
-				arm_copy_q15((q15_t *)sd.FFT_DspData, (q15_t *)sd.FFT_TempData, FFT_IQ_BUFF_LEN/2);
-			//
-			// After the above manipulation, clip the result to make sure that it is within the range of the palette table
-			//
-			for(i = 0; i < FFT_IQ_BUFF_LEN/2; i++)	{
-				if(sd.FFT_DspData[i] >= SPECTRUM_HEIGHT)	// is there an illegal height value?
-					sd.FFT_DspData[i] = SPECTRUM_HEIGHT - 1;	// yes - clip it
-
-			}
-			//
-			//
-		sd.state++;
-		break;
-
-		}
-		//
-		//  update LCD control
-		//
-		case 5:
-		{
-		uint32_t	clr;
-		UiDriverMenuMapColors(ts.scope_trace_colour,NULL, &clr);
-        // Left part of screen(mask and update in one operation to minimize flicker)
-        UiLcdHy28_DrawSpectrum_Interleaved((q15_t *)(sd.FFT_BkpData + FFT_IQ_BUFF_LEN/4), (q15_t *)(sd.FFT_DspData + FFT_IQ_BUFF_LEN/4), Black, clr,0);
-        // Right part of the screen (mask and update) left part of screen is stored in the first quarter [0...127]
-        UiLcdHy28_DrawSpectrum_Interleaved((q15_t *)(sd.FFT_BkpData), (q15_t *)(sd.FFT_DspData), Black, clr,1);
-        sd.state = 0;   // Stage 0 - collection of data by the Audio driver
-		break;
-		}
-		default:
-			sd.state = 0;
-			break;
-	}
-}
-//
-//
-//*----------------------------------------------------------------------------
-//* Function Name       : UiDriverReDrawWaterfallDisplay
-//* Object              : state machine implementation
-//* Input Parameters    :
-//* Output Parameters   :
-//* Functions called    :
-//*----------------------------------------------------------------------------
-//
-// Waterfall Display code written by C. Turner, KA7OEI, May 2015 entirely from "scratch" - which is to say that I did not borrow any of it
-// from anywhere else, aside from keeping some of the general functions found in "Case 1".
-//
-static void UiDriverReDrawWaterfallDisplay(void)
-{
-	ulong i, spec_width;
-	uint32_t	max_ptr;	// throw-away pointer for ARM maxval AND minval functions
-	float32_t	gcalc;
-	//
-
-	// Only in RX mode and NOT while powering down or in menu mode or if displaying memory information
-	if((ts.txrx_mode != TRX_MODE_RX) || (ts.powering_down) || (ts.menu_mode) || (ts.mem_disp) || (ts.boot_halt_flag))
-		return;
-
-	if((ts.spectrum_scope_scheduler) || (!ts.waterfall_speed))	// is it time to update the scan, or is this scope to be disabled?
-		return;
-	else
-		ts.spectrum_scope_scheduler = (ts.waterfall_speed-1)*2;
-
-
-	// No spectrum display in DIGI modes
-	//if(ts.dmod_mode == DEMOD_DIGI)
-	//	return;
-
-	// Nothing to do here otherwise, or if scope is to be held off while other parts of the display are to be updated or the LCD is being blanked
-	if((!sd.enabled) || (ts.hold_off_spectrum_scope > ts.sysclock) || (ts.lcd_blanking_flag))
-		return;
-
-	// The state machine will rest
-	// in between states
-//	sd.skip_process++;
-//	if(sd.skip_process < 1000)
-//		return;
-
-//	sd.skip_process = 0;
-
-	gcalc = 1/ads.codec_gain_calc;				// Get gain setting of codec and convert to multiplier factor
-
-	// Process implemented as state machine
-	switch(sd.state)
-	{
-		//
-		// Apply gain to collected IQ samples and then do FFT
-		//
-		case 1:		// Scale input according to A/D gain and apply Window function
-		{
-			arm_scale_f32((float32_t *)sd.FFT_Samples, (float32_t)(gcalc * SCOPE_PREAMP_GAIN), (float32_t *)sd.FFT_Samples, FFT_IQ_BUFF_LEN);	// scale input according to A/D gain
-			//
-			UiDriverFFTWindowFunction(ts.fft_window_type);		// do windowing function on input data to get less "Bin Leakage" on FFT data
-			//
-		sd.state++;
-		break;
-		}
-		case 2:		// Do FFT and calculate complex magnitude
-		{
-			arm_rfft_f32((arm_rfft_instance_f32 *)&sd.S,(float32_t *)(sd.FFT_Windat),(float32_t *)(sd.FFT_Samples));	// Do FFT
-			//
-			// Calculate magnitude
-			//
-			arm_cmplx_mag_f32((float32_t *)(sd.FFT_Samples),(float32_t *)(sd.FFT_MagData),(FFT_IQ_BUFF_LEN/2));
-			//
-		sd.state++;
-		break;
-		}
-		//
-		//  Low-pass filter amplitude magnitude data
-		//
-		case 3:
-		{	uint32_t i;
-			float32_t		filt_factor;
-			//
-			filt_factor = (float)ts.scope_filter;		// use stored filter setting
-			filt_factor = 1/filt_factor;		// invert filter factor to allow multiplication
-			//
-			if(sd.dial_moved)	{	// Clear filter data if dial was moved in steps greater than 1 kHz
-				sd.dial_moved = 0;	// Dial moved - reset indicator
-				if(df.tuning_step > 1000)	{	// was tuning step greater than 1kHz
-					arm_copy_f32((float32_t *)sd.FFT_MagData,(float32_t *)sd.FFT_AVGData, FFT_IQ_BUFF_LEN/2);	// copy current data into average buffer
-				}
-				//
-				UiDrawSpectrumScopeFrequencyBarText();	// redraw frequency bar on the bottom of the display
-				//
-			}
-			else	{	// dial was not moved - do IIR lowpass filtering to "smooth" display
-				arm_scale_f32((float32_t *)sd.FFT_AVGData, (float32_t)filt_factor, (float32_t *)sd.FFT_Samples, FFT_IQ_BUFF_LEN/2);	// get scaled version of previous data
-				arm_sub_f32((float32_t *)sd.FFT_AVGData, (float32_t *)sd.FFT_Samples, (float32_t *)sd.FFT_AVGData, FFT_IQ_BUFF_LEN/2);	// subtract scaled information from old, average data
-				arm_scale_f32((float32_t *)sd.FFT_MagData, (float32_t)filt_factor, (float32_t *)sd.FFT_Samples, FFT_IQ_BUFF_LEN/2);	// get scaled version of new, input data
-				arm_add_f32((float32_t *)sd.FFT_Samples, (float32_t *)sd.FFT_AVGData, (float32_t *)sd.FFT_AVGData, FFT_IQ_BUFF_LEN/2);	// add portion new, input data into average
-				//
-				for(i = 0; i < FFT_IQ_BUFF_LEN/2; i++)	{		//		// guarantee that the result will always be >= 0
-					if(sd.FFT_AVGData[i] < 1)
-						sd.FFT_AVGData[i] = 1;
-				}
-			}
-		sd.state++;
-		break;
-		}
-		//
-		// De-linearize and normalize display data and do AGC processing
-		//
-		case 4:
-		{
-			float32_t	max, min, mean, offset;
-			float32_t	sig;
-			//
-			// De-linearize data with dB/division
-			//
-			for(i = 0; i < (FFT_IQ_BUFF_LEN/2); i++)	{
-				sig = log10(sd.FFT_AVGData[i]) * DB_SCALING_10;		// take FFT data, do a log10 and multiply it to scale 10dB (fixed)
-				sig += sd.display_offset;							// apply "AGC", vertical "sliding" offset (or brightness for waterfall)
-				if(sig > 1)											// is the value greater than 1?
-					sd.FFT_DspData[i] = (q15_t)sig;					// it was a useful value - save it
-				else
-					sd.FFT_DspData[i] = 1;							// not greater than 1 - assign it to a base value of 1 for sanity's sake
-			}
-			//
-			// Transfer data to the waterfall display circular buffer, putting the bins in frequency-sequential order!
-			//
-			for(i = 0; i < (FFT_IQ_BUFF_LEN/2); i++)	{
-				if(i < (SPECTRUM_WIDTH/2))	{		// build left half of spectrum data
-					sd.FFT_Samples[i] = sd.FFT_DspData[i + FFT_IQ_BUFF_LEN/4];	// get data
-				}
-				else	{							// build right half of spectrum data
-					sd.FFT_Samples[i] = sd.FFT_DspData[i - FFT_IQ_BUFF_LEN/4];	// get data
-				}
-			}
-			//
-			// Find peak and average to vertically adjust display
-			//
-			if(sd.magnify)	{	// are we in magnify mode?
-				spec_width = FFT_IQ_BUFF_LEN/4;	// yes - define new spectrum width
-				//
-				if(!ts.iq_freq_mode)	{	// yes, are we NOT in translate mode?
-					arm_max_f32((float32_t *)&sd.FFT_Samples[FFT_IQ_BUFF_LEN/8], spec_width, &max, &max_ptr);		// find maximum element in center portion
-					arm_min_f32((float32_t *)&sd.FFT_Samples[FFT_IQ_BUFF_LEN/8], spec_width, &min, &max_ptr);		// find minimum element in center portion
-					arm_mean_f32((float32_t *)&sd.FFT_Samples[FFT_IQ_BUFF_LEN/8], spec_width, &mean);				// find mean value in center portion
-				}
-				else if(ts.iq_freq_mode == FREQ_IQ_CONV_P6KHZ)	{	// we are in RF LO HIGH mode (tuning is below center of screen)
-					arm_max_f32((float32_t *)&sd.FFT_Samples[FFT_IQ_BUFF_LEN/8 - 32], spec_width, &max, &max_ptr);		// find maximum element in center portion
-					arm_min_f32((float32_t *)&sd.FFT_Samples[FFT_IQ_BUFF_LEN/8 - 32], spec_width, &min, &max_ptr);		// find minimum element in center portion
-					arm_mean_f32((float32_t *)&sd.FFT_Samples[FFT_IQ_BUFF_LEN/8 - 32], spec_width, &mean);				// find mean value in center portion
-				}
-				else if(ts.iq_freq_mode == FREQ_IQ_CONV_M6KHZ)	{	// we are in RF LO LOW mode (tuning is above center of screen)
-					arm_max_f32((float32_t *)&sd.FFT_Samples[FFT_IQ_BUFF_LEN/8 + 32], spec_width, &max, &max_ptr);		// find maximum element in center portion
-					arm_min_f32((float32_t *)&sd.FFT_Samples[FFT_IQ_BUFF_LEN/8 + 32], spec_width, &min, &max_ptr);		// find minimum element in center portion
-					arm_mean_f32((float32_t *)&sd.FFT_Samples[FFT_IQ_BUFF_LEN/8 + 32], spec_width, &mean);				// find mean value in center portion
-				}
-				else if(ts.iq_freq_mode == FREQ_IQ_CONV_P12KHZ)	{	// we are in RF LO HIGH mode (tuning is below center of screen)		// aaaaaaaaaaaaaaaaaaaaaaaaa
-					arm_max_f32((float32_t *)&sd.FFT_Samples[FFT_IQ_BUFF_LEN/8 - 64], spec_width, &max, &max_ptr);		// find maximum element in center portion
-					arm_min_f32((float32_t *)&sd.FFT_Samples[FFT_IQ_BUFF_LEN/8 - 64], spec_width, &min, &max_ptr);		// find minimum element in center portion
-					arm_mean_f32((float32_t *)&sd.FFT_Samples[FFT_IQ_BUFF_LEN/8 - 64], spec_width, &mean);				// find mean value in center portion
-				}
-				else if(ts.iq_freq_mode == FREQ_IQ_CONV_M12KHZ)	{	// we are in RF LO LOW mode (tuning is above center of screen)
-					arm_max_f32((float32_t *)&sd.FFT_Samples[FFT_IQ_BUFF_LEN/8 + 64], spec_width, &max, &max_ptr);		// find maximum element in center portion
-					arm_min_f32((float32_t *)&sd.FFT_Samples[FFT_IQ_BUFF_LEN/8 + 64], spec_width, &min, &max_ptr);		// find minimum element in center portion
-					arm_mean_f32((float32_t *)&sd.FFT_Samples[FFT_IQ_BUFF_LEN/8 + 64], spec_width, &mean);				// find mean value in center portion
-				}
-			}
-			else	{
-				spec_width = FFT_IQ_BUFF_LEN/2;
-				arm_max_f32((float32_t *)sd.FFT_Samples, spec_width, &max, &max_ptr);		// find maximum element
-				arm_min_f32((float32_t *)sd.FFT_Samples, spec_width, &min, &max_ptr);		// find minimum element
-				arm_mean_f32((float32_t *)sd.FFT_Samples, spec_width, &mean);				// find mean value
-			}
-			//
-			// Calculate "brightness" offset for amplitude value
-			//
-			offset = (float)ts.waterfall_offset;
-			offset -= 100;
-			//
-			//
-			// Vertically adjust spectrum scope so that the strongest signals are adjusted to the top
-			//
-			if((max - offset) >= NUMBER_WATERFALL_COLOURS - 1)	{	// is result higher than display brightness
-				sd.display_offset -= sd.agc_rate;	// yes, adjust downwards quickly
-//				if(max1 > SPECTRUM_HEIGHT+(SPECTRUM_HEIGHT/2))			// is it WAY above top of screen?
-//					sd.display_offset -= sd.agc_rate*3;	// yes, adjust downwards REALLY quickly
-			}
-			//
-			// Prevent "empty" spectrum display from filling with "noise" by checking the peak/average of what was found
-			//
-			else if(((max*10/mean) <= (q15_t)ts.waterfall_nosig_adjust) && (max < SPECTRUM_HEIGHT+(SPECTRUM_HEIGHT/2)))	{	// was "average" signal ratio below set threshold and average is not insanely strong??
-				if((min > 2) && (max > 2))	{		// prevent the adjustment from going downwards, "into the weeds"
-					sd.display_offset -= sd.agc_rate;	// yes, adjust downwards
-		            if(sd.display_offset < (-(SPECTRUM_HEIGHT + SPECTRUM_SCOPE_ADJUST_OFFSET)))
-		               sd.display_offset = (-(SPECTRUM_HEIGHT + SPECTRUM_SCOPE_ADJUST_OFFSET));
-				}
-			}
-			else
-				sd.display_offset += (sd.agc_rate/3);	// no, adjust upwards more slowly
-			//
-			//
-			if((min <= 2) && (max <= 2))	{	// ARGH - We must already be in the weeds, below the bottom - let's adjust upwards quickly to get it back onto the display!
-				sd.display_offset += sd.agc_rate*10;
-			}
-			//
-			// used for debugging
-			//	char txt[32];
-			//	sprintf(txt, " %d,%d,%d ", (int)sd.display_offset*100, (int)min*100,(int)max*100);
-			//	UiLcdHy28_PrintText    ((POS_RIT_IND_X + 1), (POS_RIT_IND_Y + 20),txt,White,Grid,0);
-			//
-			// Copy to holder for the waterfall buffer
-			sd.state++;
-			break;
-		}
-		case 5:	// rescale waterfall horizontally, apply brightness/contrast, process pallate and put vertical line on screen, if enabled.
-		{
-			//
-			sd.wfall_line %= sd.wfall_size;	// make sure that the circular buffer is clipped to the size of the display area
-			//
-			//
-			// Contrast:  100 = 1.00 multiply factor:  125 = multiply by 1.25 - "sd.wfall_contrast" already converted to 100=1.00
-			//
-			arm_scale_f32((float32_t *)sd.FFT_Samples, (float32_t)sd.wfall_contrast, (float32_t *)sd.FFT_Samples, FFT_IQ_BUFF_LEN/2);
-			//
-			ushort ptr;
-			//
-			if(sd.magnify)	{	// is magnify mode on?
-				if(!ts.iq_freq_mode)	{	// yes - frequency translate mode is off
-					for(i = 0; i < FFT_IQ_BUFF_LEN/2; i++)	{	// expand data to fill entire screen - get lower half
-						ptr = (i/2)+64;
-						if(ptr < FFT_IQ_BUFF_LEN/2)	{
-							sd.wfall_temp[i] = sd.FFT_Samples[ptr];
-						}
-					}
-				}
-				else if(ts.iq_freq_mode == FREQ_IQ_CONV_P6KHZ)	{	// frequency translate mode is in "RF LO HIGH" mode - tune below center of screen
-					for(i = 0; i < FFT_IQ_BUFF_LEN/2; i++)	{	// expand data to fill entire screen - get lower half
-						ptr = (i/2)+32;
-						if(ptr < FFT_IQ_BUFF_LEN/2)	{
-							sd.wfall_temp[i] = sd.FFT_Samples[ptr];
-						}
-					}
-				}
-				else if(ts.iq_freq_mode == FREQ_IQ_CONV_M6KHZ)	{	// frequency translate mode is in "RF LO LOW" mode - tune below center of screen
-					for(i = 0; i < FFT_IQ_BUFF_LEN/2; i++)	{	// expand data to fill entire screen - get lower half
-						ptr = (i/2)+96;
-						if(ptr < FFT_IQ_BUFF_LEN/2)	{
-							sd.wfall_temp[i] = sd.FFT_Samples[ptr];
-						}
-					}
-				}
-				else if(ts.iq_freq_mode == FREQ_IQ_CONV_P12KHZ)	{	// frequency translate mode is in "RF LO HIGH" mode - tune below center of screen       aaaaaaaaaaaaaaaaaaaaaa
-					for(i = 0; i < FFT_IQ_BUFF_LEN/2; i++)	{	// expand data to fill entire screen - get lower half
-						ptr = (i/2);
-						if(ptr < FFT_IQ_BUFF_LEN/2)	{
-							sd.wfall_temp[i] = sd.FFT_Samples[ptr];
-						}
-					}
-				}
-				else if(ts.iq_freq_mode == FREQ_IQ_CONV_M12KHZ)	{	// frequency translate mode is in "RF LO LOW" mode - tune below center of screen
-					for(i = 0; i < FFT_IQ_BUFF_LEN/2; i++)	{	// expand data to fill entire screen - get lower half
-						ptr = (i/2)+128;
-						if(ptr < FFT_IQ_BUFF_LEN/2)	{
-							sd.wfall_temp[i] = sd.FFT_Samples[ptr];
-						}
-					}
-				}
-				arm_copy_f32((float32_t *)sd.wfall_temp, (float32_t *)sd.FFT_Samples, FFT_IQ_BUFF_LEN/2);		// copy the rescaled/shifted data into the main buffer
-			}
-			//
-			// After the above manipulation, clip the result to make sure that it is within the range of the palette table
-			//
-			for(i = 0; i < FFT_IQ_BUFF_LEN/2; i++)	{
-				if(sd.FFT_Samples[i] >= NUMBER_WATERFALL_COLOURS)	// is there an illegal color value?
-					sd.FFT_Samples[i] = NUMBER_WATERFALL_COLOURS - 1;	// yes - clip it
-				//
-				sd.waterfall[sd.wfall_line][i] = (ushort)sd.FFT_Samples[i];	// save the manipulated value in the circular waterfall buffer
-			}
-			//
-			// Place center line marker on screen:  Location [64] (the 65th) of the palette is reserved is a special color reserved for this
-			//
-			if(sd.magnify)	{
-				sd.waterfall_colours[NUMBER_WATERFALL_COLOURS] = (ushort)ts.scope_centre_grid_colour_active;	// for some reason it is necessary to reload this entry of the palette!
-				sd.waterfall[sd.wfall_line][128] = NUMBER_WATERFALL_COLOURS;	// set graticule in the middle
-			}
-			else if(!ts.iq_freq_mode)	// is frequency translate off OR magnification mode on
-				sd.waterfall[sd.wfall_line][128] = NUMBER_WATERFALL_COLOURS;	// set graticule in the middle
-			else if(ts.iq_freq_mode == FREQ_IQ_CONV_P6KHZ)			// LO HIGH - set graticule below center
-				sd.waterfall[sd.wfall_line][96] = NUMBER_WATERFALL_COLOURS;
-			else if(ts.iq_freq_mode == FREQ_IQ_CONV_M6KHZ)			// LO LOW - set graticule above center
-				sd.waterfall[sd.wfall_line][160] = NUMBER_WATERFALL_COLOURS;
-			else if(ts.iq_freq_mode == FREQ_IQ_CONV_P12KHZ)			// LO HIGH - set graticule below center
-				sd.waterfall[sd.wfall_line][64] = NUMBER_WATERFALL_COLOURS;
-			else if(ts.iq_freq_mode == FREQ_IQ_CONV_M12KHZ)			// LO LOW - set graticule above center
-				sd.waterfall[sd.wfall_line][192] = NUMBER_WATERFALL_COLOURS;
-
-			//
-			sd.wfall_line++;		// bump to the next line in the circular buffer for next go-around
-			//
-			// scan_top is used to limit AGC action to "magnified" portion
-			//
-		sd.state++;
-		break;
-		}
-		//
-		//  update LCD control
-		//
-		case 6:
-		{
-			uchar lptr = sd.wfall_line;		// get current line of "bottom" of waterfall in circular buffer
-			uchar lcnt = 0;					// initialize count of number of lines of display
-
-			//
-			sd.wfall_line_update++;									// update waterfall line count
-			sd.wfall_line_update %= ts.waterfall_vert_step_size;	// clip it to number of lines per iteration
-
-			if(!sd.wfall_line_update)	{							// if it's count is zero, it's time to move the waterfall up
-				//
-				lptr %= sd.wfall_size;		// do modulus limit of spectrum high
-				//
-				// set up LCD for bulk write, limited only to area of screen with waterfall display.  This allow data to start from the
-				// bottom-left corner and advance to the right and up to the next line automatically without ever needing to address
-				// the location of any of the display data - as long as we "blindly" write precisely the correct number of pixels per
-				// line and the number of lines.
-				//
-				UiLcdHy28_OpenBulkWrite(SPECTRUM_START_X, SPECTRUM_WIDTH, (sd.wfall_ystart + 1), sd.wfall_height);
-				//
-				ushort spectrumLine[SPECTRUM_WIDTH];
-
-				while(lcnt < sd.wfall_size)	{				// set up counter for number of lines defining height of waterfall
-					for(i = 0; i < (SPECTRUM_WIDTH); i++)	{	// scan to copy one line of spectral data - "unroll" to optimize for ARM processor
-						spectrumLine[i] = sd.waterfall_colours[sd.waterfall[lptr][i]];	// write to memory using waterfall color from palette
-					}
-
-					UiLcdHy28_BulkWrite(spectrumLine,SPECTRUM_WIDTH);
-
-					lcnt++;									// update count of lines we have done
-					lptr++;									// point to next line in circular display buffer
-					lptr %= sd.wfall_size;				// clip to display height
-				}
-				//
-				UiLcdHy28_CloseBulkWrite();					// we are done updating the display - return to normal full-screen mode
-				}
-				sd.state = 0;	// Stage 0 - collection of data by the Audio driver
-				break;
-		}
-		default:
-			sd.state = 0;
-			break;
-	}
-}
-//
-//
-//
-//*----------------------------------------------------------------------------
-//* Function Name       : UiInitSpectrumScopeWaterfall
-//* Object              : Does all steps for clearing screen and initializing spectrum scope and waterfall
-//* Input Parameters    :
-//* Output Parameters   :
-//* Functions called    :
-//*----------------------------------------------------------------------------
-//
-static void UiInitSpectrumScopeWaterfall(void)
-{
-	if(ts.boot_halt_flag)			// do not build spectrum display/waterfall if we are loading EEPROM defaults!
-		return;
-
-	UiDriverClearSpectrumDisplay();			// clear display under spectrum scope
-	UiDriverCreateSpectrumScope();
-	UiDriverInitSpectrumDisplay();
-	UiDriverDisplayFilterBW();	// Update on-screen indicator of filter bandwidth
-}
-
 
 
 //*----------------------------------------------------------------------------

--- a/mchf-eclipse/drivers/ui/ui_driver.h
+++ b/mchf-eclipse/drivers/ui/ui_driver.h
@@ -96,55 +96,6 @@ typedef struct KeypadState
 
 #define S_METER_MAX							34
 
-// Spectrum scope operational constants
-//
-#define	SPECTRUM_SCOPE_TOP_LIMIT			5	// Top limit of spectrum scope magnitude
-//
-#define SPECTRUM_SCOPE_AGC_THRESHOLD		2000//400	// AGC "Knee" above which output from spectrum scope FFT  AGC will cause action
-#define SPECTRUM_SCOPE_MAX_FFT_VAL			8192//16384 // Value above which input to spectrum scope FFT will cause AGC action
-#define SPECTRUM_SCOPE_MIN_GAIN				0.001//0.1	// Minimum gain for spectrum scope FFT AGC loop
-#define SPECTRUM_SCOPE_MAX_GAIN				140	// Maximum gain for spectrum scope FFT AGC loop
-#define	SPECTRUM_SCOPE_AGC_ATTACK			0.5//0.1	// Attack rate for spectrum scope FFT AGC/gain
-#define	SPECTRUM_SCOPE_AGC_DECAY			0.166//0.1	// Decay rate for spectrum scope FFT AGC/gain
-//
-#define	SPECTRUM_SCOPE_LPF_FACTOR			4	// IIR Factor for spectrum scope low-pass filtering
-	// Higher = slower response.  3 = 33% input; 66% feedback, 4 = 25% input, 75% feedback, 5 = 20% input, 80% feedback
-#define	SPECTRUM_SCOPE_LPF_FACTOR_SPI		2	// IIR Factor for spectrum scope low-pass filtering using SPI display (update rate is slower, use faster filter)
-//
-#define PK_AVG_RESCALE_THRESH		3		// This sets the minimum peak-to-average ratio of the spectrum display before it starts to rescale the peak
-		// value from the top.  This prevents it from going completely "white" on noise/no-signal conditions.
-//
-#define	SPECTRUM_SCOPE_RESCALE_ATTACK_RATE	0.1	// Rate at which scaling of spectrum scope adapts to strong signals within its passband
-#define	SPECTRUM_SCOPE_RESCALE_DECAY_RATE	0.033	// Rate at which scaling of spectrum scope decays after strong signals disappear from its passband
-//
-#define SPECTRUM_SCOPE_SPEED_MIN			1	// minimum spectrum scope speed
-#define SPECTRUM_SCOPE_SPEED_MAX			25	// maximum spectrum scope speed
-#define SPECTRUM_SCOPE_SPEED_DEFAULT		5
-//
-#define SPECTRUM_SCOPE_FILTER_MIN			1	// minimum filter setting
-#define	SPECTRUM_SCOPE_FILTER_MAX			10	// maximum filter setting
-#define SPECTRUM_SCOPE_FILTER_DEFAULT		4	// default filter setting
-//
-#define	SPECTRUM_SCOPE_AGC_MIN				1	// minimum spectrum scope AGC rate setting
-#define	SPECTRUM_SCOPE_AGC_MAX				50	// maximum spectrum scope AGC rate setting
-#define	SPECTRUM_SCOPE_AGC_DEFAULT			25	// default spectrum scope AGC rate setting
-//
-#define SPECTRUM_SCOPE_NOSIG_ADJUST_MIN		10
-#define SPECTRUM_SCOPE_NOSIG_ADJUST_MAX		30
-#define	SPECTRUM_SCOPE_NOSIG_ADJUST_DEFAULT		20
-//
-#define	SPECTRUM_SCOPE_ADJUST_OFFSET	100
-//
-//
-#define	SPECTRUM_AGC_SCALING				25	// scaling factor by which the on-screen Spec. AGC Adj. is divided for adjustment.
-//
-#define	SCOPE_PREAMP_GAIN					1000//200	// amount of "amplification" in front of the FFT used for the Spectrum Scope and Waterfall used to overcome mathematical "noise floor"
-//
-#define INIT_SPEC_AGC_LEVEL					-80	// Initial offset for AGC level for spectrum/waterfall display
-//
-#define SPECTRUM_SCOPE_SPI_HOLDOFF_TIME_TUNE	25	// time, in 100's of second to inhibit spectrum scope update after adjusting tuning while in SPI mode
-//
-#define	NUMBER_WATERFALL_COLOURS			64		// number of colors in the waterfall table
 //
 // Settings for dB/division for spectrum display
 //
@@ -245,7 +196,7 @@ enum	{
 #define	FFT_WINDOW_DEFAULT	FFT_WINDOW_BLACKMAN
 //
 #define	WATERFALL_SIZE_DEFAULT	WATERFALL_NORMAL
-#define	WFALL_MEDIUM_ADDITIONAL	12					// additional vertical height in pixels of "medium" waterfall
+
 //
 #define SWR_SAMPLES_SKP						1	//5000
 #define SWR_SAMPLES_CNT						5//10
@@ -534,14 +485,6 @@ typedef struct EepromSave
 #define POS_FIR_IND_X						0
 #define POS_FIR_IND_Y						163
 
-// Spectrum display
-#define POS_SPECTRUM_IND_X					60
-#define POS_SPECTRUM_IND_Y					150
-#define POS_SPECTRUM_IND_H					80
-#define	POS_SPECTRUM_FREQ_BAR_Y				64	// reducing value moves upwards
-#define	POS_SPECTRUM_FILTER_WIDTH_BAR_Y		61
-#define POS_SPECTRUM_IND_W					258
-#define COL_SPECTRUM_GRAD					0x40
 
 // ETH position
 #define POS_ETH_IND_X						220
@@ -580,13 +523,13 @@ void 	ui_driver_toggle_tx(void);
 void 	UiCalcRxPhaseAdj(void);
 void 	UiCalcTxPhaseAdj(void);
 void 	UiDriverLoadFilterValue(void);
-void 	UiDriverClearSpectrumDisplay(void);
+void 	UiSpectrumClearDisplay(void);
 //
 void 	UiDriverChangeBandFilter(uchar band);
 void 	UiDriverChangeFilter(uchar ui_only_update);
 void 	UiDriverCreateTemperatureDisplay(uchar enabled,uchar create);
 void 	UiDriverUpdateFrequency(char skip_encoder_check, uchar mode);
-void 	UiDriverCreateSpectrumScope(void);
+void 	UiSpectrumCreateDrawArea(void);
 void 	UiDriverUpdateFrequencyFast(void);
 void	UiCalcRxIqGainAdj(void);
 void	UiCalcTxIqGainAdj(void);
@@ -638,6 +581,8 @@ void 	UiCalcSubaudibleDetFreq(void);		// load/set current FM subaudible tone set
 bool	check_tp_coordinates(uint8_t,uint8_t,uint8_t,uint8_t);
 
 void UiDriverSetDemodMode(uint32_t new_mode); // switch to different demodulation mode.
+void UiDriverMenuMapColors(uint32_t color ,char* options,volatile uint32_t* clr_ptr);
+
 //
 //
 #define	SIDETONE_MAX_GAIN	10		// Maximum sidetone gain

--- a/mchf-eclipse/drivers/ui/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/ui_menu.c
@@ -727,7 +727,7 @@ if(mode > 3)
     	    screen_disp = offset+1+ ((ts.menu_item - MAX_MENU_ITEM) / MENUSIZE);
 
        	if(old_screen_disp != screen_disp)	// redraw if this screen wasn't already displayed
-       				UiDriverClearSpectrumDisplay();
+       				UiSpectrumClearDisplay();
 		update_vars = 1;
 
 

--- a/mchf-eclipse/hardware/mchf_board.c
+++ b/mchf-eclipse/hardware/mchf_board.c
@@ -673,7 +673,7 @@ void mchf_board_power_off(void)
 	char	tx[40];
 	// Power off all - high to disable main regulator
 
-	UiDriverClearSpectrumDisplay();	// clear display under spectrum scope
+	UiSpectrumClearDisplay();	// clear display under spectrum scope
 
 	Codec_Mute(1);	// mute audio when powering down
 

--- a/mchf-eclipse/hardware/mchf_board.h
+++ b/mchf-eclipse/hardware/mchf_board.h
@@ -1398,6 +1398,7 @@ typedef struct TransceiverState
 	ulong	alc_tx_postfilt_gain;		// amount of gain after the TX audio filtering - EEPROM read/write version
 	ulong	alc_tx_postfilt_gain_var;	// amount of gain after the TX audio filtering - working variable version
 	//
+	#define FREQ_STEP_SWAP_BTN	0xf0
 	uchar	freq_step_config;			// configuration of step size (line, step button reversal) - setting any of the 4 upper bits -> step button switch, any of the lower bits -> frequency marker display enabled
 	//
 	bool	nb_disable;					// TRUE if noise blanker is to be disabled
@@ -1439,6 +1440,7 @@ typedef struct TransceiverState
 	//
 	uchar	tx_disable;					// TRUE if transmit is to be disabled
 	//
+	#define MISC_FLAGS1_SWAP_BAND_BTN 0x02
 	uchar	misc_flags1;				// Used to hold individual status flags, stored in EEPROM location "EEPROM_MISC_FLAGS1"
 										// LSB = 0 if on-screen AFG/(STG/CMP) and WPM/(MIC/LIN) indicators are changed on TX
 										// LSB+1 = 1 if BAND-/BAND+ buttons are to be swapped in their positions


### PR DESCRIPTION
Moved all code and almost all constants related to computing and
drawing spectrum views to ui_spectrum.
Did a few optimizations on the Spectrum Scope code, should run much faster
in most cases.
Enabling the optimization for the ui_lcd_hy28.c gave at least the SPI
display a real performance boost.

Please test using the different displays and modes. If any issue arises, we should try to fix it
without having to give up optimization for LCD code.