### PR TITLE
snap carrier mode alpha version - not yet properly working

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -115,7 +115,6 @@ __IO	arm_fir_instance_f32	FIR_Q_TX;
 // Transceiver state public structure
 extern __IO TransceiverState 	ts;
 
-
 // Audio driver publics
 __IO	AudioDriverState		ads;
 
@@ -1681,6 +1680,19 @@ static void audio_rx_processor(int16_t *src, int16_t *dst, int16_t size)
 				sd.state    = 1;
 			}
 		}
+		if(sc.state == 0){
+			sc.FFT_Samples[sc.samp_ptr] = (float32_t)(*(src + 1));	// get floating point data for FFT for snap carrier
+			sc.samp_ptr++;
+			sc.FFT_Samples[sc.samp_ptr] = (float32_t)(*(src));
+			sc.samp_ptr++;
+			// obtain samples for snap carrier mode
+			if(sc.samp_ptr >= FFT_IQ_BUFF_LEN2*2)
+			{
+				sc.samp_ptr = 0;
+				sc.state    = 1;
+			}
+		}
+
 		//
 		if(*src > ADC_CLIP_WARN_THRESHOLD/4)	{		// This is the release threshold for the auto RF gain
 			ads.adc_quarter_clip = 1;

--- a/mchf-eclipse/drivers/audio/audio_driver.h
+++ b/mchf-eclipse/drivers/audio/audio_driver.h
@@ -29,6 +29,8 @@
 // -----------------------------
 // FFT buffer (128, 512 or 2048)
 #define FFT_IQ_BUFF_LEN		512
+
+
 //
 // Useful DEFINEs for windowing functions
 //
@@ -512,7 +514,6 @@ void I2S_RX_CallBack(int16_t *src, int16_t *dst, int16_t size, uint16_t ht);
 extern __IO		AudioDriverState	ads;
 extern __IO     SMeter              sm;
 extern __IO FilterCoeffs        fc;
-
 
 
 #endif

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -50,7 +50,6 @@
 #include "ui_configuration.h"
 #include "cw_gen.h"
 
-
 static void 	UiDriverPublicsInit(void);
 static void 	UiDriverProcessKeyboard(void);
 static void 	UiDriverPressHoldStep(uchar is_up);
@@ -97,6 +96,8 @@ static void 	UiDriverRefreshTemperatureDisplay(uchar enabled,int temp);
 static void 	UiDriverHandleLoTemperature(void);
 static void 	UiDriverSwitchOffPtt(void);
 static void 	UiDriverInitMainFreqDisplay(void);
+static void 	audio_snap_carrier (void);
+
 //
 //
 //
@@ -229,6 +230,11 @@ uchar drv_state = 0;
 
 bool filter_path_change = false;
 //
+
+
+
+// Snap carrier
+//__IO   SnapCarrier     sc;
 
 
 
@@ -1036,6 +1042,7 @@ static void UiDriverProcessKeyboard(void)
 				if(ts.menu_mode)	{		// Are we in menu mode?
 				  UiMenu_RenderFirstScreen();
 				}
+				else audio_snap_carrier();
 				break;
 			case BUTTON_F3_PRESSED:	// Press-and-hold button F3
 				//
@@ -6349,3 +6356,163 @@ void UiDriver_KeyTestScreen(void)
 		}
 	}
 }
