### PR TITLE
Support for controlling the DIG USB TX gain level via PC

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -1582,8 +1582,8 @@ static void audio_rx_processor(int16_t *src, int16_t *dst, int16_t size)
 		//  0 - 16: via codec command
 		// 17 - 20: soft gain after decoder
 		//
-		if(ts.audio_gain > 16)	// is volume control above highest hardware setting?
-			arm_scale_f32((float32_t *)ads.b_buffer, (float32_t)ts.audio_gain_active, (float32_t *)ads.b_buffer, size/2);	// yes, do software volume control adjust on "b" buffer
+		if(ts.rx_gain[RX_AUDIO_SPKR].value > 16)	// is volume control above highest hardware setting?
+			arm_scale_f32((float32_t *)ads.b_buffer, (float32_t)ts.rx_gain[RX_AUDIO_SPKR].active_value, (float32_t *)ads.b_buffer, size/2);	// yes, do software volume control adjust on "b" buffer
 	}
 	//
 	// Transfer processed audio to DMA buffer
@@ -1607,7 +1607,7 @@ static void audio_rx_processor(int16_t *src, int16_t *dst, int16_t size)
 		// Unless this is DIGITAL I/Q Mode, we sent processed audio
 		if (ts.tx_audio_source != TX_AUDIO_DIGIQ) {
 			if (i%USBD_AUDIO_IN_OUT_DIV == modulus) {
-				float32_t val = ads.a_buffer[i] * ts.rx_usb_gain/31.0;
+				float32_t val = ads.a_buffer[i] * ts.rx_gain[RX_AUDIO_DIG].value/31.0;
 				audio_in_put_buffer(val);
 				if (USBD_AUDIO_IN_CHANNELS == 2) {
 					audio_in_put_buffer(val);
@@ -1772,8 +1772,8 @@ static void audio_dv_rx_processor(int16_t *src, int16_t *dst, int16_t size)
 		//  0 - 16: via codec command
 		// 17 - 20: soft gain after decoder
 		//
-		if(ts.audio_gain > 16)	// is volume control above highest hardware setting?
-			arm_scale_f32((float32_t *)ads.b_buffer, (float32_t)ts.audio_gain_active, (float32_t *)ads.b_buffer, size/2);	// yes, do software volume control adjust on "b" buffer
+		if(ts.rx_gain[RX_AUDIO_SPKR].value > 16)	// is volume control above highest hardware setting?
+			arm_scale_f32((float32_t *)ads.b_buffer, (float32_t)ts.rx_gain[RX_AUDIO_SPKR].active_value, (float32_t *)ads.b_buffer, size/2);	// yes, do software volume control adjust on "b" buffer
 	}
 	//
 	// Transfer processed audio to DMA buffer

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -89,14 +89,9 @@ static void 	UiDriverProcessKeyboard(void);
 static void 	UiDriverPressHoldStep(uchar is_up);
 static void 	UiDriverProcessFunctionKeyClick(ulong id);
 
-//static void 	UiDriverShowMode(void);
-//static void 	UiDriverShowStep(ulong step);
 static void 	UiDriverShowBand(uchar band);
 static void 	UiDriverCreateDesktop(void);
 static void 	UiDriverCreateFunctionButtons(bool full_repaint);
-//static void 	UiDriverCreateSpectrumScope(void);
-//static void 	UiDriverCreateDigiPanel(void);
-//
 static void UiDriverDeleteSMeter(void);
 static void 	UiDriverCreateSMeter(void);
 static void 	UiDriverDrawSMeter(ushort color);
@@ -108,10 +103,7 @@ static void 	UiDriverInitFrequency(void);
 //
 static void 	UiDriverCheckFilter(ulong freq);
 uchar 			UiDriverCheckBand(ulong freq, ushort update);
-//static void 	UiDriverUpdateFrequency(char skip_encoder_check, uchar mode);
-//static void 	UiDriverUpdateFrequencyFast(void);
 static void 	UiDriverUpdateLcdFreq(ulong dial_freq,ushort color,ushort mode);
-//static void 	UiDriverChangeTuningStep(uchar is_up);
 static uchar 	UiDriverButtonCheck(ulong button_num);
 static void		UiDriverTimeScheduler(void);				// Also handles audio gain and switching of audio on return from TX back to RX
 static void 	UiDriverChangeDemodMode(uchar noskip);
@@ -124,24 +116,14 @@ static void 	UiDriverChangeEncoderOneMode(uchar skip);
 static void 	UiDriverChangeEncoderTwoMode(uchar skip);
 static void 	UiDriverChangeEncoderThreeMode(uchar skip);
 // encoder one
-static void 	UiDriverChangeAfGain(uchar enabled);
-//static void 	UiDriverChangeStGain(uchar enabled);
-//static void 	UiDriverChangeKeyerSpeed(uchar enabled);
 // encoder two
-//static void 	UiDriverChangeRfGain(uchar enabled);
 static void 	UiDriverChangeSigProc(uchar enabled);
 // encoder three
 static void 	UiDriverChangeRit(uchar enabled);
-//static void 	UiDriverChangeFilter(uchar ui_only_update);
 static void 	UiDriverProcessActiveFilterScan(void);
 static void 	UiDriverChangeDSPMode(void);
 static void 	UiDriverChangeDigitalMode(void);
 static void 	UiDriverChangePowerLevel(void);
-//static void 	UiDrawSpectrumScopeFrequencyBarText(void);
-//static void 	UiDriverClearSpectrumDisplay(void);
-// static ulong 	UiDriverGetScopeTraceColour(void);
-//static void 	UiDriverUpdateEthernetStatus(void);
-//static void 	UiDriverUpdateUsbKeyboardStatus(void);
 static void 	UiDriverHandleSmeter(void);
 static void 	UiDriverHandleLowerMeter(void);
 static void 	UiDriverHandlePowerSupply(void);
@@ -150,11 +132,7 @@ static void 	UiDriverUpdateLoMeter(uchar val,uchar active);
 void 			UiDriverCreateTemperatureDisplay(uchar enabled,uchar create);
 static void 	UiDriverRefreshTemperatureDisplay(uchar enabled,int temp);
 static void 	UiDriverHandleLoTemperature(void);
-//static void 	UiDriverEditMode(void);
 static void 	UiDriverSwitchOffPtt(void);
-//static void 	UiDriverSetBandPowerFactor(uchar band);
-//
-//static void		UiCalcTxIqGainAdj(void);
 static void 	UiDriverLoadEepromValues(void);
 void			UiDriverUpdateMenu(uchar mode);
 uint16_t 		UiDriverSaveEepromValuesPowerDown(void);
@@ -686,7 +664,7 @@ void ui_driver_init(void)
 	// Update codec volume
 	//  0 - 16: via codec command
 	// 17 - 30: soft gain after decoder
-	Codec_Volume((ts.audio_gain*8));		// This is only approximate - it will be properly set later
+	Codec_Volume((ts.rx_gain[RX_AUDIO_SPKR].value*8));		// This is only approximate - it will be properly set later
 
 	// Set TX power factor
 	UiDriverSetBandPowerFactor(ts.band);
@@ -843,7 +821,6 @@ void ui_driver_toggle_tx(void)
 			}
 			else	{	// we are in MIC IN mode
 				Codec_Line_Gain_Adj(0);			// momentarily mute LINE IN audio until we switch modes because we will blast any connected LINE IN source until we switch
-				ts.tx_mic_gain_mult_temp = ts.tx_mic_gain_mult;		// temporarily hold the mic gain value while we switch
 				ts.tx_mic_gain_mult = 0;		// momentarily set the mic gain to zero while we go to TX
 				Codec_WriteRegister(W8731_ANLG_AU_PATH_CNTR,0x0016);	// Mute the microphone with the CODEC (this does so without a CLICK)
 			}
@@ -1354,9 +1331,9 @@ static void UiDriverProcessKeyboard(void)
 						ts.tx_audio_source = TX_AUDIO_MIC;
 					//
 					if(ts.enc_thr_mode == ENC_THREE_MODE_RIT)	// if encoder in RIT mode, grey out audio gain control
-						UIDriverChangeAudioGain(0);
+						UiDriverChangeAudioGain(0);
 					else									// not RIT mode - don't grey out
-						UIDriverChangeAudioGain(1);
+						UiDriverChangeAudioGain(1);
 				}
 				break;
 			case BUTTON_POWER_PRESSED:
