### PR TITLE
Added proper handling of graphical bw updates for filter paths.

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_filter.h
+++ b/mchf-eclipse/drivers/audio/audio_filter.h
@@ -142,6 +142,10 @@ typedef struct FilterPathDescriptor_s {
   const arm_iir_lattice_instance_f32* pre_instance;
   const arm_fir_interpolate_instance_f32* interpolate;
   const arm_iir_lattice_instance_f32* iir_instance;
+
+  const uint16_t offset; // how much offset in Hz has the center frequency of the filter from base frequency.
+                         // For most non-CW filters 0 is okay,
+                         // in this case bandwidth/2 is being used here.
 } FilterPathDescriptor;
 
 

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -4886,13 +4886,19 @@ void UiDriverDisplayFilterBW(void)
 
 	// Update screen indicator - first get the width and center-frequency offset of the currently-selected filter
 	//
-	const FilterDescriptor* filter_p = &FilterInfo[ts.filter_id];
-	const FilterConfig* config_p = &filter_p->config[ts.filter_select[ts.filter_id]];
-	offset = config_p->offset;
-	width = filter_p->width;
+	if (ts.filter_path != 0) {
+	  const FilterPathDescriptor* path_p = &FilterPathInfo[ts.filter_path-1];
+	  const FilterDescriptor* filter_p = &FilterInfo[path_p->id];
+	  offset = path_p->offset;
+	  width = filter_p->width;
 
-	// TODO: We cheat here a  little, until all filter configs are properly filled.
-	if (ts.filter_select[ts.filter_id] != 0 && offset == 0) {
+	} else {
+	  const FilterDescriptor* filter_p = &FilterInfo[ts.filter_id];
+	  const FilterConfig* config_p = &filter_p->config[ts.filter_select[ts.filter_id]];
+	  offset = config_p->offset;
+	  width = filter_p->width;
+	}
+	if (offset == 0) {
 	  offset = width/2;
 	}
 	//


### PR DESCRIPTION
For some paths, a non-zero offset needs  to be defined, most should be fine with
default of bandwidth/2.
