### PR TITLE
Free up much needed RAM space in the main RAM area

### DIFF
--- a/mchf-eclipse/arm-gcc-link.ld
+++ b/mchf-eclipse/arm-gcc-link.ld
@@ -122,6 +122,14 @@ SECTIONS
 		*(.co_stack .co_stack.*)
 	} > ram 
 	
+	.ccm : {
+  		. = ALIGN(4);
+  		_sccm = .;
+  		*(.ccm)
+  		. = ALIGN(4);      
+  		_eccm = .;
+	}>ram1
+	
 	/* Set stack top to end of ram , and stack limit move down by
 	* size of stack_dummy section */
 	__StackTop = ORIGIN(ram ) + LENGTH(ram );

--- a/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
@@ -21,7 +21,11 @@
 #include "waterfall_colours.h"
 // ------------------------------------------------
 // Spectrum display public
-__IO    SpectrumDisplay         sd;
+__IO    SpectrumDisplay  __attribute__ ((section (".ccm")))       sd;
+// this data structure is now located in the Core Connected Memory of the STM32F4
+// this is highly hardware specific code. This data structure nicely fills the 64k with roughly 60k.
+// If this data structure is being changed,  be aware of the 64k limit. See linker script arm-gcc-link.ld
+
 
 static void 	UiDriverFFTWindowFunction(char mode);
 


### PR DESCRIPTION
 by moving the SpectrumDisplay data structure sd to
the  Core Connected Memory area of the STM32F4