@@ -1505,7 +1482,7 @@ void UiInitRxParms(void)
 		UiDriverChangeStGain(0);			// sidetone gain when in CW mode
 	}
 	else	{
-		UIDriverChangeAudioGain(0);			// display Line/Mic gain and
+		UiDriverChangeAudioGain(0);			// display Line/Mic gain and
 		UiDriverChangeCmpLevel(0);			// Compression level when in voice mode
 	}
 }
@@ -1702,7 +1679,7 @@ static void UiDriverProcessFunctionKeyClick(ulong id)
 				if(ts.dmod_mode == DEMOD_CW)
 					UiDriverChangeKeyerSpeed(0);
 				else
-					UIDriverChangeAudioGain(0);
+					UiDriverChangeAudioGain(0);
 				//
 				UiDriverChangeRit(0);
 				//
@@ -2440,7 +2417,7 @@ static void UiDriverCreateDesktop(void)
 	if(ts.dmod_mode == DEMOD_CW)
 		UiDriverChangeKeyerSpeed(0);
 	else
-		UIDriverChangeAudioGain(0);
+		UiDriverChangeAudioGain(0);
 	//
 	cw_gen_init();
 
@@ -3649,19 +3626,19 @@ static void UiDriverTimeScheduler(void)
 	if(ts.txrx_mode != TRX_MODE_TX)	{
 		was_rx = 1;			// set flag to indicate that we are in RX mode
 		if(ts.boot_halt_flag)	{	// are we halting boot?
-			ts.audio_gain_active = 0;	// yes - null out audio
+			ts.rx_gain[RX_AUDIO_SPKR].active_value = 0;	// yes - null out audio
 			Codec_Volume(0);
 		}
-		else if((ts.audio_gain != ts.audio_gain_change) || (unmute_flag) || ts.band_change)	{	// in normal mode - calculate volume normally
-			ts.audio_gain_change = ts.audio_gain;
-			ts.audio_gain_active = 1;		// software gain not active - set to unity
-			if(ts.audio_gain <= 16)				// Note:  Gain > 16 adjusted in audio_driver.c via software
-				Codec_Volume((ts.audio_gain*5));
+		else if((ts.rx_gain[RX_AUDIO_SPKR].value != ts.rx_gain[RX_AUDIO_SPKR].value_old) || (unmute_flag) || ts.band_change)	{	// in normal mode - calculate volume normally
+			ts.rx_gain[RX_AUDIO_SPKR].value_old = ts.rx_gain[RX_AUDIO_SPKR].value;
+			ts.rx_gain[RX_AUDIO_SPKR].active_value = 1;		// software gain not active - set to unity
+			if(ts.rx_gain[RX_AUDIO_SPKR].value <= 16)				// Note:  Gain > 16 adjusted in audio_driver.c via software
+				Codec_Volume((ts.rx_gain[RX_AUDIO_SPKR].value*5));
 			else	{	// are we in the "software amplification" range?
 				Codec_Volume((80));		// set to fixed "maximum" gain
-				ts.audio_gain_active = (float)ts.audio_gain;	// to float
-				ts.audio_gain_active /= 2.5;	// rescale to reasonable step size
-				ts.audio_gain_active -= 5.35;	// offset to get gain multiplier value
+				ts.rx_gain[RX_AUDIO_SPKR].active_value = (float)ts.rx_gain[RX_AUDIO_SPKR].value;	// to float
+				ts.rx_gain[RX_AUDIO_SPKR].active_value /= 2.5;	// rescale to reasonable step size
+				ts.rx_gain[RX_AUDIO_SPKR].active_value -= 5.35;	// offset to get gain multiplier value
 			}
 			//
 			unmute_flag = 0;
@@ -3716,7 +3693,7 @@ static void UiDriverTimeScheduler(void)
 				ts.enc_thr_mode = ENC_THREE_MODE_CW_SPEED;
 				UiDriverChangeRit(0);
 				if(ts.dmod_mode != DEMOD_CW)
-					UIDriverChangeAudioGain(1);		// enable audio gain
+					UiDriverChangeAudioGain(1);		// enable audio gain
 				else
 					UiDriverChangeKeyerSpeed(1);	// enable keyer speed if it was CW mode
 
@@ -3741,7 +3718,7 @@ static void UiDriverTimeScheduler(void)
 				if(ts.enc_thr_mode == ENC_THREE_MODE_RIT)	{		// are we to switch back to RIT mode?
 					UiDriverChangeRit(1);			// enable RIT
 					if(ts.dmod_mode != DEMOD_CW)
-						UIDriverChangeAudioGain(0);		// disable audio gain if it was voice mode
+						UiDriverChangeAudioGain(0);		// disable audio gain if it was voice mode
 					else
 						UiDriverChangeKeyerSpeed(0);	// disable keyer speed if it was CW mode
 
@@ -4278,12 +4255,12 @@ static void UiDriverCheckEncoderOne(void)
 		{
 			// Convert to Audio Gain incr/decr
 			if(pot_diff < 0) {
-				if(ts.audio_gain)
-					ts.audio_gain -= 1;
+				if(ts.rx_gain[RX_AUDIO_SPKR].value)
+					ts.rx_gain[RX_AUDIO_SPKR].value -= 1;
 			} else {
-				ts.audio_gain += 1;
-				if(ts.audio_gain > ts.audio_max_volume)
-					ts.audio_gain = ts.audio_max_volume;
+				ts.rx_gain[RX_AUDIO_SPKR].value += 1;
+				if(ts.rx_gain[RX_AUDIO_SPKR].value > ts.rx_gain[RX_AUDIO_SPKR].max)
+					ts.rx_gain[RX_AUDIO_SPKR].value = ts.rx_gain[RX_AUDIO_SPKR].max;
 			}
 
 			UiDriverChangeAfGain(1);
@@ -4575,7 +4552,7 @@ static void UiDriverCheckEncoderThree(void)
 				if (ts.tx_audio_source == TX_AUDIO_MIC) {
 					Codec_MicBoostCheck();
 				}
-				UIDriverChangeAudioGain(1);
+				UiDriverChangeAudioGain(1);
 			}
 			break;
 		}
@@ -4767,7 +4744,7 @@ static void UiDriverChangeEncoderThreeMode(uchar skip)
 			if(ts.dmod_mode == DEMOD_CW)
 				UiDriverChangeKeyerSpeed(0);
 			else
-				UIDriverChangeAudioGain(0);
+				UiDriverChangeAudioGain(0);
 
 			break;
 		}
@@ -4780,7 +4757,7 @@ static void UiDriverChangeEncoderThreeMode(uchar skip)
 			if(ts.dmod_mode == DEMOD_CW)
 				UiDriverChangeKeyerSpeed(1);
 			else
-				UIDriverChangeAudioGain(1);
+				UiDriverChangeAudioGain(1);
 
 			break;
 		}
@@ -4794,7 +4771,7 @@ static void UiDriverChangeEncoderThreeMode(uchar skip)
 			if(ts.dmod_mode == DEMOD_CW)
 				UiDriverChangeKeyerSpeed(0);
 			else
-				UIDriverChangeAudioGain(0);
+				UiDriverChangeAudioGain(0);
 
 			break;
 		}
