### PR TITLE
simplifying filter switching

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -833,7 +833,7 @@ void audio_driver_set_rx_audio_filter(void)
 	ads.af_disabled = 0;
 	ts.dsp_inhibit = dsp_inhibit_temp;
 	//
-	AudioFilter_CalcRxPhaseAdj();
+	AudioFilter_CalcRxPhaseAdj(); // this switches the Hilbert/FIR-filters
 }
 //
 

--- a/mchf-eclipse/drivers/audio/audio_filter.c
+++ b/mchf-eclipse/drivers/audio/audio_filter.c
@@ -189,7 +189,7 @@ IIR_antialias_coeff_pv: points to the array of IIR coeffs for the antialias IIR 
  */
 
 const FilterPathDescriptor FilterPathInfo[86] = // how to automatically determine this figure? --> also change in audio_filter.h !!!
-									// sum(
+									//
 {
 // ID, mode, filter_select_ID, FIR_numTaps, FIR_I_coeff_file, FIR_Q_coeff_file, FIR_dec_numTaps, FIR_dec_coeff_file,
 //		sample_rate_dec,bool IIR_PreFilter_yes_no, &IIR_PreFilter_numTaps, &IIR_PreFilter_pk_file,
@@ -242,7 +242,7 @@ const FilterPathDescriptor FilterPathInfo[86] = // how to automatically determin
 	{	AUDIO_300HZ, "750", FILTER_SSBCW, 6, I_NUM_TAPS, i_rx_3k6_coeffs, q_rx_3k6_coeffs, &FirRxDecimate,
 		RX_DECIMATION_RATE_12KHZ, &IIR_300hz_750,
 		&FirRxInterpolate, NULL},
-
+//10
 	{	AUDIO_300HZ, "800", FILTER_SSBCW, 7, I_NUM_TAPS, i_rx_3k6_coeffs, q_rx_3k6_coeffs, &FirRxDecimate,
 		RX_DECIMATION_RATE_12KHZ, &IIR_300hz_800,
 		&FirRxInterpolate, NULL},
@@ -263,7 +263,7 @@ const FilterPathDescriptor FilterPathInfo[86] = // how to automatically determin
 	{	AUDIO_500HZ, "550", FILTER_SSBCW, 1, I_NUM_TAPS, i_rx_3k6_coeffs, q_rx_3k6_coeffs, &FirRxDecimate,
 		RX_DECIMATION_RATE_12KHZ, &IIR_500hz_550,
 		&FirRxInterpolate, NULL},
-
+//15
 	{	AUDIO_500HZ, "650", FILTER_SSBCW, 2, I_NUM_TAPS, i_rx_3k6_coeffs, q_rx_3k6_coeffs, &FirRxDecimate,
 		RX_DECIMATION_RATE_12KHZ, &IIR_500hz_650,
 		&FirRxInterpolate, NULL},
@@ -287,7 +287,7 @@ const FilterPathDescriptor FilterPathInfo[86] = // how to automatically determin
 	{	AUDIO_1P4KHZ, "LPF", FILTER_SSBCW, 1, I_NUM_TAPS, i_rx_3k6_coeffs, q_rx_3k6_coeffs, &FirRxDecimate,
 		RX_DECIMATION_RATE_12KHZ, &IIR_1k4_LPF,
 		&FirRxInterpolate, NULL},
-
+//20
 	{	AUDIO_1P4KHZ, "BPF", FILTER_SSB, 2, I_NUM_TAPS, i_rx_3k6_coeffs, q_rx_3k6_coeffs, &FirRxDecimate,
 		RX_DECIMATION_RATE_12KHZ, &IIR_1k4_BPF,
 		&FirRxInterpolate, NULL},
@@ -305,10 +305,9 @@ const FilterPathDescriptor FilterPathInfo[86] = // how to automatically determin
 		&FirRxInterpolate, NULL},
 
 	{	AUDIO_1P8KHZ, "1.3", FILTER_SSB, 2, I_NUM_TAPS, i_rx_3k6_coeffs, q_rx_3k6_coeffs, &FirRxDecimate,
-//25
 		RX_DECIMATION_RATE_12KHZ, &IIR_1k8_1k275,
 		&FirRxInterpolate, NULL},