+
+
+//
+//*----------------------------------------------------------------------------
+//* Function Name       : audio_snap_carrier
+//* Object              :
+//* Object              : when called, it determines the carrier frequency inside the filter bandwidth and tunes Rx to that freqeuency
+//* Input Parameters    :
+//* Output Parameters   :
+//* Functions called    :
+//*----------------------------------------------------------------------------
+
+static void audio_snap_carrier (void)
+{
+	int16_t Lbin, Ubin;
+	int16_t bw_LSB = 0;
+	int16_t maximum = 0;
+	int16_t posbin = 0;
+	int16_t maxbin = 1;
+	int16_t bw_USB = 0;
+	float bin_BW = 48000.0 * 2.0 / FFT_IQ_BUFF_LEN2;
+	ulong delta, i;
+	ulong freq = df.tune_new / 4;
+	float32_t bin1, bin2, bin3;
+	arm_status a;
+	// Init FFT structures
+	a = arm_rfft_init_f32((arm_rfft_instance_f32 *)&sc.S,(arm_cfft_radix4_instance_f32 *)&sc.S_CFFT,FFT_IQ_BUFF_LEN2,1,1);
+//	if (!a) return;
+
+//	1. determine Lbin and Ubin from ts.dmod_mode and FilterInfo.width
+
+//	2. determine posbin from ts.iq_freq_mode
+
+		if(!ts.iq_freq_mode)	{	// yes, are we NOT in translate mode?
+			posbin = FFT_IQ_BUFF_LEN2 / 4;
+		}
+		else if(ts.iq_freq_mode == FREQ_IQ_CONV_P6KHZ)	{	// we are in RF LO HIGH mode (tuning is below center of screen)
+			posbin = (FFT_IQ_BUFF_LEN2 / 4) - (FFT_IQ_BUFF_LEN2 / 16);
+		}
+		else if(ts.iq_freq_mode == FREQ_IQ_CONV_M6KHZ)	{	// we are in RF LO LOW mode (tuning is above center of screen)
+			posbin = (FFT_IQ_BUFF_LEN2 / 4) + (FFT_IQ_BUFF_LEN2 / 16);
+		}
+		else if(ts.iq_freq_mode == FREQ_IQ_CONV_P12KHZ)	{	// we are in RF LO HIGH mode (tuning is below center of screen)
+			posbin = (FFT_IQ_BUFF_LEN2 / 4) - (FFT_IQ_BUFF_LEN2 / 8);
+		}
+		else if(ts.iq_freq_mode == FREQ_IQ_CONV_M12KHZ)	{	// we are in RF LO LOW mode (tuning is above center of screen)
+			posbin = (FFT_IQ_BUFF_LEN2 / 4) + (FFT_IQ_BUFF_LEN2 / 8);
+		}
+
+// 	3. calculate upper and lower limit for determination of maximum magnitude
+
+//		determine bandwith separately for lower and upper sideband
+
+		if (ts.dmod_mode == DEMOD_LSB) {
+			bw_USB = 0;
+			bw_LSB = FilterInfo[FilterPathInfo[ts.filter_path].id].width;
+		}
+
+		if (ts.dmod_mode == DEMOD_USB) {
+			bw_LSB = 0;
+			bw_USB = FilterInfo[FilterPathInfo[ts.filter_path].id].width;
+		}
+
+		if (ts.dmod_mode == DEMOD_SAM || ts.dmod_mode == DEMOD_AM) {
+			bw_LSB = FilterInfo[FilterPathInfo[ts.filter_path].id].width;
+			bw_USB = FilterInfo[FilterPathInfo[ts.filter_path].id].width;
+		}
+
+		Lbin = posbin - (bw_LSB / bin_BW); // the bin on the lower sideband side
+		Ubin = posbin + (bw_USB / bin_BW); // the bin on the upper sideband side
+
+
+// 	FFT preparation
+
+		arm_scale_f32((float32_t *)sc.FFT_Samples, (float32_t)(1/ads.codec_gain_calc * 1000), (float32_t *)sc.FFT_Samples, FFT_IQ_BUFF_LEN2);	// scale input according to A/D gain
+		//
+// do windowing function on input data to get less "Bin Leakage" on FFT data
+		// Hanning window
+		for(int i = 0; i < FFT_IQ_BUFF_LEN2; i++){
+		    sc.FFT_Windat[i] = 0.5 * (float32_t)((1 - (arm_cos_f32(PI*2 * (float32_t)i / (float32_t)(FFT_IQ_BUFF_LEN2-1)))) * sc.FFT_Samples[i]);
+		}
+
+		// run FFT
+		arm_rfft_f32((arm_rfft_instance_f32 *)&sc.S,(float32_t *)(sc.FFT_Windat),(float32_t *)(sc.FFT_Samples));	// Do FFT
+		//
+		// Calculate magnitude
+		//
+		arm_cmplx_mag_f32((float32_t *)(sc.FFT_Samples),(float32_t *)(sc.FFT_MagData),(FFT_IQ_BUFF_LEN2/2));
+		//
+		// putting the bins in frequency-sequential order!
+		//
+			for(i = 0; i < (FFT_IQ_BUFF_LEN2/2); i++)	{
+				if(i < (FFT_IQ_BUFF_LEN2/4))	{		// build left half of spectrum data
+					sc.FFT_Samples[i] = sc.FFT_MagData[i + FFT_IQ_BUFF_LEN2/4];	// get data
+				}
+				else	{							// build right half of spectrum data
+					sc.FFT_Samples[i] = sc.FFT_MagData[i - FFT_IQ_BUFF_LEN2/4];	// get data
+				}
+			}
+
+		// look for maximum value and save the bin # for frequency delta calculation
+        for (int c = Lbin; c <= Ubin; c++) { // search for FFT bin with highest value = carrier and save the no. of the bin in maxbin
+        if (maximum < sc.FFT_Samples[c]) {
+            maximum = sc.FFT_Samples[c];
+            maxbin = c;
+        }}
+        maximum = 0; // reset maximum for next time ;-)
+
+        // ok, we have found the maximum, now set frequency to that bin
+        delta = (maxbin - posbin) * bin_BW;
+        // set frequency variable
+        freq = freq + delta;
+        df.tune_new = freq * 4;
+        // set frequency of Si570
+        UiDriverUpdateFrequency ( 2, 0);
+//        UiLcdHy28_PrintText(80,160, delta,Cyan,Black,1);
+        // Do FFT again for finetuning !
+       // 	FFT preparation
+        		arm_scale_f32((float32_t *)sc.FFT_Samples, (float32_t)(1/ads.codec_gain_calc * 1000), (float32_t *)sc.FFT_Samples, FFT_IQ_BUFF_LEN2);	// scale input according to A/D gain
+       		//
+       // do windowing function on input data to get less "Bin Leakage" on FFT data
+       		// Hanning window
+       		for(i = 0; i < FFT_IQ_BUFF_LEN2; i++){
+       		    sc.FFT_Windat[i] = 0.5 * (float32_t)((1 - (arm_cos_f32(PI*2 * (float32_t)i / (float32_t)(FFT_IQ_BUFF_LEN2-1)))) * sc.FFT_Samples[i]);
+       		}
+        	// run FFT
+       		arm_rfft_f32((arm_rfft_instance_f32 *)&sc.S,(float32_t *)(sc.FFT_Windat),(float32_t *)(sc.FFT_Samples));	// Do FFT
+       		//
+       		// Calculate magnitude
+       		//
+       		arm_cmplx_mag_f32((float32_t *)(sc.FFT_Samples),(float32_t *)(sc.FFT_MagData),(FFT_IQ_BUFF_LEN2/2));
+       		//
+       		// putting the bins in frequency-sequential order!
+       		//
+       			for(i = 0; i < (FFT_IQ_BUFF_LEN2/2); i++)	{
+       				if(i < (FFT_IQ_BUFF_LEN2/4))	{		// build left half of spectrum data
+       					sc.FFT_Samples[i] = sc.FFT_MagData[i + FFT_IQ_BUFF_LEN2/4];	// get data
+       				}
+       				else	{							// build right half of spectrum data
+       					sc.FFT_Samples[i] = sc.FFT_MagData[i - FFT_IQ_BUFF_LEN2/4];	// get data
+       				}
+       			}
+         // estimate frequ of carrier by three-point-interpolation of bins around posbin
+   		bin1 = sc.FFT_Samples[posbin-1];
+   		bin2 = sc.FFT_Samples[posbin];
+   		bin3 = sc.FFT_Samples[posbin+1];
+
+       	// formula by (Jacobsen & Kootsookos 2007) equation (4) P=1.36 for Hanning window FFT function
+   		delta = bin_BW * (1.36 * (bin3 - bin1)) / (bin1 + bin2 + bin3);
+//        UiLcdHy28_PrintText(80,160, delta,Cyan,Black,1);
+    		// set frequency variable
+        freq = freq + delta;
+        df.tune_new = freq * 4;
+
+        UiDriverUpdateFrequency ( 2, 0);
+        sc.state = 0;
+
+}
+
+