@@ -4809,9 +4786,9 @@ static void UiDriverChangeEncoderThreeMode(uchar skip)
 //* Output Parameters   :
 //* Functions called    :
 //*----------------------------------------------------------------------------
-static void UiDriverChangeAfGain(uchar enabled)
+void UiDriverChangeAfGain(uchar enabled)
 {
-	UiDriverEncoderDisplaySimple(0,0,"AFG", enabled, ts.audio_gain);
+	UiDriverEncoderDisplaySimple(0,0,"AFG", enabled, ts.rx_gain[RX_AUDIO_SPKR].value);
 }
 
 //*----------------------------------------------------------------------------
@@ -5006,7 +4983,7 @@ void UiDriverChangeKeyerSpeed(uchar enabled)
 //* Output Parameters   :
 //* Functions called    :
 //*----------------------------------------------------------------------------
-void UIDriverChangeAudioGain(uchar enabled)
+void UiDriverChangeAudioGain(uchar enabled)
 {
 	ushort 	color = enabled?White:Grey;
 	const char* txt;
@@ -7868,7 +7845,7 @@ void UiDriverLoadEepromValues(void)
 
 	UiReadSettingEEPROM_UInt8(EEPROM_TX_AUDIO_SRC,&ts.tx_audio_source,0,0,TX_AUDIO_MAX_ITEMS);
 	UiReadSettingEEPROM_UInt8(EEPROM_TCXO_STATE,&df.temp_enabled,TCXO_ON,0,TCXO_TEMP_STATE_MAX);
-	UiReadSettingEEPROM_UInt8(EEPROM_AUDIO_GAIN,&ts.audio_gain,DEFAULT_AUDIO_GAIN,0,MAX_AUDIO_GAIN);
+	UiReadSettingEEPROM_UInt8(EEPROM_AUDIO_GAIN,&ts.rx_gain[RX_AUDIO_SPKR].value,DEFAULT_AUDIO_GAIN,0,MAX_AUDIO_GAIN);
 	UiReadSettingEEPROM_UInt8(EEPROM_RX_CODEC_GAIN,&ts.rf_codec_gain,DEFAULT_RF_CODEC_GAIN_VAL,0,MAX_RF_CODEC_GAIN_VAL);
 	UiReadSettingEEPROM_Int(EEPROM_RX_GAIN,&ts.rf_gain,DEFAULT_RF_GAIN,0,MAX_RF_GAIN);
 	UiReadSettingEEPROM_UInt8(EEPROM_NB_SETTING,&ts.nb_setting,0,0,MAX_RF_ATTEN);
@@ -7892,7 +7869,7 @@ void UiDriverLoadEepromValues(void)
 	UiReadSettingEEPROM_UInt8(EEPROM_SPECTRUM_SCALE_COLOUR,&ts.scope_scale_colour,SPEC_COLOUR_SCALE_DEFAULT, 0, SPEC_MAX_COLOUR);
 	UiReadSettingEEPROM_UInt8(EEPROM_PADDLE_REVERSE,&ts.paddle_reverse,0,0,1);
 	UiReadSettingEEPROM_UInt8(EEPROM_CW_RX_DELAY,&ts.cw_rx_delay,CW_RX_DELAY_DEFAULT,0,CW_RX_DELAY_MAX);
-	UiReadSettingEEPROM_UInt8(EEPROM_MAX_VOLUME,&ts.audio_max_volume,MAX_VOLUME_DEFAULT,MAX_VOLUME_MIN,MAX_VOLUME_MAX);
+	UiReadSettingEEPROM_UInt8(EEPROM_MAX_VOLUME,&ts.rx_gain[RX_AUDIO_SPKR].max,MAX_VOLUME_DEFAULT,MAX_VOLUME_MIN,MAX_VOLUME_MAX);
 	UiReadSettingEEPROM_UInt8(EEPROM_FILTER_300HZ_SEL,&ts.filter_300Hz_select,FILTER_300HZ_DEFAULT,0,MAX_300HZ_FILTER);
 	UiReadSettingEEPROM_UInt8(EEPROM_FILTER_500HZ_SEL,&ts.filter_500Hz_select,FILTER_500HZ_DEFAULT,0,MAX_500HZ_FILTER);
 	UiReadSettingEEPROM_UInt8(EEPROM_FILTER_1K8_SEL,&ts.filter_1k8_select,FILTER_1K8_DEFAULT,0,MAX_1K8_FILTER);
@@ -8124,7 +8101,7 @@ uint16_t UiDriverSaveEepromValuesPowerDown(void)
 	UiReadWriteSettingEEPROM_UInt32_16(EEPROM_FREQ_STEP,df.selected_idx,3);
 	UiReadWriteSettingEEPROM_UInt16(EEPROM_TX_AUDIO_SRC,ts.tx_audio_source,0);
 	UiReadWriteSettingEEPROM_UInt16(EEPROM_TCXO_STATE,df.temp_enabled,0);
-	UiReadWriteSettingEEPROM_UInt16(EEPROM_AUDIO_GAIN,ts.audio_gain,DEFAULT_AUDIO_GAIN);
+	UiReadWriteSettingEEPROM_UInt16(EEPROM_AUDIO_GAIN,ts.rx_gain[RX_AUDIO_SPKR].value,DEFAULT_AUDIO_GAIN);
 	UiReadWriteSettingEEPROM_UInt16(EEPROM_RX_CODEC_GAIN,ts.rf_codec_gain,DEFAULT_RF_CODEC_GAIN_VAL);
 	UiReadWriteSettingEEPROM_Int32_16(EEPROM_RX_GAIN,ts.rf_gain,DEFAULT_RF_GAIN);
 	UiReadWriteSettingEEPROM_UInt16(EEPROM_NB_SETTING,ts.nb_setting,0);
@@ -8146,7 +8123,7 @@ uint16_t UiDriverSaveEepromValuesPowerDown(void)
 	UiReadWriteSettingEEPROM_UInt16(EEPROM_SPECTRUM_SCALE_COLOUR,ts.scope_scale_colour,SPEC_COLOUR_SCALE_DEFAULT);
 	UiReadWriteSettingEEPROM_UInt16(EEPROM_PADDLE_REVERSE,ts.paddle_reverse,0);
 	UiReadWriteSettingEEPROM_UInt16(EEPROM_CW_RX_DELAY,ts.cw_rx_delay,CW_RX_DELAY_DEFAULT);
-	UiReadWriteSettingEEPROM_UInt16(EEPROM_MAX_VOLUME,ts.audio_max_volume,MAX_VOLUME_DEFAULT);
+	UiReadWriteSettingEEPROM_UInt16(EEPROM_MAX_VOLUME,ts.rx_gain[RX_AUDIO_SPKR].max,MAX_VOLUME_DEFAULT);
 	UiReadWriteSettingEEPROM_UInt16(EEPROM_FILTER_300HZ_SEL,ts.filter_300Hz_select,FILTER_300HZ_DEFAULT);
 	UiReadWriteSettingEEPROM_UInt16(EEPROM_FILTER_500HZ_SEL,ts.filter_500Hz_select,FILTER_500HZ_DEFAULT);
 	UiReadWriteSettingEEPROM_UInt16(EEPROM_FILTER_1K8_SEL,ts.filter_1k8_select,FILTER_1K8_DEFAULT);

--- a/mchf-eclipse/drivers/ui/ui_driver.h
+++ b/mchf-eclipse/drivers/ui/ui_driver.h
@@ -542,13 +542,14 @@ void 	UiDriverSetBandPowerFactor(uchar band);
 void	UiCalcRxIqGainAdj(void);
 void	UiCalcTxIqGainAdj(void);
 //
+void    UiDriverChangeAudioGain(uchar enabled);
 void 	UiDriverChangeStGain(uchar enabled);
 void 	UiDriverChangeCmpLevel(uchar enabled);
 void 	UiDriverChangeKeyerSpeed(uchar enabled);
-void	UiDriverChangeAudioGain(uchar enabled);
 void 	UiDriverChangeRfGain(uchar enabled);
+void    UiDriverChangeAfGain(uchar enabled);
+
 //
-void 	UIDriverChangeAudioGain(uchar enabled);
 //
 void 	UiDriverShowStep(ulong step);
 //
@@ -618,8 +619,9 @@ void UiDriverMenuMapColors(uint32_t color ,char* options,volatile uint32_t* clr_
 #define	DEFAULT_RF_CODEC_GAIN_VAL	9		// Default RF gain setting (9 = AUTO mode)
 //
 #define	MAX_AUDIO_GAIN		30		// Maximum audio gain setting
+#define MAX_DIG_GAIN      31      // Maximum audio gain setting
 #define	DEFAULT_AUDIO_GAIN	16		// Default audio gain
-#define	DEFAULT_USB_GAIN	16		// Default audio gain
+#define	DEFAULT_DIG_GAIN	16		// Default audio gain
 //
 // The following are used in the max volume setting in the menu system
 //

--- a/mchf-eclipse/drivers/ui/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/ui_menu.c
@@ -1443,7 +1443,7 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode)
 				UiDriverChangeKeyerSpeed(0);
 			else
 				{
-				UIDriverChangeAudioGain(0);
+				UiDriverChangeAudioGain(0);
 				UiDriverUpdateMenu(0);
 				}
 		}
