### PR TITLE
LCD Reset did not work with gcc 4.9 compiled code 

### DIFF
--- a/mchf-eclipse/drivers/ui/lcd/ui_lcd_hy28.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_lcd_hy28.c
@@ -1389,5 +1389,5 @@ static void UiLcdHy28_Delay(ulong delay)
    ulong    i,k;
 
     for ( k = 0 ;(k < delay );k++ )
-      for ( i = 0 ;(i < US_DELAY );i++ );
+      for ( i = 0 ;(i < US_DELAY );i++ ) { asm(""); }
 }


### PR DESCRIPTION
using optimization. Result was white screen on some displays (SPI and parallel)
on some source commits. Now fixed.
GCC 5.2 compiled code did not have this issue.