-
+//25
 	{	AUDIO_1P8KHZ, "1.4", FILTER_SSB, 3, I_NUM_TAPS, i_rx_3k6_coeffs, q_rx_3k6_coeffs, &FirRxDecimate,
 		RX_DECIMATION_RATE_12KHZ, &IIR_1k8_1k425,
 		&FirRxInterpolate, NULL},
@@ -328,7 +327,7 @@ const FilterPathDescriptor FilterPathInfo[86] = // how to automatically determin
 	{	AUDIO_2P1KHZ, "LPF", FILTER_SSB, 1, I_NUM_TAPS, i_rx_3k6_coeffs, q_rx_3k6_coeffs, &FirRxDecimate,
 		RX_DECIMATION_RATE_12KHZ, &IIR_2k1_LPF,
 		&FirRxInterpolate, NULL},
-
+//30
 	{	AUDIO_2P1KHZ, "BPF", FILTER_SSB, 2, I_NUM_TAPS, i_rx_3k6_coeffs, q_rx_3k6_coeffs, &FirRxDecimate,
 		RX_DECIMATION_RATE_12KHZ, &IIR_2k1_BPF,
 		&FirRxInterpolate, NULL},
@@ -348,11 +347,11 @@ const FilterPathDescriptor FilterPathInfo[86] = // how to automatically determin
 	{	AUDIO_2P3KHZ, "1.7", FILTER_SSB, 4, I_NUM_TAPS, i_rx_3k6_coeffs, q_rx_3k6_coeffs, &FirRxDecimate,
 		RX_DECIMATION_RATE_12KHZ, &IIR_2k3_1k712,
 		&FirRxInterpolate, NULL},
-
+//35
 	{	AUDIO_2P3KHZ, "LPF", FILTER_SSB, 5, I_NUM_TAPS, i_rx_3k6_coeffs, q_rx_3k6_coeffs, &FirRxDecimate,
 		RX_DECIMATION_RATE_12KHZ, &IIR_2k3_LPF,
 		&FirRxInterpolate, NULL},
-//33
+
 	{	AUDIO_2P5KHZ, "LPF", FILTER_SSB, 1, I_NUM_TAPS, i_rx_3k6_coeffs, q_rx_3k6_coeffs, &FirRxDecimate,
 		RX_DECIMATION_RATE_12KHZ, &IIR_2k5_LPF,
 		&FirRxInterpolate, NULL},
@@ -368,7 +367,7 @@ const FilterPathDescriptor FilterPathInfo[86] = // how to automatically determin
 	{	AUDIO_2P7KHZ, "BPF", FILTER_SSB, 2, I_NUM_TAPS, i_rx_3k6_coeffs, q_rx_3k6_coeffs, &FirRxDecimate,
 		RX_DECIMATION_RATE_12KHZ, &IIR_2k7_BPF,
 		&FirRxInterpolate, NULL},
-
+//40
 	{	AUDIO_2P9KHZ, "LPF", FILTER_SSB, 1, I_NUM_TAPS, i_rx_3k6_coeffs, q_rx_3k6_coeffs, &FirRxDecimate,
 		RX_DECIMATION_RATE_12KHZ, &IIR_2k9_LPF,
 		&FirRxInterpolate, NULL},
@@ -386,11 +385,11 @@ const FilterPathDescriptor FilterPathInfo[86] = // how to automatically determin
 		&FirRxInterpolate, NULL},
 
 		// in filters from 3k4 on, the FIR interpolate is 4 taps and an additional IIR interpolation filter
-		// is switched in to accurately prevent alias frequencies
+//44	// is switched in to accurately prevent alias frequencies
 	{	AUDIO_3P4KHZ, "LPF", FILTER_SSB, 1, I_NUM_TAPS, i_rx_3k6_coeffs, q_rx_3k6_coeffs, &FirRxDecimate,
 		RX_DECIMATION_RATE_12KHZ, &IIR_3k4_LPF,
 		&FirRxInterpolate_4_5k, &IIR_aa_5k},