@@ -1473,7 +1473,7 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode)
 			if(ts.dmod_mode == DEMOD_CW)
 				UiDriverChangeKeyerSpeed(0);
 			else
-				UIDriverChangeAudioGain(0);
+				UiDriverChangeAudioGain(0);
 		}
 		//
 		if(ts.tx_audio_source != TX_AUDIO_MIC) {	// Orange if not in MIC-IN mode
@@ -1500,7 +1500,7 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode)
 			if(ts.dmod_mode == DEMOD_CW)
 				UiDriverChangeKeyerSpeed(0);
 			else	{		// in voice mode
-				UIDriverChangeAudioGain(0);
+				UiDriverChangeAudioGain(0);
 				if(ts.txrx_mode == TRX_MODE_TX)		// in transmit mode?
 					// TODO: Think about this, this is a hack
 					Codec_Line_Gain_Adj(ts.tx_gain[TX_AUDIO_LINEIN_L]);		// change codec gain
@@ -1606,7 +1606,7 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode)
 			if(ts.dmod_mode == DEMOD_CW)		// yes, update on-screen info
 				UiDriverChangeKeyerSpeed(0);
 			else
-				UIDriverChangeAudioGain(0);
+				UiDriverChangeAudioGain(0);
 		}
 		//
 		sprintf(options, "  %u", ts.keyer_speed);