--- a/mchf-eclipse/drivers/ui/ui_driver.h
+++ b/mchf-eclipse/drivers/ui/ui_driver.h
@@ -624,6 +624,27 @@ STATE_SWITCH_OFF_PTT			//
 #define	STEP_PRESS_PLUS				2
 //
 
+#define FFT_IQ_BUFF_LEN2 2048
+typedef struct SnapCarrier
+{
+    // FFT state
+    arm_rfft_instance_f32           S;
+
+    arm_cfft_radix4_instance_f32    S_CFFT;
+
+    // Samples buffer
+    //
+    float32_t   FFT_Samples[FFT_IQ_BUFF_LEN2];
+    float32_t   FFT_Windat[FFT_IQ_BUFF_LEN2];
+    float32_t   FFT_MagData[FFT_IQ_BUFF_LEN2/2];
+    // Current data ptr
+    ulong   samp_ptr;
+    // State machine current state
+    uchar   state;
+
+} SnapCarrier;
+
+__IO SnapCarrier sc;
 // ------------------------------------------------
 // Keypad state
 extern __IO KeypadState				ks;


### PR DESCRIPTION
long press on F2 snaps the carrier, which is intended to automatically tune the mcHF to a carrier in the receiver filter bandwidth. Does tune at the moment but does not work very accurately yet, this pull request in order to save the acquired working status.
