### PR TITLE
snap carrier mode working 

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -31,6 +31,7 @@
 #include "ui_spectrum.h"
 #include "ui_rotary.h"
 #include "filters.h"
+#include "ui_lcd_hy28.h"
 
 
 // SSB filters - now handled in ui_driver to allow I/Q phase adjustment
@@ -1647,44 +1648,44 @@ static void audio_lms_noise_reduction(int16_t psize)
 //* Object              : when called, it determines the carrier frequency inside the filter bandwidth and tunes Rx to that freqeuency
 //* Input Parameters    :
 //* Output Parameters   :
-//* Functions called    : NOT YET WORKING 2016 03 29
+//* Functions called    :
 //*----------------------------------------------------------------------------
 
 // FIXME:
 
-// * snap_carrier is called every time in the audio_rx_driver
-// * sc.snap is assigned 1, if button for snap carrier has been pressed
+// it now works! But it has to be finetuned for greater accuracy DD4WH, 2016_03_30
+
+// * snap_carrier is called every time in the audio_rx_driver --> DONE
+// * sc.snap is assigned 1, if button for snap carrier has been pressed --> DONE
 // * if sc.snap = 1, the audio_rx_driver collects the IQ samples for the FFT and when ready, sets sc.state = 1;
 // * call init FFT only once at startup of mcHF --> DONE
 // * only call frequency update once --> DONE
 // * only call FFT once, but choose the right bins for bin1, bin2, bin3 ;-) --> DONE
 // * experiment with gain: 1000/2000/3000 . . .