@@ -2162,7 +2162,7 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode)
 //
 static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode)
 {
-	char options[32], temp[32];
+	char options[32];
 	ulong opt_pos;					// y position of option
 	static ulong opt_oldpos = 999;	// y position of option
 	uchar select;
@@ -2331,23 +2331,21 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode)
 		break;
 		//
 	case CONFIG_MAX_VOLUME:	// maximum audio volume
-		UiDriverMenuItemChangeUInt8(var, mode, &ts.audio_max_volume,
+		UiDriverMenuItemChangeUInt8(var, mode, &ts.rx_gain[RX_AUDIO_SPKR].max,
 						MAX_VOLUME_MIN,
 						MAX_VOLUME_MAX,
 						MAX_VOLUME_DEFAULT,
 						1
 						);
-		if(ts.audio_gain > ts.audio_max_volume)	{			// is the volume currently higher than the new setting?
-			ts.audio_gain = ts.audio_max_volume;		// yes - force the volume to the new value
-			//  TODO: Remove this display write
-			sprintf(temp,"%02d",ts.audio_gain);			// Update screen indicator
-			UiLcdHy28_PrintText((POS_AG_IND_X + 38),(POS_AG_IND_Y + 1), temp,White,Black,0);
+		if(ts.rx_gain[RX_AUDIO_SPKR].value > ts.rx_gain[RX_AUDIO_SPKR].max)	{			// is the volume currently higher than the new setting?
+			ts.rx_gain[RX_AUDIO_SPKR].value = ts.rx_gain[RX_AUDIO_SPKR].max;		// yes - force the volume to the new value
+			UiDriverChangeAfGain(0);
 		}
-		sprintf(options, "    %u", ts.audio_max_volume);
+		sprintf(options, "    %u", ts.rx_gain[RX_AUDIO_SPKR].value);
 		//
-		if(ts.audio_max_volume <= MAX_VOL_RED_THRESH)			// Indicate that gain has been reduced by changing color
+		if(ts.rx_gain[RX_AUDIO_SPKR].max <= MAX_VOL_RED_THRESH)			// Indicate that gain has been reduced by changing color
 			clr = Red;
-		else if(ts.audio_max_volume <= MAX_VOLT_YELLOW_THRESH)
+		else if(ts.rx_gain[RX_AUDIO_SPKR].max <= MAX_VOLT_YELLOW_THRESH)
 			clr = Orange;
 		break;
 	case CONFIG_MAX_RX_GAIN:	// maximum RX gain setting

--- a/mchf-eclipse/hardware/mchf_board.h
+++ b/mchf-eclipse/hardware/mchf_board.h
@@ -1203,6 +1203,14 @@ typedef struct FilterCoeffs
 	uint32_t	tx_i_block_size;
 } FilterCoeffs;
 
+typedef struct Gain_s {
+  uint8_t value;
+  uint8_t max;
+  uint8_t value_old;
+  float   active_value;
+} Gain;
+
+
 // Transceiver state public structure
 typedef struct TransceiverState
 {
@@ -1211,10 +1219,11 @@ typedef struct TransceiverState
 
 	// Virtual pots public values
 	short  	rit_value;
-	uchar 	audio_gain;
-	float	audio_gain_active;	// working variable for processing audio gain - used in rx audio function
-	uchar	audio_max_volume;	// limit for maximum audio gain
-	uchar   audio_gain_change;	// change detect for audio gain
+
+#define RX_AUDIO_SPKR 0
+#define RX_AUDIO_DIG  1
+	Gain    rx_gain[2]; //ts.rx_gain[RX_AUDIO_SPKR].value
+
 	int 	rf_gain;			// RF gain control
 	uchar	rf_codec_gain;		// gain for codec (A/D converter) in receive mode
 	uchar 	nb_setting;
@@ -1282,20 +1291,11 @@ typedef struct TransceiverState
 	//uchar	txrx_lock;
 	uchar	ptt_req;
 
-	// Unattended TX public flag
-	//uchar 	auto_mode;
 
 	// Demodulator mode public flag
 	uchar 	dmod_mode;
 
-	// Digital mode public flag
-	//uchar 	digi_mode;
 
-	// FIR encoder current mode
-	//uchar 	fir_enc_mode;
-
-	// Gain encoder current mode
-	//uchar 	gain_enc_mode;			// old var, to be removed
 	uchar 	enc_one_mode;
 	uchar 	enc_two_mode;
 	uchar 	enc_thr_mode;
@@ -1344,12 +1344,9 @@ typedef struct TransceiverState
 	uchar	power_level;
 
 	uchar 	tx_audio_source;
-	uchar   tx_line_channel;  // 1 LEFT 2 RIGHT
 	ulong	tx_mic_gain_mult;
-	ulong	tx_mic_gain_mult_temp;	// used to temporarily hold the mic gain when going from RX to TX
 	uchar	tx_gain[TX_AUDIO_NUM];
 	uchar	tx_comp_level;			// Used to hold compression level which is used to calculate other values for compression.  0 = manual.
-	uchar	rx_usb_gain;			// volume setting for usb audio out
 
 	// Microphone gain boost of +20dB via Codec command (TX)
 	uchar	mic_boost;

--- a/mchf-eclipse/main.c
+++ b/mchf-eclipse/main.c
@@ -700,10 +700,14 @@ void TransceiverStateInit(void)
 	ts.band_change		= 0;						// used in muting audio during band change
 	ts.filter_band		= 0;						// used to indicate the bpf filter selection for power detector coefficient selection
 	ts.dmod_mode 		= DEMOD_USB;				// demodulator mode
-	ts.audio_gain		= DEFAULT_AUDIO_GAIN;		// Set initial volume
-	ts.rx_usb_gain		= DEFAULT_USB_GAIN;
-	ts.audio_max_volume	= MAX_VOLUME_DEFAULT;		// Set max volume default
-	ts.audio_gain_active = 1;						// this variable is used in the active RX audio processing function
+	ts.rx_gain[RX_AUDIO_SPKR].value = DEFAULT_AUDIO_GAIN;
+	ts.rx_gain[RX_AUDIO_DIG].value		= DEFAULT_DIG_GAIN;
+
+	ts.rx_gain[RX_AUDIO_SPKR].max	= MAX_VOLUME_DEFAULT;		// Set max volume default
+    ts.rx_gain[RX_AUDIO_DIG].max   =  MAX_DIG_GAIN;       // Set max volume default
+
+	ts.rx_gain[RX_AUDIO_SPKR].active_value = 1;						// this variable is used in the active RX audio processing function
+	ts.rx_gain[RX_AUDIO_DIG].active_value = 1;                     // this variable is used in the active RX audio processing function
 	ts.rf_gain			= DEFAULT_RF_GAIN;			//
 	ts.max_rf_gain		= MAX_RF_GAIN_DEFAULT;		// setting for maximum gain (e.g. minimum S-meter reading)
 	ts.rf_codec_gain	= DEFAULT_RF_CODEC_GAIN_VAL;	// Set default RF gain (0 = lowest, 8 = highest, 9 = "Auto")
@@ -1150,7 +1154,7 @@ int main(void)
 	//
 	UiLoadBeepFreq();		// load/set beep frequency
 	//
-	ts.audio_gain_change = 99;		// Force update of volume control
+	ts.rx_gain[RX_AUDIO_SPKR].value_old = 99;		// Force update of volume control
 	uiCodecMute(0);					// make cure codec is un-muted
 
 	UiCheckForEEPROMLoadDefaultRequest();	// check - and act on - request for loading of EEPROM defaults, if any

--- a/mchf-eclipse/usb/usbd/class/audio/inc/usbd_audio_core.h
+++ b/mchf-eclipse/usb/usbd/class/audio/inc/usbd_audio_core.h
@@ -136,6 +136,7 @@ typedef struct UsbAudioUnit_s {
 	int16_t max;
 	uint16_t res;
 	int16_t cur;
+	uint8_t* ptr; // pointer to data structure which is used elsewhere to store volume
 } UsbAudioUnit;
 
 // In / Out Volume;

--- a/mchf-eclipse/usb/usbd/class/audio/src/usbd_audio_core.c
+++ b/mchf-eclipse/usb/usbd/class/audio/src/usbd_audio_core.c
@@ -231,7 +231,8 @@ UsbAudioUnit usbUnits[UnitMax] =
 				.min = -31 * 0x100,
 				.max = 0 * 0x100,
 				.res = 0x100,
-				.cur = -16* 0x100
+				.cur = -16* 0x100,
+				.ptr = &ts.tx_gain[TX_AUDIO_DIG]
 		},
 		{
 				.cs  = AUDIO_CONTROL_VOLUME,
@@ -239,7 +240,8 @@ UsbAudioUnit usbUnits[UnitMax] =
 				.min = -31 * 0x100,
 				.max = 0 * 0x100,
 				.res = 0x100,
-				.cur = -16* 0x100
+				.cur = -16* 0x100,
+				.ptr = &ts.rx_gain[RX_AUDIO_DIG].value
 		}
 
 };
