### PR TITLE
reviewed FilterPath code in audio_driver.c

### DIFF
--- a/mchf-eclipse/.settings/language.settings.xml
+++ b/mchf-eclipse/.settings/language.settings.xml
@@ -5,7 +5,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-997235909776597029" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings Cross ARM" parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-994311972106045477" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings Cross ARM" parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>
@@ -16,7 +16,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-1069506505916026015" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings Cross ARM" parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-1052375410106970143" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings Cross ARM" parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>

--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -289,7 +289,7 @@ void audio_driver_set_rx_audio_filter(void)
 	// to do: implement switching according to FilterPathInfo
 	// ts.filter_id & ts.dmod_mode & ts.filter_select
 
-	if (ts.filter_path == 0 ) {
+	if (ts.filter_path == 0 ) {  // for the moment, everything remains as-is until new filter path structure works
 
 	switch(ts.filter_id)	{
 		case AUDIO_300HZ:
@@ -601,12 +601,15 @@ void audio_driver_set_rx_audio_filter(void)
 		default:
 			break;
 	}
-	} else {
+	}  // HERE (after the "else") the new filter switching starts !!!
+
+	else {
         IIR_PreFilter.numStages = FilterPathInfo[ts.filter_path-1].IIR_PreFilter_numTaps;        // number of stages
         IIR_PreFilter.pkCoeffs = (float *)FilterPathInfo[ts.filter_path-1].IIR_PreFilter_pk_file; // point to reflection coefficients
-        IIR_PreFilter.pvCoeffs = (float *)FilterPathInfo[ts.filter_path-1].IIR_PreFilter_pk_file; // point to ladder coefficients
-
+        IIR_PreFilter.pvCoeffs = (float *)FilterPathInfo[ts.filter_path-1].IIR_PreFilter_pv_file; // point to ladder coefficients
 	}
+
+
 	//
 	// Initialize IIR filter state buffer
  	//
@@ -618,16 +621,15 @@ void audio_driver_set_rx_audio_filter(void)
 	//
 	// Initialize IIR antialias filter state buffer
  	//
-	// TODO: Review FilterPath Code
+	// TODO: Review FilterPath Code --> DONE, DD4WH 2016_03_13
 	if (ts.filter_path == 0) {
 	  IIR_AntiAlias.numStages = IIR_aa_5k_numStages;		// number of stages
 	  IIR_AntiAlias.pkCoeffs = (float *)IIR_aa_5k_pkCoeffs;	// point to reflection coefficients
 	  IIR_AntiAlias.pvCoeffs = (float *)IIR_aa_5k_pvCoeffs;	// point to ladder coefficients
 	} else {
-
-	  IIR_AntiAlias.numStages = IIR_aa_5k_numStages;      // number of stages
-	  IIR_AntiAlias.pkCoeffs = (float *)IIR_aa_5k_pkCoeffs;   // point to reflection coefficients
-	  IIR_AntiAlias.pvCoeffs = (float *)IIR_aa_5k_pvCoeffs;   // point to ladder coefficients
+		IIR_AntiAlias.numStages = FilterPathInfo[ts.filter_path-1].IIR_int_numTaps;        // number of stages
+        IIR_AntiAlias.pkCoeffs = (float *)FilterPathInfo[ts.filter_path-1].IIR_int_pk_file; // point to reflection coefficients
+        IIR_AntiAlias.pvCoeffs = (float *)FilterPathInfo[ts.filter_path-1].IIR_int_pv_file; // point to ladder coefficients
 	}
 
     for(i = 0; i < FIR_RXAUDIO_BLOCK_SIZE+FIR_RXAUDIO_NUM_TAPS-1; i++)	{	// initialize state buffer to zeroes
@@ -639,6 +641,7 @@ void audio_driver_set_rx_audio_filter(void)
 	// Initialize high-pass filter used for the FM noise squelch
 	//
     // TODO: Review FilterPath Code
+	// NOT NECESSARY: this filter is always the same in FM !
 	if (ts.filter_path == 0) {
 	  IIR_Squelch_HPF.numStages = IIR_15k_hpf_numStages;		// number of stages
 	  IIR_Squelch_HPF.pkCoeffs = (float *)IIR_15k_hpf_pkCoeffs;	// point to reflection coefficients
@@ -759,6 +762,7 @@ void audio_driver_set_rx_audio_filter(void)
 	// Adjust decimation rate based on selected filter
 	//
     // TODO: Review FilterPath Code
+	// DONE: DD4WH 2016_03_13
     if (ts.filter_path != 0) {
       ads.decimation_rate = FilterPathInfo[ts.filter_path-1].sample_rate_dec;
       DECIMATE_RX.pCoeffs = (float32_t *)FilterPathInfo[ts.filter_path-1].FIR_dec_coeff_file;       // Filter coefficients for lower-rate (slightly strong LPF)
@@ -774,7 +778,8 @@ void audio_driver_set_rx_audio_filter(void)
 		DECIMATE_RX.pCoeffs = (float32_t *)&FirRxDecimateMinLPF[0];	// Filter coefficients for higher rate (weak LPF:  Hilbert is used for main LPF!)
 		INTERPOLATE_RX.pCoeffs = (float32_t *)&FirRxInterpolate10KHZ[0];	// Filter coefficients for higher rate (relaxed LPF)
 	}										// FM - no decimation
-	if(ts.dmod_mode == DEMOD_FM)
+
+    if(ts.dmod_mode == DEMOD_FM)
 		ads.decimation_rate = RX_DECIMATION_RATE_48KHZ;		//
 	//
 	//
@@ -797,6 +802,7 @@ void audio_driver_set_rx_audio_filter(void)
 	//
 	INTERPOLATE_RX.L = ads.decimation_rate;			// Interpolation factor, L  (12 kHz * 4 = 48 kHz)
 	// TODO: Review FilterPath Code
+	// DONE: DD4WH 2016_03_13
 	if (ts.filter_path != 0) {
 	  INTERPOLATE_RX.phaseLength = FilterPathInfo[ts.filter_path-1].FIR_int_numTaps/ads.decimation_rate;    // Phase Length ( numTaps / L )
 	} else {
@@ -839,6 +845,7 @@ void Audio_TXFilter_Init(void)
 	//
 	if(ts.dmod_mode != DEMOD_FM)	{						// not FM - use bandpass filter that restricts low and, stops at 2.7 kHz
 	  // TODO: Review FilterPath Code
+		// We have not (yet?) coded TX filters in the FilterPathInfo!
 	  if (ts.filter_path != 0) {
 	    IIR_TXFilter.numStages = IIR_TX_2k7_numStages;		// number of stages
 	    IIR_TXFilter.pkCoeffs = (float *)IIR_TX_2k7_pkCoeffs;	// point to reflection coefficients
@@ -1706,7 +1713,14 @@ static void audio_rx_processor(int16_t *src, int16_t *dst, int16_t size)
 		//
 		// ------------------------
 		// Apply audio  bandpass filter
-		if((!ads.af_disabled)	&& (ts.filter_id < AUDIO_5P0KHZ))	{	// we don't need to filter here if running in "wide" AM mode (Hilbert/FIR does the job!)
+	    // TODO: Review FilterPath Code
+		// DONE: DD4WH 2016_03_13
+	    if (ts.filter_path != 0) {
+			if ((!ads.af_disabled)	&& (FilterPathInfo[ts.filter_path-1].IIR_PreFilter_yes)) // yes, we want an audio IIR filter
+			arm_iir_lattice_f32(&IIR_PreFilter, (float32_t *)ads.a_buffer, (float32_t *)ads.a_buffer, psize/2);
+	    } else
+
+	    	if((!ads.af_disabled)	&& (ts.filter_id < AUDIO_5P0KHZ))	{	// we don't need to filter here if running in "wide" AM mode (Hilbert/FIR does the job!)
 			// IIR ARMA-type lattice filter
 			arm_iir_lattice_f32(&IIR_PreFilter, (float32_t *)ads.a_buffer, (float32_t *)ads.a_buffer, psize/2);
 		}
@@ -1726,6 +1740,14 @@ static void audio_rx_processor(int16_t *src, int16_t *dst, int16_t size)
 		//
 		// Calculate scaling based on decimation rate since this affects the audio gain
 		//
+	    // TODO: Review FilterPath Code
+		// DONE: DD4WH 2016_03_13
+		if (ts.filter_path != 0) {
+			if ((FilterPathInfo[ts.filter_path-1].sample_rate_dec) == RX_DECIMATION_RATE_12KHZ)
+				post_agc_gain_scaling = POST_AGC_GAIN_SCALING_DECIMATE_4;
+			else
+				post_agc_gain_scaling = POST_AGC_GAIN_SCALING_DECIMATE_2;
+		} else
 		if(ts.filter_id < AUDIO_5P0KHZ)
 			post_agc_gain_scaling = POST_AGC_GAIN_SCALING_DECIMATE_4;
 		else
@@ -1741,8 +1763,15 @@ static void audio_rx_processor(int16_t *src, int16_t *dst, int16_t size)
 		// resample back to original sample rate while doing low-pass filtering to minimize audible aliasing effects
 		//
 		arm_fir_interpolate_f32(&INTERPOLATE_RX, (float32_t *)ads.a_buffer,(float32_t *) ads.b_buffer, psize/2);
+
 		// additional antialias filter for specific bandwidths
 		// IIR ARMA-type lattice filter
+	    // TODO: Review FilterPath Code
+		// DONE: DD4WH 2016_03_13
+	    if (ts.filter_path != 0) {
+			if (FilterPathInfo[ts.filter_path-1].IIR_int_yes) // yes, we want an interpolation IIR filter
+				arm_iir_lattice_f32(&IIR_AntiAlias, (float32_t *)ads.b_buffer, (float32_t *)ads.b_buffer, size/2);
+	    } else
 		if((ts.filter_id > AUDIO_1P8KHZ) && (ts.filter_id < AUDIO_5P0KHZ))
 		arm_iir_lattice_f32(&IIR_AntiAlias, (float32_t *)ads.b_buffer, (float32_t *)ads.b_buffer, size/2);
 

--- a/mchf-eclipse/drivers/audio/audio_filter.c
+++ b/mchf-eclipse/drivers/audio/audio_filter.c
@@ -79,13 +79,8 @@
 #include "filters/iir_9_5k.h"
 #include "filters/iir_10k.h"
 
-// single file with all of the different interpolation IIR filters
+// single file with all the different interpolation IIR filters
 #include "filters/iir_antialias.h"
-
-#include "filters/iir_15k_hpf_fm_squelch.h"
-
-#include "filters/iir_2k7_tx_bpf.h"
-#include "filters/iir_2k7_tx_bpf_fm.h"
 
 // FIR filters for decimation and interpolation
 #include "filters/fir_rx_decimate_4.h"	// with low-pass filtering
@@ -93,6 +88,12 @@
 #include "filters/fir_rx_interpolate_16.h"	// filter for interpolate-by-16 operation
 #include "filters/fir_rx_interpolate_16_10kHz.h"	// This has relaxed LPF for the 10 kHz filter mode
 
+// FM highhpass filter for squelch
+#include "filters/iir_15k_hpf_fm_squelch.h"
+
+// TX filters
+#include "filters/iir_2k7_tx_bpf.h"
+#include "filters/iir_2k7_tx_bpf_fm.h"
 
 /*
 typedef struct FilterDescriptor_s {
@@ -208,7 +209,13 @@ FilterDescriptor FilterInfo[AUDIO_FILTER_NUM] =
     {  AUDIO_10P0KHZ," 10.0k ", 10000, FILTER_SSBAM,   FILTER_NONE, 2, 1, filter_stdLabelsOnOff }
 };
 
-/*// filter_characteristic: bandpass (with different centre freqs), lowpass etc.
+/*
+id --> at the moment, we only have an ID for bandwidth, but no ID yet for each single filter path
+--> needs to be done
+
+mode
+
+filter_select_ID
 
 FIR coeff_I_numTaps (= FIR coeff_Q_numTaps)
 FIR coeff_I_coeffs: points to the array of FIR filter coeffs used in the I path

--- a/mchf-eclipse/drivers/audio/audio_filter.c
+++ b/mchf-eclipse/drivers/audio/audio_filter.c
@@ -260,7 +260,7 @@ IIR_antialias_coeff_pv: points to the array of IIR coeffs for the antialias IIR 
  * ###############################################################
  */
 
-FilterPathDescriptor FilterPathInfo[80] = // how to automatically determine this figure? --> also change in audio_filter.h !!!
+FilterPathDescriptor FilterPathInfo[83] = // how to automatically determine this figure? --> also change in audio_filter.h !!!
 									// sum(
 {
 // ID, mode, filter_select_ID, FIR_numTaps, FIR_I_coeff_file, FIR_Q_coeff_file, FIR_dec_numTaps, FIR_dec_coeff_file,
@@ -490,7 +490,19 @@ FilterPathDescriptor FilterPathInfo[80] = // how to automatically determine this
 		RX_DECIMATION_RATE_24KHZ, 0, 0, 0, 0,
 		RX_INTERPOLATE_10KHZ_NUM_TAPS, FirRxInterpolate10KHZ, 0, 0 ,0 , 0},
 
+	{	AUDIO_5P5KHZ, FILTER_SSB, 1, I_NUM_TAPS, i_rx_5k_coeffs, q_rx_5k_coeffs, RX_DECIMATE_MIN_LPF_NUM_TAPS, FirRxDecimateMinLPF,
+		RX_DECIMATION_RATE_24KHZ, 0, 0, 0, 0,
+		RX_INTERPOLATE_10KHZ_NUM_TAPS, FirRxInterpolate10KHZ, 0, 0 ,0 , 0},
+
 	{	AUDIO_6P0KHZ, FILTER_SSB, 1, I_NUM_TAPS, i_rx_6k_coeffs, q_rx_6k_coeffs, RX_DECIMATE_MIN_LPF_NUM_TAPS, FirRxDecimateMinLPF,
+		RX_DECIMATION_RATE_24KHZ, 0, 0, 0, 0,
+		RX_INTERPOLATE_10KHZ_NUM_TAPS, FirRxInterpolate10KHZ, 0, 0 ,0 , 0},
+
+	{	AUDIO_6P5KHZ, FILTER_SSB, 1, I_NUM_TAPS, i_rx_6k_coeffs, q_rx_6k_coeffs, RX_DECIMATE_MIN_LPF_NUM_TAPS, FirRxDecimateMinLPF,
+		RX_DECIMATION_RATE_24KHZ, 0, 0, 0, 0,
+		RX_INTERPOLATE_10KHZ_NUM_TAPS, FirRxInterpolate10KHZ, 0, 0 ,0 , 0},
+
+	{	AUDIO_7P0KHZ, FILTER_SSB, 1, I_NUM_TAPS, i_rx_6k_coeffs, q_rx_6k_coeffs, RX_DECIMATE_MIN_LPF_NUM_TAPS, FirRxDecimateMinLPF,
 		RX_DECIMATION_RATE_24KHZ, 0, 0, 0, 0,
 		RX_INTERPOLATE_10KHZ_NUM_TAPS, FirRxInterpolate10KHZ, 0, 0 ,0 , 0},
 
@@ -740,12 +752,26 @@ void AudioFilter_CalcRxPhaseAdj(void)
     // always make a fresh copy of the original Q and I coefficients
     // NOTE:  We are assuming that the I and Q filters are of the same length!
     //
+
+    // new filter_path method
+    // take all info from FilterPathInfo
+    // IIR_PreFilter.pkCoeffs = (float *)FilterPathInfo[ts.filter_path-1].IIR_PreFilter_pk_file;
+    //
+    if (ts.filter_path == 0) {
     fc.rx_q_num_taps = Q_NUM_TAPS;
     fc.rx_i_num_taps = I_NUM_TAPS;
+    } else
+    {
+        fc.rx_q_num_taps = FilterPathInfo[ts.filter_path-1].FIR_numTaps;
+        fc.rx_i_num_taps = FilterPathInfo[ts.filter_path-1].FIR_numTaps;
+    }
     //
     fc.rx_q_block_size = Q_BLOCK_SIZE;
     fc.rx_i_block_size = I_BLOCK_SIZE;
     //
+
+    if (ts.filter_path == 0) {
+
     if(ts.dmod_mode == DEMOD_AM)    {       // AM - load low-pass, non Hilbert filters (e.g. no I/Q phase shift
         // FIR 2k3 up to 2k3 filter
         // FIR 3k6 up to 3k6 filter
@@ -827,14 +853,22 @@ void AudioFilter_CalcRxPhaseAdj(void)
                             }
         } // end for
     }   // end else = SSB
+    } // END old routine / if ts.filter_path == 0
+    else {
+    		// in FilterPathInfo, we have stored the coefficients already, so no if . . . necessary
+    		for(i = 0; i < fc.rx_q_num_taps; i++) { // fc.rx_q_num_taps is ALWAYS == fc.rx_i_num_taps
+    			fc.rx_filt_q[i] = FilterPathInfo[ts.filter_path-1].FIR_I_coeff_file[i];
+                fc.rx_filt_i[i] = FilterPathInfo[ts.filter_path-1].FIR_Q_coeff_file[i];
+    		}
+    }//
 
-        //
-        if(ts.dmod_mode == DEMOD_LSB)   // get phase setting appropriate to mode
+    	if(ts.dmod_mode == DEMOD_LSB)   // get phase setting appropriate to mode
             phase = ts.rx_iq_lsb_phase_balance;     // yes, get current gain adjustment setting for LSB
         else
             phase = ts.rx_iq_usb_phase_balance;     // yes, get current gain adjustment setting for USB and other mdoes
         //
-        if(phase != 0)  {   // is phase adjustment non-zero?
+    	if (ts.filter_path ==0){
+    	if(phase != 0)  {   // is phase adjustment non-zero?
             var_norm = (float)phase;
             var_norm = fabs(var_norm);      // get absolute value of this gain adjustment
             var_inv = 32 - var_norm;        // calculate "inverse" of number of steps
@@ -914,8 +948,93 @@ void AudioFilter_CalcRxPhaseAdj(void)
                                     }
             } // end phase adjustment positive
         } // end if phase adjustment non-zero
+		} // END old routine (if (ts.filter_path == 0)
+    	else { // new switching with FilterPathInfo
 
-    //
+        	if(phase != 0)  {   // is phase adjustment non-zero?
+                var_norm = (float)phase;
+                var_norm = fabs(var_norm);      // get absolute value of this gain adjustment
+                var_inv = 32 - var_norm;        // calculate "inverse" of number of steps
+                var_norm /= 32;     // fractionalize by the number of steps
+                var_inv /= 32;                      // fractionalize this one, too
+                if(phase < 0)   {   // was the phase adjustment negative?
+
+                    if(FilterPathInfo[ts.filter_path-1].FIR_I_coeff_file == i_rx_3k6_coeffs){ // Hilbert 3k6
+                        for(i = 0; i < FilterPathInfo[ts.filter_path-1].FIR_numTaps; i++) {
+                            f_coeff = var_inv * q_rx_3k6_coeffs[i]; // get fraction of 90 degree setting
+                            f_offset = var_norm * q_rx_3k6_coeffs_minus[i]; // get fraction of 89.5 degree setting
+                            fc.rx_filt_q[i] = f_coeff + f_offset;   // synthesize new coefficient
+                        }
+                    } else
+                        if(FilterPathInfo[ts.filter_path-1].FIR_I_coeff_file == i_rx_5k_coeffs){ // Hilbert 5k
+                            for(i = 0; i < FilterPathInfo[ts.filter_path-1].FIR_numTaps; i++) {
+                                f_coeff = var_inv * q_rx_5k_coeffs[i];  // get fraction of 90 degree setting
+                                f_offset = var_norm * q_rx_5k_coeffs_minus[i];  // get fraction of 89.5 degree setting
+                                fc.rx_filt_q[i] = f_coeff + f_offset;   // synthesize new coefficient
+                            }
+                        } else
+                            if(FilterPathInfo[ts.filter_path-1].FIR_I_coeff_file == i_rx_6k_coeffs){
+                                for(i = 0; i < FilterPathInfo[ts.filter_path-1].FIR_numTaps; i++) { // Hilbert 6k
+                                    f_coeff = var_inv * q_rx_6k_coeffs[i];  // get fraction of 90 degree setting
+                                    f_offset = var_norm * q_rx_6k_coeffs_minus[i];  // get fraction of 89.5 degree setting
+                                    fc.rx_filt_q[i] = f_coeff + f_offset;   // synthesize new coefficient
+                                }
+                            }   else
+                                    if(FilterPathInfo[ts.filter_path-1].FIR_I_coeff_file == i_rx_7k5_coeffs){ // Hilbert 7k5
+                                        for(i = 0; i < FilterPathInfo[ts.filter_path-1].FIR_numTaps; i++) {
+                                            f_coeff = var_inv * q_rx_7k5_coeffs[i]; // get fraction of 90 degree setting
+                                            f_offset = var_norm * q_rx_7k5_coeffs_minus[i]; // get fraction of 89.5 degree setting
+                                            fc.rx_filt_q[i] = f_coeff + f_offset;   // synthesize new coefficient
+                                        }
+                                    }   else {
+                                            for(i = 0; i < FilterPathInfo[ts.filter_path-1].FIR_numTaps; i++) { // hilbert 10k
+                                                f_coeff = var_inv * q_rx_10k_coeffs[i]; // get fraction of 90 degree setting
+                                                f_offset = var_norm * q_rx_10k_coeffs_minus[i]; // get fraction of 89.5 degree setting
+                                                fc.rx_filt_q[i] = f_coeff + f_offset;   // synthesize new coefficient
+                                            }
+                                        }
+                } // end phase adjustment negative
+                else    {                           // adjustment was positive
+                    if(FilterPathInfo[ts.filter_path-1].FIR_I_coeff_file == i_rx_3k6_coeffs){
+                        for(i = 0; i < FilterPathInfo[ts.filter_path-1].FIR_numTaps; i++) {
+                            f_coeff = var_inv * q_rx_3k6_coeffs[i]; // get fraction of 90 degree setting
+                            f_offset = var_norm * q_rx_3k6_coeffs_plus[i];  // get fraction of 90.5 degree setting
+                            fc.rx_filt_q[i] = f_coeff + f_offset;   // synthesize new coefficient
+                        }
+                    } else
+                        if(FilterPathInfo[ts.filter_path-1].FIR_I_coeff_file == i_rx_5k_coeffs){
+                            for(i = 0; i < FilterPathInfo[ts.filter_path-1].FIR_numTaps; i++) {
+                                f_coeff = var_inv * q_rx_5k_coeffs[i];  // get fraction of 90 degree setting
+                                f_offset = var_norm * q_rx_5k_coeffs_plus[i];   // get fraction of 90.5 degree setting
+                                fc.rx_filt_q[i] = f_coeff + f_offset;   // synthesize new coefficient
+                            }
+                        } else
+                            if(FilterPathInfo[ts.filter_path-1].FIR_I_coeff_file == i_rx_6k_coeffs){
+                                for(i = 0; i < FilterPathInfo[ts.filter_path-1].FIR_numTaps; i++) {
+                                    f_coeff = var_inv * q_rx_6k_coeffs[i];  // get fraction of 90 degree setting
+                                    f_offset = var_norm * q_rx_6k_coeffs_plus[i];   // get fraction of 90.5 degree setting
+                                    fc.rx_filt_q[i] = f_coeff + f_offset;   // synthesize new coefficient
+                                }
+                            }   else
+                                    if(FilterPathInfo[ts.filter_path-1].FIR_I_coeff_file == i_rx_7k5_coeffs){
+                                        for(i = 0; i < FilterPathInfo[ts.filter_path-1].FIR_numTaps; i++) {
+                                            f_coeff = var_inv * q_rx_7k5_coeffs[i]; // get fraction of 90 degree setting
+                                            f_offset = var_norm * q_rx_7k5_coeffs_plus[i];  // get fraction of 90.5 degree setting
+                                            fc.rx_filt_q[i] = f_coeff + f_offset;   // synthesize new coefficient
+                                        }
+                                    }   else {
+                                            for(i = 0; i < FilterPathInfo[ts.filter_path-1].FIR_numTaps; i++) {
+                                                f_coeff = var_inv * q_rx_10k_coeffs[i]; // get fraction of 90 degree setting
+                                                f_offset = var_norm * q_rx_10k_coeffs_plus[i];  // get fraction of 90.5 degree setting
+                                                fc.rx_filt_q[i] = f_coeff + f_offset;   // synthesize new coefficient
+                                            }
+                                        }
+                } // end phase adjustment positive
+            } // end if phase adjustment non-zero
+
+    	}// END new switching with FilterPathInfo
+
+    	//
     // In AM mode we do NOT do 90 degree phase shift, so we do FIR low-pass instead of Hilbert, setting "I" channel the same as "Q"
     if(ts.dmod_mode == DEMOD_AM)        // use "Q" filter settings in AM mode for "I" channel
         arm_fir_init_f32((arm_fir_instance_f32 *)&FIR_I,fc.rx_q_num_taps,(float32_t *)&fc.rx_filt_i[0], &FirState_I[0],fc.rx_q_block_size); // load "I" with "Q" coefficients

--- a/mchf-eclipse/drivers/audio/audio_filter.h
+++ b/mchf-eclipse/drivers/audio/audio_filter.h
@@ -135,7 +135,7 @@ typedef struct FilterPathDescriptor_s {
   const float *IIR_int_pv_file;
 } FilterPathDescriptor;
 
-extern FilterPathDescriptor FilterPathInfo[80]; // also change this figure in audio_filter.c
+extern FilterPathDescriptor FilterPathInfo[83]; // also change this figure in audio_filter.c
 //
 // Define visual widths of audio filters for on-screen indicator in Hz
 //

--- a/mchf-eclipse/drivers/ui/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/ui_menu.c
@@ -1363,59 +1363,6 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode, int pos)
       UiMenuHandleFilterConfig(var,mode,options,&clr,AUDIO_6P0KHZ);
 	  break;
 
-
-/*	case MENU_WIDE_SEL: // Wide filter select
-		if(ts.dmod_mode != DEMOD_FM)	{
-			fchange = UiDriverMenuItemChangeUInt8(var, mode, &ts.filter_wide_select,
-					0,
-					WIDE_FILTER_MAX,
-					WIDE_FILTER_10K,
-					1
-			);
-			if((ts.filter_id != AUDIO_WIDE))	// make orange if NOT in "Wide" mode
-				clr = Orange;
-		}
-		else				// show disabled if in FM
-			clr = Red;
-		//
-		switch(ts.filter_wide_select)	{
-			case WIDE_FILTER_5K_AM:
-				strcpy(options, "  5kHz AM");
-				break;
-			case WIDE_FILTER_6K_AM:
-				strcpy(options, "  6kHz AM");
-				break;
-			case WIDE_FILTER_7K5_AM:
-				strcpy(options, "7.5kHz AM");
-				break;
-			case WIDE_FILTER_10K_AM:
-				strcpy(options, "10 kHz AM");
-				break;
-			case WIDE_FILTER_5K:
-				strcpy(options, "     5kHz");
-				break;
-			case WIDE_FILTER_6K:
-				strcpy(options, "     6kHz");
-				break;
-			case WIDE_FILTER_7K5:
-				strcpy(options, "    7.5kHz");
-				break;
-			case WIDE_FILTER_10K:
-			default:
-				strcpy(options, "     10kHz");
-				break;
-		}
-		//
-		if((ts.filter_id == AUDIO_WIDE) && fchange)	{
-			//UiDriverProcessActiveFilterScan();	// find next active filter
-			UiDriverChangeFilter(0);
-			UiCalcRxPhaseAdj();						// update Hilbert/LowPass filter setting
-			UiDriverDisplayFilterBW();	// update on-screen filter bandwidth indicator
-		}
-		//
-		// disp_shift = 1;		// move the options to the left slightly
-		break;
-	*/
 	case MENU_CW_WIDE_FILT: // CW mode wide filter enable/disable
 		UiDriverMenuItemChangeDisableOnOff(var, mode, &ts.filter_cw_wide_disable,0,options,&clr);
 

--- a/mchf-eclipse/hardware/mchf_board.h
+++ b/mchf-eclipse/hardware/mchf_board.h
@@ -1204,7 +1204,7 @@ typedef struct TransceiverState
 	//
 	uint8_t   filter_select[AUDIO_FILTER_NUM];
 
-	uint8_t  filter_path;
+	uint16_t  filter_path;
 	//
 
 	uchar	filter_cw_wide_disable;		// TRUE if wide filters are disabled in CW mode

--- a/mchf-eclipse/main.c
+++ b/mchf-eclipse/main.c
@@ -538,7 +538,7 @@ void TransceiverStateInit(void)
 	ts.audio_int_counter = 0;		//test DL2FW
 
 
-	ts.filter_path = 70; // uncomment to use  filter path of given number -1 (hack, filter path is used all the time)
+	//ts.filter_path = 52; // uncomment to use  filter path of given number -1 (hack, filter path is used all the time)
 }
 
 //*----------------------------------------------------------------------------

--- a/mchf-eclipse/main.c
+++ b/mchf-eclipse/main.c
@@ -538,7 +538,7 @@ void TransceiverStateInit(void)
 	ts.audio_int_counter = 0;		//test DL2FW
 
 
-	// ts.filter_path = 22; // uncomment to use  filter path of given number -1 (hack, filter path is used all the time)
+	ts.filter_path = 70; // uncomment to use  filter path of given number -1 (hack, filter path is used all the time)
 }
 
 //*----------------------------------------------------------------------------


### PR DESCRIPTION
First review of filter path code in audio_driver.c, also in AudioFilter_CalcRxPhaseAdj
Seems to work when you uncomment ts.filter_path == 56; in main.c
! This version does not work properly with FM, if ts.filter_path == is uncommented
At the moment: no filter paths for FM in FilterPathInfo
ToDo: Insert the three filter paths into FilterPathInfo for FM!