-// * change from long press of button to short press
+// * change from long press of button to short press --> DONE
 
 static void audio_snap_carrier (void)
 {
 	if (!sc.snap) return; // button has not been pressed
 	if (!sc.state) return; // FFT samples have not yet been collected
 
-	int16_t Lbin, Ubin;
-	int16_t bw_LSB = 0;
-	int16_t maximum = 0;
-	int16_t posbin = 0;
-	int16_t maxbin = 1;
-	int16_t bw_USB = 0;
+	int Lbin, Ubin;
+	int bw_LSB = 0;
+	int maximum = 0;
+	int posbin = 0;
+	int maxbin = 1;
+	int bw_USB = 0;
 	float bin_BW = 48000.0 * 2.0 / FFT_IQ_BUFF_LEN2; // width of a 1024 tap FFT bin = 46.875Hz, if FFT_IQ_BUFF_LEN2 = 2048 --> 1024 tap FFT
-	long delta, i;
+	long i;
+	float delta1, delta2;
 	ulong freq = df.tune_new / 4;
-	float32_t bin1, bin2, bin3;
+	float bin1, bin2, bin3;
 
 	// now init of FFT structure has been moved to audio_driver_init()
-	//	arm_status a;
-	// Init FFT structures
-	//	a = arm_rfft_init_f32((arm_rfft_instance_f32 *)&sc.S,(arm_cfft_radix4_instance_f32 *)&sc.S_CFFT,FFT_IQ_BUFF_LEN2,1,1);
 
-//	1. determine Lbin and Ubin from ts.dmod_mode and FilterInfo.width
+	//	1. determine Lbin and Ubin from ts.dmod_mode and FilterInfo.width
 
-//	2. determine posbin (where we receive at the moment) from ts.iq_freq_mode
+	//	2. determine posbin (where we receive at the moment) from ts.iq_freq_mode
 
 		if(!ts.iq_freq_mode)	{	// frequency translation off, IF = 0 Hz
 			posbin = FFT_IQ_BUFF_LEN2 / 4; // right in the middle!
@@ -1723,7 +1724,8 @@ static void audio_snap_carrier (void)
 
 		Lbin = posbin - (bw_LSB / bin_BW); // the bin on the lower sideband side
 		Ubin = posbin + (bw_USB / bin_BW); // the bin on the upper sideband side
-
+//		Lbin = posbin - 100;
+//		Ubin = posbin + 100;
 
 // 	FFT preparation
 
@@ -1743,7 +1745,9 @@ static void audio_snap_carrier (void)
 		arm_cmplx_mag_f32((float32_t *)(sc.FFT_Samples),(float32_t *)(sc.FFT_MagData),(FFT_IQ_BUFF_LEN2/2));
 		//
 		// putting the bins in frequency-sequential order!
-/*		// why is this necessary ? I do not understand this? DD4WH 2016_03_29
+		// why is this necessary ? I do not understand this? DD4WH 2016_03_29
+		// it puts the Magnitude samples into FFT_Samples again
+		//
 			for(i = 0; i < (FFT_IQ_BUFF_LEN2/2); i++)	{
 				if(i < (FFT_IQ_BUFF_LEN2/4))	{		// build left half of spectrum data
 					sc.FFT_Samples[i] = sc.FFT_MagData[i + FFT_IQ_BUFF_LEN2/4];	// get data
@@ -1752,63 +1756,29 @@ static void audio_snap_carrier (void)
 					sc.FFT_Samples[i] = sc.FFT_MagData[i - FFT_IQ_BUFF_LEN2/4];	// get data
 				}
 			}
-*/
+
 		// look for maximum value and save the bin # for frequency delta calculation
-	int c;
+		int c;
         for (c = Lbin; c <= Ubin; c++) { // search for FFT bin with highest value = carrier and save the no. of the bin in maxbin
-        if (maximum < sc.FFT_MagData[c]) {
-            maximum = sc.FFT_MagData[c];
+        if (maximum < sc.FFT_Samples[c]) {
+            maximum = sc.FFT_Samples[c];
             maxbin = c;
         }}
         maximum = 0; // reset maximum for next time ;-)
-
+//        maxbin = 2;
+//        posbin = 4;
         // ok, we have found the maximum, now set frequency to that bin
-        delta = (maxbin - posbin) * bin_BW;
+        delta1 = (maxbin - posbin) * bin_BW;
         // set frequency variable
-        freq = freq + delta;
-        df.tune_new = freq * 4;
-        // set frequency of Si570
-//        UiDriverUpdateFrequency ( 2, 0);
-//        UiLcdHy28_PrintText(80,160, delta,Cyan,Black,1);
-
-/*        // We don´t want to do FFT again for finetuning !
-       // 	FFT preparation
-        		arm_scale_f32((float32_t *)sc.FFT_Samples, (float32_t)(1/ads.codec_gain_calc * 1000), (float32_t *)sc.FFT_Samples, FFT_IQ_BUFF_LEN2);	// scale input according to A/D gain
-       		//
-       // do windowing function on input data to get less "Bin Leakage" on FFT data
-       		// Hanning window
-       		for(i = 0; i < FFT_IQ_BUFF_LEN2; i++){
-       		    sc.FFT_Windat[i] = 0.5 * (float32_t)((1 - (arm_cos_f32(PI*2 * (float32_t)i / (float32_t)(FFT_IQ_BUFF_LEN2-1)))) * sc.FFT_Samples[i]);
-       		}
-        	// run FFT
-       		arm_rfft_f32((arm_rfft_instance_f32 *)&sc.S,(float32_t *)(sc.FFT_Windat),(float32_t *)(sc.FFT_Samples));	// Do FFT
-       		//
-       		// Calculate magnitude
-       		//
-       		arm_cmplx_mag_f32((float32_t *)(sc.FFT_Samples),(float32_t *)(sc.FFT_MagData),(FFT_IQ_BUFF_LEN2/2));
-       		//
-       		// putting the bins in frequency-sequential order!
-       		//
-       			for(i = 0; i < (FFT_IQ_BUFF_LEN2/2); i++)	{
-       				if(i < (FFT_IQ_BUFF_LEN2/4))	{		// build left half of spectrum data
-       					sc.FFT_Samples[i] = sc.FFT_MagData[i + FFT_IQ_BUFF_LEN2/4];	// get data
-       				}
-       				else	{							// build right half of spectrum data
-       					sc.FFT_Samples[i] = sc.FFT_MagData[i - FFT_IQ_BUFF_LEN2/4];	// get data
-       				}
-       			}
-*/
-
-        // estimate frequ of carrier by three-point-interpolation of bins around maxbin
+       // estimate frequ of carrier by three-point-interpolation of bins around maxbin
    		bin1 = sc.FFT_Samples[maxbin-1];
    		bin2 = sc.FFT_Samples[maxbin];
    		bin3 = sc.FFT_Samples[maxbin+1];
-
+        if (bin1+bin2+bin3==0) bin1=1; // prevent divide by 0
        	// formula by (Jacobsen & Kootsookos 2007) equation (4) P=1.36 for Hanning window FFT function
-   		delta = bin_BW * (1.36 * (bin3 - bin1)) / (bin1 + bin2 + bin3);
-//        UiLcdHy28_PrintText(80,160, delta,Cyan,Black,1);
-    		// set frequency variable
-        freq = freq + delta;
+        delta2 = 1.0 * (bin_BW * (1.36 * (bin3 - bin1)) / (bin1 + bin2 + bin3));
+   		// set frequency variable
+        freq = freq + delta1 + delta2;
         // set frequency of Si570 with 4 * dialfrequency
         df.tune_new = freq * 4;
         UiDriverUpdateFrequency ( 2, 0);
@@ -1817,9 +1787,6 @@ static void audio_snap_carrier (void)
         sc.snap = 0; // reset flag for button press (used in ui_driver)
 
 }
-
-
-
 
 //
 //*----------------------------------------------------------------------------

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -1037,12 +1037,17 @@ static void UiDriverProcessKeyboard(void)
 				else
 					UiMenu_RenderMenu(MENU_RENDER_ONLY);	// update menu display to remove indicator to do power-off to save EEPROM value
 				break;
-			case BUTTON_F2_PRESSED:	// Press-and-hold button F3
+			case BUTTON_F2_PRESSED:	// Press-and-hold button F2
 				// Move to the BEGINNING of the current menu structure
 				if(ts.menu_mode)	{		// Are we in menu mode?
 				  UiMenu_RenderFirstScreen();
+				} else {
+					// Not in MENU mode - select the METER mode
+				    incr_wrap_uint8(&ts.tx_meter_mode,0,METER_MAX-1);
+
+				    UiDriverDeleteSMeter();
+					UiDriverCreateSMeter();	// redraw meter
 				}
-				else sc.snap = 1;
 				break;
 			case BUTTON_F3_PRESSED:	// Press-and-hold button F3
 				//
@@ -1510,11 +1515,10 @@ static void UiDriverProcessFunctionKeyClick(ulong id)
 		if(ts.menu_mode)	{		// Button F2 restores default setting of selected item
           UiMenu_RenderPrevScreen();
 		}
-		else	{	// Not in MENU mode - select the METER mode
-		    incr_wrap_uint8(&ts.tx_meter_mode,0,METER_MAX-1);
+		else	{
+			sc.snap = 1;
 
-		    UiDriverDeleteSMeter();
-			UiDriverCreateSMeter();	// redraw meter
+
 		}
 	}
 


### PR DESCRIPTION
Short Press F2 button for automatically tuning to the carrier of an AM signal.
The signal to be tuned to has to be in the filter bandwidth of the chosen filter. In USB carriers 1kHz below the carrier, in LSB 1kHz above the carrier are also detected. 
Please test and give feedback!
Does not (yet) have the accuracy I would like it to have ;-)