@@ -833,7 +835,7 @@ static uint8_t  usbd_audio_EP0_RxReady (void  *pdev)
 		/* Check for which addressed unit the AudioControl request has been issued */
 		if (AudioCtlUnit == AUDIO_OUT_STREAMING_CTRL)
 		{/* In this driver, to simplify code, only one unit is manage */
-			/* Call the audio interface mute function */
+			/* Call the audio interface volume function */
 			int16_t val = *((int16_t*)&AudioCtl[0]);
 			retval = AUDIO_OUT_fops.VolumeCtl((val/0x100)+31);
 			usbUnits[UnitVolumeTX].cur = val;
@@ -1037,6 +1039,9 @@ static void AUDIO_Req_GetCurrent(void *pdev, USB_SETUP_REQ *req)
 		word[0] = unit->res;
 		break;
 	case AUDIO_REQ_GET_CUR:
+	    // we load the current value from the application layer and convert it.
+	    // not the most beautiful approach
+	    unit->cur = (((int16_t)(*unit->ptr))-31)*0x100;
 		word[0] = unit->cur;
 		break;
 	}

--- a/mchf-eclipse/usb/usbd/class/audio/src/usbd_audio_out_if.c
+++ b/mchf-eclipse/usb/usbd/class/audio/src/usbd_audio_out_if.c
@@ -401,6 +401,8 @@ static uint8_t  VolumeCtl    (uint8_t vol)
     return AUDIO_FAIL;
   }
 */
+  uint16_t source = ts.tx_audio_source == TX_AUDIO_DIGIQ?TX_AUDIO_DIGIQ:TX_AUDIO_DIG;
+  ts.tx_gain[source] = vol;
   return AUDIO_OK;
 }
 static uint8_t  InVolumeCtl    (uint8_t vol)
@@ -412,7 +414,7 @@ static uint8_t  InVolumeCtl    (uint8_t vol)
     return AUDIO_FAIL;
   }
 */
-  ts.rx_usb_gain = vol;
+  ts.rx_gain[RX_AUDIO_DIG].value = vol;
   return AUDIO_OK;
 }
 


### PR DESCRIPTION
Refactored RX GAIN to use data structure, so that SPKR and DIG USB RX gain
can be controlled using the same data structure.
Added support for controlling the DIG USB TX gain level from the PC.
Does not show automatically up in the TX gain control display on the mcHF
but takes effect immediately.