### PR TITLE
SAM demodulation alpha version

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -1708,6 +1708,11 @@ static void audio_rx_processor(int16_t *src, int16_t *dst, int16_t size)
 		case DEMOD_AM:
 			audio_demod_am(size);
 			break;
+		case DEMOD_SAM:
+			arm_sub_f32((float32_t *)ads.i_buffer, (float32_t *)ads.q_buffer, (float32_t *)ads.a3_buffer, size/2);	// difference of I and Q - LSB
+			arm_add_f32((float32_t *)ads.i_buffer, (float32_t *)ads.q_buffer, (float32_t *)ads.a2_buffer, size/2);	// sum of I and Q - USB
+			arm_add_f32((float32_t *)ads.a2_buffer, (float32_t *)ads.a3_buffer, (float32_t *)ads.a_buffer, size/2);	// sum of LSB & USB = DSB
+			break;
 		case DEMOD_FM:
 			audio_demod_fm(size);
 			break;

--- a/mchf-eclipse/drivers/audio/audio_driver.h
+++ b/mchf-eclipse/drivers/audio/audio_driver.h
@@ -56,6 +56,8 @@ typedef struct AudioDriverState
 	float32_t					i_buffer[IQ_BUFSZ+1];
 	float32_t 					q_buffer[IQ_BUFSZ+1];
 	float32_t 					a_buffer[IQ_BUFSZ+1];
+	float32_t 					a2_buffer[IQ_BUFSZ+1];
+	float32_t 					a3_buffer[IQ_BUFSZ+1];
 	float32_t 					b_buffer[(IQ_BUFSZ*2)+1];	// this is larger since we need interleaved data for magnitude calculation in AM demod and thus, twice as much space
 	float32_t					c_buffer[IQ_BUFSZ+1];
 	float32_t					d_buffer[IQ_BUFSZ+1];