-
+//45
 	{	AUDIO_3P4KHZ, "BPF", FILTER_SSB, 2, I_NUM_TAPS, i_rx_3k6_coeffs, q_rx_3k6_coeffs, &FirRxDecimate,
 		RX_DECIMATION_RATE_12KHZ, &IIR_3k4_BPF,
 		&FirRxInterpolate_4_5k, &IIR_aa_5k},
@@ -410,7 +409,7 @@ const FilterPathDescriptor FilterPathInfo[86] = // how to automatically determin
 	{	AUDIO_3P8KHZ, "BPF", FILTER_SSB, 2, I_NUM_TAPS, i_rx_5k_coeffs, q_rx_5k_coeffs, &FirRxDecimate,
 		RX_DECIMATION_RATE_12KHZ, &IIR_3k8_BPF,
 		&FirRxInterpolate_4_5k, &IIR_aa_5k},
-
+//50
 	{	AUDIO_4P0KHZ, "LPF", FILTER_SSB, 1, I_NUM_TAPS, i_rx_5k_coeffs, q_rx_5k_coeffs, &FirRxDecimate,
 		RX_DECIMATION_RATE_12KHZ, &IIR_4k_LPF,
 		&FirRxInterpolate_4_5k, &IIR_aa_5k},
@@ -422,7 +421,7 @@ const FilterPathDescriptor FilterPathInfo[86] = // how to automatically determin
 	{	AUDIO_4P4KHZ, "LPF", FILTER_SSB, 1, I_NUM_TAPS, i_rx_5k_coeffs, q_rx_5k_coeffs, &FirRxDecimate,
 		RX_DECIMATION_RATE_12KHZ, &IIR_4k4_LPF,
 		&FirRxInterpolate_4_5k, &IIR_aa_5k},
-//50
+
 	{	AUDIO_4P6KHZ, "LPF", FILTER_SSB, 1, I_NUM_TAPS, i_rx_5k_coeffs, q_rx_5k_coeffs, &FirRxDecimate,
 		RX_DECIMATION_RATE_12KHZ, &IIR_4k6_LPF,
 		&FirRxInterpolate_4_5k, &IIR_aa_5k},
@@ -451,7 +450,7 @@ const FilterPathDescriptor FilterPathInfo[86] = // how to automatically determin
 	{	AUDIO_7P0KHZ, NULL, FILTER_SSB, 1, I_NUM_TAPS, i_rx_6k_coeffs, q_rx_6k_coeffs, &FirRxDecimateMinLPF,
 		RX_DECIMATION_RATE_24KHZ, NULL,
 		&FirRxInterpolate10KHZ, NULL},
-
+//60
 	{	AUDIO_7P5KHZ, NULL, FILTER_SSB, 1, I_NUM_TAPS, i_rx_7k5_coeffs, q_rx_7k5_coeffs, &FirRxDecimateMinLPF,
 		RX_DECIMATION_RATE_24KHZ, NULL,
 		&FirRxInterpolate10KHZ, NULL},

--- a/mchf-eclipse/drivers/audio/audio_management.h
+++ b/mchf-eclipse/drivers/audio/audio_management.h
@@ -16,8 +16,6 @@
 
 void    AudioManagement_CalcRxIqGainAdj(void);
 void    AudioManagement_CalcTxIqGainAdj(void);
-void    AudioManagement_CalcRxIqGainAdj(void);
-void    AudioManagement_CalcTxIqGainAdj(void);
 
 void    AudioManagement_CalcTxCompLevel(void);
 void    AudioManagement_CalcNB_AGC(void);

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -1265,13 +1265,15 @@ void UiInitRxParms(void)
 
     // Init / Functional changes to operation in RX path
 	UiCWSidebandMode();
-	//
+	// I do not think we need the TX adjustments in RX ?! DD4WH
+	// not sure, I leave them here
 	AudioManagement_CalcTxIqGainAdj();		// update gain and phase values when changing modes
-	AudioFilter_CalcTxPhaseAdj();
-	AudioFilter_CalcRxPhaseAdj();
+	AudioFilter_CalcTxPhaseAdj(); // dto.
+	// AudioFilter_CalcRxPhaseAdj(); // is already included in the void audio_driver_set_rx_audio_filter(void);
 	Audio_TXFilter_Init();
 	audio_driver_set_rx_audio_filter();	// update DSP/filter settings
