### PR TITLE
Filter Handling Improvements

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_filter.c
+++ b/mchf-eclipse/drivers/audio/audio_filter.c
@@ -76,38 +76,132 @@ static const FilterConfig filter_list_2P3KHz[] =      {
     {"   LPF",1150},
 } ;
 
+#define FILTER_ALL (FILTER_CW|FILTER_SSB|FILTER_AM|FILTER_FM)
+#define FILTER_NOFM (FILTER_CW|FILTER_SSB|FILTER_AM)
+#define FILTER_SSBAM (FILTER_SSB|FILTER_AM)
+#define FILTER_NONE (0)
+#define FILTER_SSBAMFM (FILTER_SSB|FILTER_AM|FILTER_FM)
 
 FilterDescriptor FilterInfo[AUDIO_FILTER_NUM] =
 {
-    // ID, NAME, MAX_CONFIG, , DEFAULT_CONFIG, CONFIG_LABELS
-    { AUDIO_300HZ, "300Hz", 300, 10, 6, filter_list_300Hz},
-    { AUDIO_500HZ, "500Hz", 500, 6, 3, filter_list_500Hz},
-    {  AUDIO_1P4KHZ, "1.4k",  1400, 3, 2, filter_stdLabelsLpfBpf},
-    {  AUDIO_1P6KHZ, "1.6k",  1600, 3, 2, filter_stdLabelsLpfBpf},
-    {  AUDIO_1P8KHZ, "1.8k",  1800, 7, 6, filter_list_1P8KHz},
-    {  AUDIO_2P1KHZ, "2.1k",  2100, 3, 2, filter_stdLabelsLpfBpf },
-    {  AUDIO_2P3KHZ, "2.3k",  2300, 6, 2, filter_list_2P3KHz },
-    {  AUDIO_2P5KHZ, "2.5k",  2500, 3, 2, filter_stdLabelsLpfBpf },
-    {  AUDIO_2P7KHZ, "2.7k",  2700, 3, 2, filter_stdLabelsLpfBpf },
-    {  AUDIO_2P9KHZ, "2.9k",  2900, 3, 2, filter_stdLabelsLpfBpf },
-    {  AUDIO_3P2KHZ, "3.2k",  3200, 3, 2, filter_stdLabelsLpfBpf },
-    {  AUDIO_3P4KHZ, "3.4k",  3400, 3, 2, filter_stdLabelsLpfBpf },
-    {  AUDIO_3P6KHZ, "3.6k",  3600, 3, 2, filter_stdLabelsLpfBpf },
-    {  AUDIO_3P8KHZ, "3.8k",  3800, 2, 1, filter_stdLabelsOnOff },
-    {  AUDIO_4P0KHZ, "4.0k",  4000, 2, 1, filter_stdLabelsOnOff },
-    {  AUDIO_4P2KHZ, "4.2k",  4200, 2, 1, filter_stdLabelsOnOff },
-    {  AUDIO_4P4KHZ, "4.4k",  4400, 2, 1, filter_stdLabelsOnOff },
-    {  AUDIO_4P6KHZ, "4.6k",  4600, 2, 1, filter_stdLabelsOnOff },
-    {  AUDIO_4P8KHZ, "4.8k",  4800, 2, 1, filter_stdLabelsOnOff },
-    {  AUDIO_5P0KHZ, "5.0k",  5000, 2, 1, filter_stdLabelsOnOff },
-    {  AUDIO_5P5KHZ, "5.5k",  5500, 2, 1, filter_stdLabelsOnOff },
-    {  AUDIO_6P0KHZ, "6.0k",  6000, 2, 1, filter_stdLabelsOnOff },
-    {  AUDIO_6P5KHZ, "6.5k",  6500, 2, 1, filter_stdLabelsOnOff },
-    {  AUDIO_7P0KHZ, "7.0k",  7000, 2, 1, filter_stdLabelsOnOff },
-    {  AUDIO_7P5KHZ, "7.5k",  7500, 2, 1, filter_stdLabelsOnOff },
-    {  AUDIO_8P0KHZ, "8.0k",  8000, 2, 1, filter_stdLabelsOnOff },
-    {  AUDIO_8P5KHZ, "8.5k",  8500, 2, 1, filter_stdLabelsOnOff },
-    {  AUDIO_9P0KHZ, "9.0k",  9000, 2, 1, filter_stdLabelsOnOff },
-    {  AUDIO_9P5KHZ, "9.5k",  9500, 2, 1, filter_stdLabelsOnOff },
-    {  AUDIO_10P0KHZ, "10k", 10000 ,2, 1, filter_stdLabelsOnOff }
+    // ID, NAME, MAX_CONFIG, VALID MODES, ALWAYS IN MODE , DEFAULT_CONFIG, CONFIG_LABELS
+    {  AUDIO_300HZ, "300Hz",   300, FILTER_NOFM,    FILTER_CW,  10, 6, filter_list_300Hz},
+    {  AUDIO_500HZ, "500Hz",   500, FILTER_NOFM,    FILTER_CW,   6, 3, filter_list_500Hz},
+    {  AUDIO_1P4KHZ, "1.4k",  1400, FILTER_SSBAM,   FILTER_NONE, 3, 2, filter_stdLabelsLpfBpf},
+    {  AUDIO_1P6KHZ, "1.6k",  1600, FILTER_SSBAM,   FILTER_NONE, 3, 2, filter_stdLabelsLpfBpf},
+    {  AUDIO_1P8KHZ, "1.8k",  1800, FILTER_SSBAM,   FILTER_SSB,  7, 6, filter_list_1P8KHz},
+    {  AUDIO_2P1KHZ, "2.1k",  2100, FILTER_SSBAM,   FILTER_NONE, 3, 2, filter_stdLabelsLpfBpf },
+    {  AUDIO_2P3KHZ, "2.3k",  2300, FILTER_SSBAM,   FILTER_SSB,  6, 2, filter_list_2P3KHz },
+    {  AUDIO_2P5KHZ, "2.5k",  2500, FILTER_SSBAMFM, FILTER_FM,   3, 2, filter_stdLabelsLpfBpf },
+    {  AUDIO_2P7KHZ, "2.7k",  2700, FILTER_NOFM,    FILTER_NONE, 3, 2, filter_stdLabelsLpfBpf },
+    {  AUDIO_2P9KHZ, "2.9k",  2900, FILTER_SSBAM,   FILTER_AM,   3, 2, filter_stdLabelsLpfBpf },
+    {  AUDIO_3P2KHZ, "3.2k",  3200, FILTER_SSBAM,   FILTER_NONE, 3, 2, filter_stdLabelsLpfBpf },
+    {  AUDIO_3P4KHZ, "3.4k",  3400, FILTER_SSBAM,   FILTER_NONE, 3, 2, filter_stdLabelsLpfBpf },
+    {  AUDIO_3P6KHZ, "3.6k",  3600, FILTER_SSBAM,   FILTER_NONE, 3, 2, filter_stdLabelsLpfBpf },
+    {  AUDIO_3P8KHZ, "3.8k",  3800, FILTER_SSBAM,   FILTER_NONE, 2, 1, filter_stdLabelsOnOff },
+    {  AUDIO_4P0KHZ, "4.0k",  4000, FILTER_SSBAM,   FILTER_NONE, 2, 1, filter_stdLabelsOnOff },
+    {  AUDIO_4P2KHZ, "4.2k",  4200, FILTER_SSBAM,   FILTER_NONE, 2, 1, filter_stdLabelsOnOff },
+    {  AUDIO_4P4KHZ, "4.4k",  4400, FILTER_NOFM,    FILTER_NONE, 2, 1, filter_stdLabelsOnOff },
+    {  AUDIO_4P6KHZ, "4.6k",  4600, FILTER_SSBAM,   FILTER_NONE, 2, 1, filter_stdLabelsOnOff },
+    {  AUDIO_4P8KHZ, "4.8k",  4800, FILTER_SSBAM,   FILTER_NONE, 2, 1, filter_stdLabelsOnOff },
+    {  AUDIO_5P0KHZ, "5.0k",  5000, FILTER_SSBAMFM, FILTER_FM,   2, 1, filter_stdLabelsOnOff },
+    {  AUDIO_5P5KHZ, "5.5k",  5500, FILTER_SSBAM,   FILTER_NONE, 2, 1, filter_stdLabelsOnOff },
+    {  AUDIO_6P0KHZ, "6.0k",  6000, FILTER_SSBAM,   FILTER_NONE, 2, 1, filter_stdLabelsOnOff },
+    {  AUDIO_6P5KHZ, "6.5k",  6500, FILTER_SSBAM,   FILTER_NONE, 2, 1, filter_stdLabelsOnOff },
+    {  AUDIO_7P0KHZ, "7.0k",  7000, FILTER_SSBAM,   FILTER_NONE, 2, 1, filter_stdLabelsOnOff },
+    {  AUDIO_7P5KHZ, "7.5k",  7500, FILTER_SSBAM,   FILTER_NONE, 2, 1, filter_stdLabelsOnOff },
+    {  AUDIO_8P0KHZ, "8.0k",  8000, FILTER_SSBAM,   FILTER_NONE, 2, 1, filter_stdLabelsOnOff },
+    {  AUDIO_8P5KHZ, "8.5k",  8500, FILTER_SSBAM,   FILTER_NONE, 2, 1, filter_stdLabelsOnOff },
+    {  AUDIO_9P0KHZ, "9.0k",  9000, FILTER_SSBAM,   FILTER_NONE, 2, 1, filter_stdLabelsOnOff },
+    {  AUDIO_9P5KHZ, "9.5k",  9500, FILTER_SSBAM,   FILTER_NONE, 2, 1, filter_stdLabelsOnOff },
+    {  AUDIO_10P0KHZ, "10k", 10000, FILTER_SSBAM,   FILTER_NONE, 2, 1, filter_stdLabelsOnOff }
 };