--- a/mchf-eclipse/drivers/audio/audio_filter.c
+++ b/mchf-eclipse/drivers/audio/audio_filter.c
@@ -99,6 +99,8 @@ static const FilterConfig filter_list_2P3KHz[] =      {
 #define FILTER_ALL (FILTER_CW|FILTER_SSB|FILTER_AM|FILTER_FM)
 #define FILTER_NOFM (FILTER_CW|FILTER_SSB|FILTER_AM)
 #define FILTER_SSBAM (FILTER_SSB|FILTER_AM)
+#define FILTER_SSBSAM (FILTER_SSB|FILTER_AM|FILTER_SAM)
+#define FILTER_AMSAM (FILTER_AM|FILTER_SAM)
 #define FILTER_SSBCW (FILTER_SSB|FILTER_CW)
 #define FILTER_AMFM (FILTER_AM|FILTER_FM)
 #define FILTER_NONE (0)
@@ -115,7 +117,7 @@ FilterDescriptor FilterInfo[AUDIO_FILTER_NUM] =
     {  AUDIO_2P3KHZ, "  2.3k ",  2300, FILTER_SSBAM,   FILTER_SSB,  6, 2, filter_list_2P3KHz },
     {  AUDIO_2P5KHZ, "  2.5k ",  2500, FILTER_SSBAM,   FILTER_SSB,   3, 2, filter_stdLabelsLpfBpf },
     {  AUDIO_2P7KHZ, "  2.7k ",  2700, FILTER_NOFM,    FILTER_NONE, 3, 2, filter_stdLabelsLpfBpf },
-    {  AUDIO_2P9KHZ, "  2.9k ",  2900, FILTER_SSBAM,   FILTER_AM,   3, 2, filter_stdLabelsLpfBpf },
+    {  AUDIO_2P9KHZ, "  2.9k ",  2900, FILTER_SSBSAM,  FILTER_AM,   3, 2, filter_stdLabelsLpfBpf },
     {  AUDIO_3P2KHZ, "  3.2k ",  3200, FILTER_SSBAM,   FILTER_NONE, 3, 2, filter_stdLabelsLpfBpf },
     {  AUDIO_3P4KHZ, "  3.4k ",  3400, FILTER_SSBAM,   FILTER_NONE, 3, 2, filter_stdLabelsLpfBpf },
     {  AUDIO_3P6KHZ, "  3.6k ",  3600, FILTER_SSBAMFM, FILTER_NONE, 3, 2, filter_stdLabelsLpfBpf },
@@ -124,7 +126,7 @@ FilterDescriptor FilterInfo[AUDIO_FILTER_NUM] =
     {  AUDIO_4P2KHZ, "  4.2k ",  4200, FILTER_SSBAM,   FILTER_NONE, 2, 1, filter_stdLabelsOnOff },
     {  AUDIO_4P4KHZ, "  4.4k ",  4400, FILTER_NOFM,    FILTER_NONE, 2, 1, filter_stdLabelsOnOff },
     {  AUDIO_4P6KHZ, "  4.6k ",  4600, FILTER_AM,      FILTER_NONE, 2, 1, filter_stdLabelsOnOff },
-    {  AUDIO_4P8KHZ, "  4.8k ",  4800, FILTER_AM,      FILTER_NONE, 2, 1, filter_stdLabelsOnOff },
+    {  AUDIO_4P8KHZ, "  4.8k ",  4800, FILTER_AMSAM,      FILTER_NONE, 2, 1, filter_stdLabelsOnOff },
     {  AUDIO_5P0KHZ, "  5.0k ",  5000, FILTER_AMFM,    FILTER_FM,   2, 1, filter_stdLabelsOnOff },
     {  AUDIO_5P5KHZ, "  5.5k ",  5500, FILTER_AM,      FILTER_NONE, 2, 1, filter_stdLabelsOnOff },
     {  AUDIO_6P0KHZ, "  6.0k ",  6000, FILTER_AMFM,    FILTER_NONE, 2, 1, filter_stdLabelsOnOff },
@@ -188,7 +190,7 @@ IIR_antialias_coeff_pv: points to the array of IIR coeffs for the antialias IIR 
  * ###############################################################
  */
 
-const FilterPathDescriptor FilterPathInfo[86] = // how to automatically determine this figure? --> also change in audio_filter.h !!!
+const FilterPathDescriptor FilterPathInfo[88] = // how to automatically determine this figure? --> also change in audio_filter.h !!!
 									//
 {
 // ID, mode, filter_select_ID, FIR_numTaps, FIR_I_coeff_file, FIR_Q_coeff_file, FIR_dec_numTaps, FIR_dec_coeff_file,
@@ -431,47 +433,47 @@ const FilterPathDescriptor FilterPathInfo[86] = // how to automatically determin
 		&FirRxInterpolate_4_5k, &IIR_aa_5k},
 
 //55		// new decimation rate, new decimation filter, new interpolation filter, no IIR Prefilter, no IIR interpolation filter
-	{	AUDIO_5P0KHZ, NULL, FILTER_SSB, 1, I_NUM_TAPS, i_rx_5k_coeffs, q_rx_5k_coeffs, &FirRxDecimateMinLPF,
+	{	AUDIO_5P0KHZ, "LPF", FILTER_SSB, 1, I_NUM_TAPS, i_rx_5k_coeffs, q_rx_5k_coeffs, &FirRxDecimateMinLPF,
 		RX_DECIMATION_RATE_24KHZ, NULL,
 		&FirRxInterpolate10KHZ, NULL},
 
-	{	AUDIO_5P5KHZ, NULL, FILTER_SSB, 1, I_NUM_TAPS, i_rx_5k_coeffs, q_rx_5k_coeffs, &FirRxDecimateMinLPF,
+	{	AUDIO_5P5KHZ, "LPF", FILTER_SSB, 1, I_NUM_TAPS, i_rx_5k_coeffs, q_rx_5k_coeffs, &FirRxDecimateMinLPF,
 		RX_DECIMATION_RATE_24KHZ, NULL,
 		&FirRxInterpolate10KHZ, NULL},
 
-	{	AUDIO_6P0KHZ, NULL, FILTER_SSB, 1, I_NUM_TAPS, i_rx_6k_coeffs, q_rx_6k_coeffs, &FirRxDecimateMinLPF,
+	{	AUDIO_6P0KHZ, "LPF", FILTER_SSB, 1, I_NUM_TAPS, i_rx_6k_coeffs, q_rx_6k_coeffs, &FirRxDecimateMinLPF,
 		RX_DECIMATION_RATE_24KHZ, NULL,
 		&FirRxInterpolate10KHZ, NULL},
 
-	{	AUDIO_6P5KHZ, NULL, FILTER_SSB, 1, I_NUM_TAPS, i_rx_6k_coeffs, q_rx_6k_coeffs, &FirRxDecimateMinLPF,
+	{	AUDIO_6P5KHZ, "LPF", FILTER_SSB, 1, I_NUM_TAPS, i_rx_6k_coeffs, q_rx_6k_coeffs, &FirRxDecimateMinLPF,
 		RX_DECIMATION_RATE_24KHZ, NULL,
 		&FirRxInterpolate10KHZ, NULL},
 
-	{	AUDIO_7P0KHZ, NULL, FILTER_SSB, 1, I_NUM_TAPS, i_rx_6k_coeffs, q_rx_6k_coeffs, &FirRxDecimateMinLPF,
+	{	AUDIO_7P0KHZ, "LPF", FILTER_SSB, 1, I_NUM_TAPS, i_rx_6k_coeffs, q_rx_6k_coeffs, &FirRxDecimateMinLPF,
 		RX_DECIMATION_RATE_24KHZ, NULL,
 		&FirRxInterpolate10KHZ, NULL},
 //60
-	{	AUDIO_7P5KHZ, NULL, FILTER_SSB, 1, I_NUM_TAPS, i_rx_7k5_coeffs, q_rx_7k5_coeffs, &FirRxDecimateMinLPF,
+	{	AUDIO_7P5KHZ, "LPF", FILTER_SSB, 1, I_NUM_TAPS, i_rx_7k5_coeffs, q_rx_7k5_coeffs, &FirRxDecimateMinLPF,
 		RX_DECIMATION_RATE_24KHZ, NULL,
 		&FirRxInterpolate10KHZ, NULL},
 			// additional IIR interpolation filter
-	{	AUDIO_8P0KHZ, NULL, FILTER_SSB, 1, I_NUM_TAPS, i_rx_10k_coeffs, q_rx_10k_coeffs, &FirRxDecimateMinLPF,
+	{	AUDIO_8P0KHZ, "LPF", FILTER_SSB, 1, I_NUM_TAPS, i_rx_10k_coeffs, q_rx_10k_coeffs, &FirRxDecimateMinLPF,
 		RX_DECIMATION_RATE_24KHZ, NULL,
 		&FirRxInterpolate_4_10k, &IIR_aa_8k},
 
-	{	AUDIO_8P5KHZ, NULL, FILTER_SSB, 1, I_NUM_TAPS, i_rx_10k_coeffs, q_rx_10k_coeffs, &FirRxDecimateMinLPF,
+	{	AUDIO_8P5KHZ, "LPF", FILTER_SSB, 1, I_NUM_TAPS, i_rx_10k_coeffs, q_rx_10k_coeffs, &FirRxDecimateMinLPF,
 		RX_DECIMATION_RATE_24KHZ, NULL,
 		&FirRxInterpolate_4_10k, &IIR_aa_8k5},
 
-	{	AUDIO_9P0KHZ, NULL, FILTER_SSB, 1, I_NUM_TAPS, i_rx_10k_coeffs, q_rx_10k_coeffs, &FirRxDecimateMinLPF,
+	{	AUDIO_9P0KHZ, "LPF", FILTER_SSB, 1, I_NUM_TAPS, i_rx_10k_coeffs, q_rx_10k_coeffs, &FirRxDecimateMinLPF,
 		RX_DECIMATION_RATE_24KHZ, NULL,
 		&FirRxInterpolate_4_10k, &IIR_aa_9k},
 
-	{	AUDIO_9P5KHZ, NULL, FILTER_SSB, 1, I_NUM_TAPS, i_rx_10k_coeffs, q_rx_10k_coeffs, &FirRxDecimateMinLPF,
+	{	AUDIO_9P5KHZ, "LPF", FILTER_SSB, 1, I_NUM_TAPS, i_rx_10k_coeffs, q_rx_10k_coeffs, &FirRxDecimateMinLPF,
 		RX_DECIMATION_RATE_24KHZ, NULL,
 		&FirRxInterpolate_4_10k, &IIR_aa_9k5},
 
-	{	AUDIO_10P0KHZ, NULL, FILTER_SSB, 1, I_NUM_TAPS, i_rx_10k_coeffs, q_rx_10k_coeffs, &FirRxDecimateMinLPF,
+	{	AUDIO_10P0KHZ, "LPF", FILTER_SSB, 1, I_NUM_TAPS, i_rx_10k_coeffs, q_rx_10k_coeffs, &FirRxDecimateMinLPF,
 		RX_DECIMATION_RATE_24KHZ, NULL,
 		&FirRxInterpolate_4_10k, &IIR_aa_10k},
 
@@ -481,7 +483,7 @@ const FilterPathDescriptor FilterPathInfo[86] = // how to automatically determin
 //		when tuned away from the carrier, this has been called "sideband-selected AM demodulation" . . . wow . . .
 //###################################################################################################################################
 
-		// in AM, we ALWAYS use the LPF IIR audio PreFilter, regardless of the selected filter_select_ID.
+		// in AM, we ALWAYS use the lowpass filter version of the IIR audio PreFilter, regardless of the selected filter_select_ID.
 		// this is because we assume AM mode to be used to demodulate DSB signals, so BPF (sideband suppression) is not necessary
 
 	{	AUDIO_1P4KHZ, " AM", FILTER_AM, 1, Q_NUM_TAPS, iq_rx_am_2k3_coeffs, iq_rx_am_2k3_coeffs, &FirRxDecimate,
@@ -573,7 +575,16 @@ const FilterPathDescriptor FilterPathInfo[86] = // how to automatically determin
 	{	AUDIO_10P0KHZ, " AM", FILTER_AM, 1, Q_NUM_TAPS, iq_rx_am_10k_coeffs, iq_rx_am_10k_coeffs, &FirRxDecimateMinLPF,
 		RX_DECIMATION_RATE_24KHZ, NULL,
 		&FirRxInterpolate_4_10k, &IIR_aa_10k},
-	}; // end FilterPath
+
+	{	AUDIO_2P9KHZ, "SAM", FILTER_SAM, 1, I_NUM_TAPS, i_rx_3k6_coeffs, q_rx_3k6_coeffs, &FirRxDecimate,
+		RX_DECIMATION_RATE_12KHZ, &IIR_2k9_LPF,
+		&FirRxInterpolate, NULL},
+
+	{	AUDIO_4P8KHZ, "SAM", FILTER_SAM, 1, I_NUM_TAPS, i_rx_5k_coeffs, q_rx_5k_coeffs, &FirRxDecimate,
+		RX_DECIMATION_RATE_12KHZ, &IIR_4k8_LPF,
+		&FirRxInterpolate, NULL},
+
+}; // end FilterPath
 
 
 /*
@@ -595,6 +606,9 @@ uint8_t AudioFilter_NextApplicableFilter()
   switch(ts.dmod_mode) {
   case DEMOD_AM:
     myMode = FILTER_AM;
+    break;
+  case DEMOD_SAM:
+    myMode = FILTER_SAM;
     break;
   case DEMOD_FM:
     myMode = FILTER_FM;
@@ -700,7 +714,7 @@ void AudioFilter_CalcRxPhaseAdj(void)
 
     // new filter_path method
     // take all info from FilterPathInfo
-    // IIR_PreFilter.pkCoeffs = (float *)FilterPathInfo[ts.filter_path-1].IIR_PreFilter_pk_file;
+    // I_NUM_TAPS, i_rx_3k6_coeffs, q_rx_3k6_coeffs
     //
     if (ts.filter_path == 0) {
     fc.rx_q_num_taps = Q_NUM_TAPS;
@@ -982,11 +996,14 @@ void AudioFilter_CalcRxPhaseAdj(void)
 
     	//
     // In AM mode we do NOT do 90 degree phase shift, so we do FIR low-pass instead of Hilbert, setting "I" channel the same as "Q"
-    if(ts.dmod_mode == DEMOD_AM)        // use "Q" filter settings in AM mode for "I" channel
+    	// hmmm, is this necessary? In AM AND in SSB, we set the fc.rx_filt_XXX in the right manner in this void, so no need to distinguish again between AM and SSB
+/*    if(ts.dmod_mode == DEMOD_AM)        // use "Q" filter settings in AM mode for "I" channel
         arm_fir_init_f32((arm_fir_instance_f32 *)&FIR_I,fc.rx_q_num_taps,(float32_t *)&fc.rx_filt_i[0], &FirState_I[0],fc.rx_q_block_size); // load "I" with "Q" coefficients
     else                                // not in AM mode, but SSB or FM - use normal settings where I and Q are 90 degrees apart
         arm_fir_init_f32((arm_fir_instance_f32 *)&FIR_I,fc.rx_i_num_taps,(float32_t *)&fc.rx_filt_i[0], &FirState_I[0],fc.rx_i_block_size); // load "I" with "I" coefficients
-    //
+  */
+    // Initialization of the FIR/Hilbert filters
+    arm_fir_init_f32((arm_fir_instance_f32 *)&FIR_I,fc.rx_i_num_taps,(float32_t *)&fc.rx_filt_i[0], &FirState_I[0],fc.rx_i_block_size); // load "I" with "I" coefficients
     arm_fir_init_f32((arm_fir_instance_f32 *)&FIR_Q,fc.rx_q_num_taps,(float32_t *)&fc.rx_filt_q[0], &FirState_Q[0],fc.rx_q_block_size);     // load "Q" with "Q" coefficients
     //
 }

--- a/mchf-eclipse/drivers/audio/audio_filter.h
+++ b/mchf-eclipse/drivers/audio/audio_filter.h
@@ -81,7 +81,8 @@ enum {
   FILTER_CW = 1,
   FILTER_SSB = 2,
   FILTER_AM = 4,
-  FILTER_FM = 8
+  FILTER_FM = 8,
+  FILTER_SAM = 16
 };
 //
 //
@@ -137,7 +138,7 @@ typedef struct FilterPathDescriptor_s {
   const arm_iir_lattice_instance_f32* iir_instance;
 } FilterPathDescriptor;
 
-extern const FilterPathDescriptor FilterPathInfo[86]; // also change this figure in audio_filter.c
+extern const FilterPathDescriptor FilterPathInfo[88]; // also change this figure in audio_filter.c
 //
 // Define visual widths of audio filters for on-screen indicator in Hz
 //

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -1698,6 +1698,10 @@ void UiDriverShowMode(void)	{
 			offset = 8;
 			txt = "LSB";
 			break;
+		case DEMOD_SAM:
+			offset = 8;
+			txt = "SAM";
+			break;
 		case DEMOD_AM:
 			offset = 12;
 			txt = "AM";
@@ -3624,6 +3628,8 @@ void UiDriverSetDemodMode(uint32_t new_mode)
 	//
 	AudioFilter_CalcTxPhaseAdj();
 	AudioManagement_CalcTxIqGainAdj();
+	// FIXME: HACK: remove this after implementation
+	if (ts.dmod_mode == DEMOD_SAM) audio_driver_set_rx_audio_filter();
 
 	// Change function buttons caption
 	//UiDriverCreateFunctionButtons(false);
@@ -3666,6 +3672,11 @@ static void UiDriverChangeDemodMode(uchar noskip)
 
 	if((loc_mode == DEMOD_FM) && (!ts.iq_freq_mode))	{	// are we in FM and frequency translate is off?
 		loc_mode++;		// yes - FM NOT permitted unless frequency translate is active, so skip!
+	}
+
+	if(loc_mode == DEMOD_SAM)	{	// yes - is this SAM mode?
+		if(!ts.sam_enabled)		// is SAM to be disabled?
+			loc_mode++;				// yes - go to next mode
 	}
 
 	// Check for overflow
@@ -4948,9 +4959,9 @@ void UiDriverDisplayFilterBW(void)
 	width /= calc;							// calculate width of line in pixels
 	//
 	//
-	if((ts.dmod_mode == DEMOD_AM) || (ts.dmod_mode == DEMOD_FM))	{	// special cases - AM and FM, which are double-sidebanded
+	if((ts.dmod_mode == DEMOD_AM) ||(ts.dmod_mode == DEMOD_SAM) || (ts.dmod_mode == DEMOD_FM))	{	// special cases - AM, SAM and FM, which are double-sidebanded
 		lpos -= width;					// line starts "width" below center
-		width *= 2;						// the width is double in AM, above and below center
+		width *= 2;						// the width is double in AM & SAM, above and below center
 	}
 	else if(!is_usb)	// not AM, but LSB:  calculate position of line, compensating for both width and the fact that SSB/CW filters are not centered
 		lpos -= ((offset - (width/2)) + width);	// if LSB it will be below zero Hz

--- a/mchf-eclipse/drivers/ui/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/ui_menu.c
@@ -563,6 +563,7 @@ const MenuDescriptor filterGroup[] = {
     { MENU_FILTER, MENU_ITEM, MENU_9K5_SEL,"528","9.5k Filter"},
     { MENU_FILTER, MENU_ITEM, MENU_10K0_SEL,"529","10.0k Filter"},
     { MENU_FILTER, MENU_ITEM, MENU_FP_SEL,"FPA","FilterPath (exp.)"  },
+	{ MENU_FILTER, MENU_ITEM, MENU_DEMOD_SAM,"SAM","Enable SAM dem."  },
     { MENU_FILTER, MENU_STOP, 0, "   " , NULL }
 };
 
@@ -3479,7 +3480,14 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
         sprintf(options, "  %u", ts.filter_path);
         break;
 
-	case CONFIG_DSP_ENABLE:	// Enable DSP NR
+    case MENU_DEMOD_SAM:	// Enable demodulation mode SAM
+		temp_var = ts.sam_enabled;
+		tchange = UiDriverMenuItemChangeEnableOnOff(var, mode, &temp_var,0,options,&clr);
+		if(tchange)
+		    ts.sam_enabled = temp_var;
+		break;
+
+    case CONFIG_DSP_ENABLE:	// Enable DSP NR
 		temp_var = ts.dsp_enabled;
 		tchange = UiDriverMenuItemChangeEnableOnOff(var, mode, &temp_var,0,options,&clr);
 		if(tchange)

--- a/mchf-eclipse/drivers/ui/ui_menu.h
+++ b/mchf-eclipse/drivers/ui/ui_menu.h
@@ -238,6 +238,7 @@ enum {
 	CONFIG_DSP_ENABLE,
 	CONFIG_CAT_XLAT,
 	MENU_FP_SEL,
+	MENU_DEMOD_SAM,
 	CONFIG_REDUCE_POWER_ON_LOW_BANDS,
 	//
 	MAX_RADIO_CONFIG_ITEM	// Number of radio configuration menu items - This must ALWAYS remain as the LAST item!

--- a/mchf-eclipse/hardware/mchf_board.h
+++ b/mchf-eclipse/hardware/mchf_board.h
@@ -430,8 +430,9 @@ typedef struct ButtonMap
 #define DEMOD_CW			2
 #define DEMOD_AM			3
 #define	DEMOD_FM			4
-#define DEMOD_DIGI			5
-#define DEMOD_MAX_MODE			5
+#define	DEMOD_SAM			5
+#define DEMOD_DIGI			6
+#define DEMOD_MAX_MODE			6
 
 #define RTC_OSC_FREQ			32768
 
@@ -1415,6 +1416,7 @@ typedef struct TransceiverState
 	uchar	tune_power_level;			// TX power in antenna tuning function
 	uchar	power_temp;				// temporary tx power if tune is different from actual tx power
 	bool	dsp_enabled;				// NR disabled
+	bool	sam_enabled;				// demodulation mode SAM enabled
 	uchar	xlat;					// CAT <> IQ-Audio
 	bool	dynamic_tuning_active;			// dynamic tuning active by estimating the encoder speed
 //	uint16_t df8oe_test;				// only debugging use

--- a/mchf-eclipse/main.c
+++ b/mchf-eclipse/main.c
@@ -536,7 +536,7 @@ void TransceiverStateInit(void)
 	ts.tune_power_level = 0;					// Tune with FULL POWER
 	ts.xlat = 0;							// 0 = report base frequency, 1 = report xlat-frequency;
 	ts.audio_int_counter = 0;					//test DL2FW
-
+	ts.sam_enabled = 0;						// demodulation mode SAM not enabled
 
 	//ts.filter_path = 52; // uncomment to use  filter path of given number -1 (hack, filter path is used all the time)
 }


### PR DESCRIPTION
This is a pre-alpha version of an SAM demodulation mode (you have to enable it in the filter menu, last entry after filter_path). It is implemented as a DSB (double side band) demodulation. It demodulates USB (I + Q) AND LSB (I - Q) simultaneously and adds the audio. After that the audio IIR filter is applied (only 2k9 and 4k8 at the moment, please push filter button after you changed mode to SAM!!!). It therefore simulates a synchronous detector and thus it is called SAM. However, broadcast stations have to be tuned to very very accurately (to the nearest one Hertz), otherwise the audio will pulsate in an annoying way. (Yes, it is planned to implement an automatic finetuning to the carrier! Please be patient ;-)).
SAM mode is better than AM demodulation in situations when heavy selective fading occurs. In Central Europe, you could try 6070kHz at daytime where selective fading is frequent.