-	AudioFilter_CalcRxPhaseAdj();           // We may have changed something in the RX filtering as well - do an update
+	// this is already included in the void audio_driver_set_rx_audio_filter(void);
+	//	AudioFilter_CalcRxPhaseAdj();           // We may have changed something in the RX filtering as well - do an update
 
 
     if(ts.dmod_mode == DEMOD_CW)	{		// update on-screen adjustments

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -1269,7 +1269,7 @@ void UiInitRxParms(void)
 	// not sure, I leave them here
 	AudioManagement_CalcTxIqGainAdj();		// update gain and phase values when changing modes
 	AudioFilter_CalcTxPhaseAdj(); // dto.
-	// AudioFilter_CalcRxPhaseAdj(); // is already included in the void audio_driver_set_rx_audio_filter(void);
+	AudioFilter_CalcRxPhaseAdj(); // is already included in the void audio_driver_set_rx_audio_filter(void);
 	Audio_TXFilter_Init();
 	audio_driver_set_rx_audio_filter();	// update DSP/filter settings
 	// this is already included in the void audio_driver_set_rx_audio_filter(void);
@@ -1292,7 +1292,8 @@ void UiInitRxParms(void)
 	}
 
     // Update Display Only Code
-    UiDriverChangeFilter(0);    // make certain that numerical on-screen bandwidth indicator is updated
+    UiDriverChangeFilterDisplay();    // make certain that numerical on-screen bandwidth indicator is updated
+//    audio_driver_set_rx_audio_filter();
     UiDriverChangeDigitalMode();    // Change Dgital display setting as well
     UiDriverChangeDSPMode();  // Change DSP display setting as well
     UiDriverDisplayFilterBW();  // update on-screen filter bandwidth indicator (graphical)
@@ -1439,7 +1440,7 @@ static void UiDriverProcessFunctionKeyClick(ulong id)
 				UiDriverChangeEncoderOneMode(0);
 				UiDriverChangeEncoderTwoMode(0);
 				UiDriverChangeEncoderThreeMode(0);