+
+
+/*
+ * @brief Find Next Applicable Filter based on the information in the filter data structure
+ *
+ * Takes into account the current mode (SSB, CW, ..., some special rules, etc,). It will wrap around and always return a
+ * valid filter id. In case not applicable filter was found, it returns the currently selected filter_id
+ *
+ * @returns next applicable filter id
+ */
+uint8_t AudioFilter_NextApplicableFilter()
+{
+
+  bool  voice_mode;
+  uint8_t retval = ts.filter_id;
+  // by default we do not change the filter selection
+
+  uint16_t myMode;
+  switch(ts.dmod_mode) {
+  case DEMOD_AM:
+    myMode = FILTER_AM;
+    break;
+  case DEMOD_FM:
+    myMode = FILTER_FM;
+    break;
+  case DEMOD_CW:
+    myMode = FILTER_CW;
+    break;
+  // case DEMOD_LSB:
+  // case DEMOD_USB:
+  // case DEMOD_DIGI:
+  default:
+    myMode = FILTER_SSB;
+  }
+
+  if(ts.dmod_mode != DEMOD_FM) {        // bail out if FM as filters are selected in configuration menu
+    int idx;
+
+    //
+    // Scan through filters to determine if the selected filter is disabled - and skip if it is.
+    // NOTE:  The 2.3 kHz filter CANNOT be disabled
+    //
+    // This also handles filters that are disabled according to mode (e.g. CW filters in SSB mode, SSB filters in CW mode)
+    //
+
+    if((ts.dmod_mode == DEMOD_USB) || (ts.dmod_mode == DEMOD_LSB) || (ts.dmod_mode == DEMOD_AM))    // check to see if we are set to a "voice" mode
+    {
+      voice_mode = 1;
+    } else {                    // not in voice mode
+      voice_mode = 0;
+    }
+
+    // we run through all audio filters, starting with the next following, making sure to wrap around
+    // we leave this loop once we found a filter that is applicable using "break"
+    // or skip to next filter to check using "continue"
+    for (idx = (ts.filter_id+1)%AUDIO_FILTER_NUM; idx != ts.filter_id; idx = (idx+1)%AUDIO_FILTER_NUM)
+    {
+
+      // these rules handle special cases
+      if((idx == AUDIO_1P8KHZ) && ((ts.filter_cw_wide_disable) && (ts.dmod_mode == DEMOD_CW))) { idx = AUDIO_300HZ; break; }
+      // in this case, next applicable mode is 300 Hz, so selected and leave loop
+
+      // we have to check if this mode is IN the list of modes always offered in this mode, regardless of enablement
+      if ((FilterInfo[idx].always_on_modes & myMode) != 0) {
+              // okay, applicable, leave loop
+              break;
+      }
+
+      // now the rules for excluding a mode follow, in this case we call continue to go to next filter
+
+      // not enable; next please
+      if (!ts.filter_select[idx]) { continue; }
+
+      if((idx == AUDIO_300HZ || idx == AUDIO_500HZ) && ((ts.filter_ssb_narrow_disable) && (voice_mode))) { continue; }
+      // jump over 300 Hz / 500 Hz if ssb_narrow_disable and voice mode
+
+      // last we have to check if this mode is NOT in the list of allowed modes for the filter
+      if ((FilterInfo[idx].allowed_modes & myMode) == 0) {
+        // okay, not applicable, next please
+        continue;
+      }
+
+      // if we have arrived here, all is good, we can  use the index, so lets bail out here
+      break;
+    }
+    retval = idx;
+  }
+  return retval;
+}