-				UiDriverChangeFilter(1);	// update bandwidth display
+				UiDriverChangeFilterDisplay();	// update bandwidth display
 				// Label for Button F1
 				{
 					char* label;
@@ -1600,7 +1601,7 @@ static void UiDriverProcessFunctionKeyClick(ulong id)
 			if(ts.filter_id != vfo[VFO_WORK].band[ts.band].filter_mode)
 			{
 				ts.filter_id = vfo[VFO_WORK].band[ts.band].filter_mode;
-				UiDriverChangeFilter(0);	// update display and change filter
+				UiDriverChangeFilterDisplay();	// update display
 				UiDriverDisplayFilterBW();	// update on-screen filter bandwidth indicator
 				audio_driver_set_rx_audio_filter();
 				audio_driver_set_rx_audio_filter();	// TODO: we have to invoke the filter change several times for some unknown reason - 'dunno why!
@@ -2077,7 +2078,7 @@ static void UiDriverCreateDesktop(void)
 	UiDriverChangePowerLevel();
 
 	// FIR via keypad, not encoder mode
-	UiDriverChangeFilter(1);
+	UiDriverChangeFilterDisplay();
 
 	UiDriverDisplayFilterBW();	// update on-screen filter bandwidth indicator
 
@@ -3823,7 +3824,7 @@ static void UiDriverChangeBand(uchar is_up)
 	if(ts.filter_id != vfo[VFO_WORK].band[new_band_index].filter_mode)
 	{
 		ts.filter_id = vfo[VFO_WORK].band[new_band_index].filter_mode;
-		UiDriverChangeFilter(0);	// update display and change filter
+		UiDriverChangeFilterDisplay();	// update display and change filter
 		UiDriverDisplayFilterBW();	// update on-screen filter bandwidth indicator
 		audio_driver_set_rx_audio_filter();
 		audio_driver_set_rx_audio_filter();	// TODO: we have to invoke the filter change several times for some unknown reason - 'dunno why!
@@ -4794,19 +4795,18 @@ static void UiDriverChangeRit(uchar enabled)
 }
 
 //*----------------------------------------------------------------------------
-//* Function Name       : UiDriverChangeFilter
-//* Object              : change audio filter, based on public flag
+//* Function Name       : UiDriverChangeFilterDisplay
+//* Object              :
 //* Input Parameters    :
 //* Output Parameters   :
 //* Functions called    :
 //*----------------------------------------------------------------------------
-void UiDriverChangeFilter(uchar ui_only_update)
+void UiDriverChangeFilterDisplay(void)
 {
 	// Do a filter re-load
-	if(!ui_only_update) {
-		audio_driver_set_rx_audio_filter();
-		AudioFilter_CalcRxPhaseAdj();
-	}
+//	if(!ui_only_update) {
+//		audio_driver_set_rx_audio_filter();
+//	}
 	char  outs[8];
 	const char* filter_ptr;
 	const FilterDescriptor* filter = &FilterInfo[ts.filter_id];

--- a/mchf-eclipse/drivers/ui/ui_driver.h
+++ b/mchf-eclipse/drivers/ui/ui_driver.h
@@ -518,7 +518,7 @@ void 	UiDriverLoadFilterValue(void);
 void 	UiSpectrumClearDisplay(void);
 //
 void 	UiDriverChangeBandFilter(uchar band);
-void 	UiDriverChangeFilter(uchar ui_only_update);
+void 	UiDriverChangeFilterDisplay(void);
 void 	UiDriverCreateTemperatureDisplay(uchar enabled,uchar create);
 void 	UiDriverUpdateFrequency(char skip_encoder_check, uchar mode);
 void 	UiSpectrumCreateDrawArea(void);
@@ -527,7 +527,7 @@ void 	UiDriverSetBandPowerFactor(uchar band);
 void 	UiDrawSpectrumScopeFrequencyBarText(void);
 void 	UiCheckForEEPROMLoadDefaultRequest(void);
 //
-void 	UiDriverChangeFilter(uchar ui_only_update);
+//void 	UiDriverChangeFilter(uchar ui_only_update);
 void 	UiDriverSetBandPowerFactor(uchar band);
 //
 void    UiDriverChangeAudioGain(uchar enabled);

--- a/mchf-eclipse/drivers/ui/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/ui_menu.c
@@ -1236,7 +1236,8 @@ static void  __attribute__ ((noinline))  UiDriverMenuChangeFilter(uint8_t filter
 	if((ts.txrx_mode == TRX_MODE_RX) && (changed))	{	// set filter if changed
 		if(ts.filter_id == filter_id)	{
 			//UiDriverProcessActiveFilterScan();	// find next active filter
-			UiDriverChangeFilter(0);
+			UiDriverChangeFilterDisplay();
+			audio_driver_set_rx_audio_filter();
 			UiDriverDisplayFilterBW();	// update on-screen filter bandwidth indicator
 		}
 	}
@@ -1525,7 +1526,7 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode, int pos)
 		//
 		if(fchange)	{			// was the bandwidth changed?
 			AudioFilter_CalcRxPhaseAdj();			// yes - update the filters!
-			UiDriverChangeFilter(1);	// update display of filter bandwidth (numerical) on screen only
+			UiDriverChangeFilterDisplay();	// update display of filter bandwidth (numerical) on screen only
 		}
 		//
 		if(ts.dmod_mode != DEMOD_FM)	// make orange if we are NOT in FM
@@ -3472,7 +3473,8 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
           // avoid FM filter paths for now
           if (ts.filter_path == 1 || ts.filter_path == 2) { ts.filter_path = 4; }
           if (ts.filter_path == 3) { ts.filter_path = 0; }
-          UiDriverChangeFilter(0);
+          UiDriverChangeFilterDisplay();
+          audio_driver_set_rx_audio_filter();
         }
         sprintf(options, "  %u", ts.filter_path);
         break;


### PR DESCRIPTION
Tried to split:
1. filterbandwidth display: is in UiDriverChangeFilterDisplay and
2. filter switching/intitialising is in audio_driver_set_rx
unfortunately, now mcHF crashes every time when an IIR filter instance goes from NULL to another state!? --> eg. filter_path = 44