--- a/mchf-eclipse/drivers/audio/audio_filter.h
+++ b/mchf-eclipse/drivers/audio/audio_filter.h
@@ -57,6 +57,13 @@ enum    {
     AUDIO_10P0KHZ,
     AUDIO_FILTER_NUM
 };
+
+enum {
+  FILTER_CW = 1,
+  FILTER_SSB = 2,
+  FILTER_AM = 4,
+  FILTER_FM = 8
+};
 //
 //
 #define AUDIO_DEFAULT_FILTER        AUDIO_2P3KHZ
@@ -79,6 +86,8 @@ typedef struct FilterDescriptor_s {
   const uint8_t id;
   const char* name;
   const uint16_t width;
+  const uint16_t allowed_modes;
+  const uint16_t always_on_modes;
   const uint8_t configs_num;
   const uint8_t config_default;
   const FilterConfig* config;
@@ -112,6 +121,8 @@ enum    {
 //
 #define HILBERT3600         1900    // "width" of "3.6 kHz" Hilbert filter - This used to depict FM detection bandwidth
 //
+
+uint8_t AudioFilter_NextApplicableFilter();
 
 
 #endif /* DRIVERS_AUDIO_AUDIO_FILTER_H_ */

--- a/mchf-eclipse/drivers/ui/ui_configuration.c
+++ b/mchf-eclipse/drivers/ui/ui_configuration.c
@@ -591,8 +591,74 @@ static void UiReadWriteSettingsBandMode(const uint16_t i,const uint16_t band_mod
     // Try to read Freq saved values - update if changed
     UiReadWriteSettingEEPROM_UInt32(band_freq_high+i,band_freq_low+i, vforeg->dial_value, vforeg->dial_value);
 }
+#define UiReadSettingFilter(EEID,FID)  UiReadSettingEEPROM_UInt8((EEID),&ts.filter_select[(FID)],FilterInfo[(FID)].config_default,0,FilterInfo[(FID)].configs_num-1);
 
 
+void UiReadWriteSettingEEPROM_Filter()
+{
+  UiReadWriteSettingEEPROM_UInt16(EEPROM_FILTER_300HZ_SEL,ts.filter_select[AUDIO_300HZ],FilterInfo[AUDIO_300HZ].config_default);
+  UiReadWriteSettingEEPROM_UInt16(EEPROM_FILTER_500HZ_SEL,ts.filter_select[AUDIO_500HZ],FilterInfo[AUDIO_500HZ].config_default);
+  UiReadWriteSettingEEPROM_UInt16(EEPROM_FILTER_1K4_SEL,ts.filter_select[AUDIO_1P4KHZ],FilterInfo[AUDIO_1P4KHZ].config_default);
+  UiReadWriteSettingEEPROM_UInt16(EEPROM_FILTER_1K6_SEL,ts.filter_select[AUDIO_1P6KHZ],FilterInfo[AUDIO_1P6KHZ].config_default);
+  UiReadWriteSettingEEPROM_UInt16(EEPROM_FILTER_1K8_SEL,ts.filter_select[AUDIO_1P8KHZ],FilterInfo[AUDIO_1P8KHZ].config_default);
+  UiReadWriteSettingEEPROM_UInt16(EEPROM_FILTER_2K1_SEL,ts.filter_select[AUDIO_2P1KHZ],FilterInfo[AUDIO_2P1KHZ].config_default);
+  UiReadWriteSettingEEPROM_UInt16(EEPROM_FILTER_2K3_SEL,ts.filter_select[AUDIO_2P3KHZ],FilterInfo[AUDIO_2P3KHZ].config_default);
+  UiReadWriteSettingEEPROM_UInt16(EEPROM_FILTER_2K5_SEL,ts.filter_select[AUDIO_2P5KHZ],FilterInfo[AUDIO_2P5KHZ].config_default);
+  UiReadWriteSettingEEPROM_UInt16(EEPROM_FILTER_2K7_SEL,ts.filter_select[AUDIO_2P7KHZ],FilterInfo[AUDIO_2P7KHZ].config_default);
+  UiReadWriteSettingEEPROM_UInt16(EEPROM_FILTER_2K9_SEL,ts.filter_select[AUDIO_2P9KHZ],FilterInfo[AUDIO_2P9KHZ].config_default);
+  UiReadWriteSettingEEPROM_UInt16(EEPROM_FILTER_3K2_SEL,ts.filter_select[AUDIO_3P2KHZ],FilterInfo[AUDIO_3P2KHZ].config_default);
+  UiReadWriteSettingEEPROM_UInt16(EEPROM_FILTER_3K4_SEL,ts.filter_select[AUDIO_3P4KHZ],FilterInfo[AUDIO_3P4KHZ].config_default);
+  UiReadWriteSettingEEPROM_UInt16(EEPROM_FILTER_3K6_SEL,ts.filter_select[AUDIO_3P6KHZ],FilterInfo[AUDIO_3P6KHZ].config_default);
+  UiReadWriteSettingEEPROM_UInt16(EEPROM_FILTER_3K8_SEL,ts.filter_select[AUDIO_3P8KHZ],FilterInfo[AUDIO_3P8KHZ].config_default);
+
+
+    // for filters above 3k8 we have only a single bit setting, this does not work with filters
+    // having more than on/off !
+    {
+      uint32_t filter_map = 0;
+      int idx, bit = 0;
+      for (idx = AUDIO_4P0KHZ; idx < AUDIO_MAX_FILTER && bit < 32; idx++,bit++) {
+        filter_map |=(ts.filter_select[idx]!=0?1:0)<<bit;
+      }
+      UiReadWriteSettingEEPROM_UInt32(EEPROM_FILTER_2_SEL,EEPROM_FILTER_1_SEL,filter_map,0x0000);
+
+    }
+
+}
+
+void UiReadSettingEEPROM_Filter()
+{
+
+    UiReadSettingFilter(EEPROM_FILTER_300HZ_SEL,AUDIO_300HZ);
+    UiReadSettingFilter(EEPROM_FILTER_500HZ_SEL,AUDIO_500HZ);
+    UiReadSettingFilter(EEPROM_FILTER_1K4_SEL,AUDIO_1P4KHZ);
+    UiReadSettingFilter(EEPROM_FILTER_1K6_SEL,AUDIO_1P6KHZ);
+    UiReadSettingFilter(EEPROM_FILTER_1K8_SEL,AUDIO_1P8KHZ);
+    UiReadSettingFilter(EEPROM_FILTER_2K1_SEL,AUDIO_2P1KHZ);
+    UiReadSettingFilter(EEPROM_FILTER_2K3_SEL,AUDIO_2P3KHZ);
+    UiReadSettingFilter(EEPROM_FILTER_2K5_SEL,AUDIO_2P5KHZ);
+    UiReadSettingFilter(EEPROM_FILTER_2K7_SEL,AUDIO_2P7KHZ);
+    UiReadSettingFilter(EEPROM_FILTER_2K9_SEL,AUDIO_2P9KHZ);
+    UiReadSettingFilter(EEPROM_FILTER_3K2_SEL,AUDIO_3P2KHZ);
+    UiReadSettingFilter(EEPROM_FILTER_3K4_SEL,AUDIO_3P4KHZ);
+    UiReadSettingFilter(EEPROM_FILTER_3K6_SEL,AUDIO_3P6KHZ);
+    UiReadSettingFilter(EEPROM_FILTER_3K8_SEL,AUDIO_3P8KHZ);
+
+    // for filters above 3k8 we have only a single bit setting, this does not work with filters
+    // having more than on/off !
+    {
+
+      uint32_t filter_map = 0;
+      int idx, bit = 0;
+      UiReadSettingEEPROM_UInt32(EEPROM_FILTER_2_SEL,EEPROM_FILTER_1_SEL,&filter_map,0x0000,0x0000,0xFFFF);
+
+      for (idx = AUDIO_4P0KHZ; idx < AUDIO_MAX_FILTER && bit < 32; idx++,bit++) {
+        ts.filter_select[idx] = (filter_map&(1<<bit))!=0?1:0;
+      }
+
+    }
+
+}
 //
 //*----------------------------------------------------------------------------
 //* Function Name       : UiDriverLoadEepromValues
@@ -701,24 +767,7 @@ void UiConfiguration_LoadEepromValues(void)
     UiReadSettingEEPROM_UInt8(EEPROM_CW_RX_DELAY,&ts.cw_rx_delay,CW_RX_DELAY_DEFAULT,0,CW_RX_DELAY_MAX);
     UiReadSettingEEPROM_UInt8(EEPROM_MAX_VOLUME,&ts.rx_gain[RX_AUDIO_SPKR].max,MAX_VOLUME_DEFAULT,MAX_VOLUME_MIN,MAX_VOLUME_MAX);
 
-#define UiReadSettingFilter(EEID,FID)  UiReadSettingEEPROM_UInt8((EEID),&ts.filter_select[(FID)],FilterInfo[(FID)].config_default,0,FilterInfo[(FID)].configs_num-1);
-
-    UiReadSettingFilter(EEPROM_FILTER_300HZ_SEL,AUDIO_300HZ);
-    UiReadSettingFilter(EEPROM_FILTER_500HZ_SEL,AUDIO_500HZ);
-    UiReadSettingFilter(EEPROM_FILTER_1K4_SEL,AUDIO_1P4KHZ);
-    UiReadSettingFilter(EEPROM_FILTER_1K6_SEL,AUDIO_1P6KHZ);
-    UiReadSettingFilter(EEPROM_FILTER_1K8_SEL,AUDIO_1P8KHZ);
-    UiReadSettingFilter(EEPROM_FILTER_2K1_SEL,AUDIO_2P1KHZ);
-    UiReadSettingFilter(EEPROM_FILTER_2K3_SEL,AUDIO_2P3KHZ);
-    UiReadSettingFilter(EEPROM_FILTER_2K5_SEL,AUDIO_2P5KHZ);
-    UiReadSettingFilter(EEPROM_FILTER_2K7_SEL,AUDIO_2P7KHZ);
-    UiReadSettingFilter(EEPROM_FILTER_2K9_SEL,AUDIO_2P9KHZ);
-    UiReadSettingFilter(EEPROM_FILTER_3K2_SEL,AUDIO_3P2KHZ);
-    UiReadSettingFilter(EEPROM_FILTER_3K4_SEL,AUDIO_3P4KHZ);
-    UiReadSettingFilter(EEPROM_FILTER_3K6_SEL,AUDIO_3P6KHZ);
-    UiReadSettingFilter(EEPROM_FILTER_3K8_SEL,AUDIO_3P8KHZ);
-    // UiReadSettingFilter(EEPROM_FILTER_1_SEL,&ts.filter_1,0,0,255);
-    // UiReadSettingFilter(EEPROM_FILTER_2_SEL,&ts.filter_2,0,0,255);
+    UiReadSettingEEPROM_Filter();
 
     //  UiReadSettingFilter(EEPROM_FILTER_WIDE_SEL,&ts.filter_wide_select,FILTER_WIDE_DEFAULT,0,WIDE_FILTER_MAX);
     UiReadSettingEEPROM_UInt8(EEPROM_PA_BIAS,&ts.pa_bias,DEFAULT_PA_BIAS,0,MAX_PA_BIAS);
@@ -968,23 +1017,8 @@ uint16_t UiConfiguration_SaveEepromValues(void)
     UiReadWriteSettingEEPROM_UInt16(EEPROM_CW_RX_DELAY,ts.cw_rx_delay,CW_RX_DELAY_DEFAULT);
     UiReadWriteSettingEEPROM_UInt16(EEPROM_MAX_VOLUME,ts.rx_gain[RX_AUDIO_SPKR].max,MAX_VOLUME_DEFAULT);
 
-    UiReadWriteSettingEEPROM_UInt16(EEPROM_FILTER_300HZ_SEL,ts.filter_select[AUDIO_300HZ],FilterInfo[AUDIO_300HZ].config_default);
-    UiReadWriteSettingEEPROM_UInt16(EEPROM_FILTER_500HZ_SEL,ts.filter_select[AUDIO_500HZ],FilterInfo[AUDIO_500HZ].config_default);
-    UiReadWriteSettingEEPROM_UInt16(EEPROM_FILTER_1K4_SEL,ts.filter_select[AUDIO_1P4KHZ],FilterInfo[AUDIO_1P4KHZ].config_default);
-    UiReadWriteSettingEEPROM_UInt16(EEPROM_FILTER_1K6_SEL,ts.filter_select[AUDIO_1P6KHZ],FilterInfo[AUDIO_1P6KHZ].config_default);
-    UiReadWriteSettingEEPROM_UInt16(EEPROM_FILTER_1K8_SEL,ts.filter_select[AUDIO_1P8KHZ],FilterInfo[AUDIO_1P8KHZ].config_default);
-    UiReadWriteSettingEEPROM_UInt16(EEPROM_FILTER_2K1_SEL,ts.filter_select[AUDIO_2P1KHZ],FilterInfo[AUDIO_2P1KHZ].config_default);
-    UiReadWriteSettingEEPROM_UInt16(EEPROM_FILTER_2K3_SEL,ts.filter_select[AUDIO_2P3KHZ],FilterInfo[AUDIO_2P3KHZ].config_default);
-    UiReadWriteSettingEEPROM_UInt16(EEPROM_FILTER_2K5_SEL,ts.filter_select[AUDIO_2P5KHZ],FilterInfo[AUDIO_2P5KHZ].config_default);
-    UiReadWriteSettingEEPROM_UInt16(EEPROM_FILTER_2K7_SEL,ts.filter_select[AUDIO_2P7KHZ],FilterInfo[AUDIO_2P7KHZ].config_default);
-    UiReadWriteSettingEEPROM_UInt16(EEPROM_FILTER_2K9_SEL,ts.filter_select[AUDIO_2P9KHZ],FilterInfo[AUDIO_2P9KHZ].config_default);
-    UiReadWriteSettingEEPROM_UInt16(EEPROM_FILTER_3K2_SEL,ts.filter_select[AUDIO_3P2KHZ],FilterInfo[AUDIO_3P2KHZ].config_default);
-    UiReadWriteSettingEEPROM_UInt16(EEPROM_FILTER_3K4_SEL,ts.filter_select[AUDIO_3P4KHZ],FilterInfo[AUDIO_3P4KHZ].config_default);
-    UiReadWriteSettingEEPROM_UInt16(EEPROM_FILTER_3K6_SEL,ts.filter_select[AUDIO_3P6KHZ],FilterInfo[AUDIO_3P6KHZ].config_default);
-    UiReadWriteSettingEEPROM_UInt16(EEPROM_FILTER_3K8_SEL,ts.filter_select[AUDIO_3P8KHZ],FilterInfo[AUDIO_3P8KHZ].config_default);
-    //UiReadWriteSettingEEPROM_UInt16(EEPROM_FILTER_1_SEL,ts.filter_1,0);
-    //UiReadWriteSettingEEPROM_UInt16(EEPROM_FILTER_2_SEL,ts.filter_2,0);
-//  UiReadWriteSettingEEPROM_UInt16(EEPROM_FILTER_WIDE_SEL,ts.filter_wide_select,FILTER_WIDE_DEFAULT);
+    UiReadWriteSettingEEPROM_Filter();
+
     UiReadWriteSettingEEPROM_UInt16(EEPROM_PA_BIAS,ts.pa_bias,DEFAULT_PA_BIAS);
     UiReadWriteSettingEEPROM_UInt16(EEPROM_PA_CW_BIAS,ts.pa_cw_bias,DEFAULT_PA_BIAS);
     UiReadWriteSettingEEPROM_Int32_16(EEPROM_TX_IQ_LSB_GAIN_BALANCE,ts.tx_iq_lsb_gain_balance,0);

--- a/mchf-eclipse/drivers/ui/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/ui_menu.c
@@ -473,7 +473,7 @@ static char* conf_screens[20][MENUSIZE] = {
 		"502-1.4k Filter",
 },
 { // 17
-		"503-1.6k Filter"
+		"503-1.6k Filter",
 		"505-2.1k Filter",
 		"507-2.5k Filter",
 		"509-2.9k Filter",
@@ -481,7 +481,7 @@ static char* conf_screens[20][MENUSIZE] = {
 		"511-3.4k Filter"
 },
 { // 18
-		"513-3.8k Filter"
+		"513-3.8k Filter",
 		"514-4.0k Filter",
 		"515-4.2k Filter",
 		"517-4.6k Filter",
@@ -489,7 +489,7 @@ static char* conf_screens[20][MENUSIZE] = {
 		"519-5.0k Filter"
 },
 { // 19
-		"520-5.5k Filter"
+		"520-5.5k Filter",
 		"522-6.5k Filter",
 		"523-7.0k Filter",
 		"524-7.5k Filter",
@@ -497,11 +497,11 @@ static char* conf_screens[20][MENUSIZE] = {
 		"526-8.5k Filter"
 },
 { // 20
-		"527-9.0k Filter"
+		"527-9.0k Filter",
 		"528-9.5k Filter",
 		"529-10.0k Filter",
-		"DSP NR (EXPERIMENTAL)"
-		"400-CAT-IQ-FREQ-XLAT"," ",
+		"DSP NR (EXPERIMENTAL)",
+		"400-CAT-IQ-FREQ-XLAT",
 		" "
 }
 };


### PR DESCRIPTION
Based on  DD4WH new set of filters, the logic
of filter selection handling was refactored.
Loading and storing of all filters works as expected.
Open Issues: Filter Label Length Alignment, so that menus and label
in main  screen look nice again.
FM Filter selection seems to be broken and is not yet completely
included in the refactoring due lack of knowledge regarding FM.

Also still to be done is to include the filter tables in the FilterConfig
structures, would clean up a lot in audio_driver.c
But this should be not too difficult for a filter expert.