### PR TITLE
scaling variables for phase & amplitude IQ adjustment

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.h
+++ b/mchf-eclipse/drivers/audio/audio_driver.h
@@ -51,6 +51,12 @@
 #define CODEC_DEFAULT_GAIN		0x1F	// Gain of line input to start with
 #define	ADC_CLIP_WARN_THRESHOLD	4096	// This is at least 12dB below the clipping threshold of the A/D converter itself
 //
+//
+//
+#define SCALING_FACTOR_IQ_PHASE_ADJUST 3000.0
+#define SCALING_FACTOR_IQ_AMPLITUDE_ADJUST 4096.0
+
+//
 // Audio driver publics
 typedef struct AudioDriverState
 {

--- a/mchf-eclipse/drivers/audio/audio_management.c
+++ b/mchf-eclipse/drivers/audio/audio_management.c
@@ -147,7 +147,7 @@ void AudioManagement_CalcRxIqGainAdj(void)
     else
         ts.rx_adj_gain_var_i = (float)ts.rx_iq_usb_gain_balance;        // get current gain adjustment setting  USB and other modes
     //
-    ts.rx_adj_gain_var_i /= 4096;       // fractionalize it
+    ts.rx_adj_gain_var_i /= SCALING_FACTOR_IQ_AMPLITUDE_ADJUST;       // fractionalize it
     ts.rx_adj_gain_var_q = -ts.rx_adj_gain_var_i;               // get "invert" of it
     ts.rx_adj_gain_var_i += 1;      // offset it by one (e.g. 0 = unity)
     ts.rx_adj_gain_var_q += 1;
@@ -174,7 +174,7 @@ void AudioManagement_CalcTxIqGainAdj(void)
         ts.tx_adj_gain_var_i = (float)ts.tx_iq_usb_gain_balance;        // get current gain adjustment setting for USB and other non AM/FM modes
 
     //
-    ts.tx_adj_gain_var_i /= 4096;       // fractionalize it
+    ts.tx_adj_gain_var_i /= SCALING_FACTOR_IQ_AMPLITUDE_ADJUST;       // fractionalize it
     ts.tx_adj_gain_var_q = -ts.tx_adj_gain_var_i;               // get "invert" of it
     ts.tx_adj_gain_var_i += 1;      // offset it by one (e.g. 0 = unity)
     ts.tx_adj_gain_var_q += 1;


### PR DESCRIPTION
Added scaling variables instead of hard coded figures for IQ phase & amplitude adjustment.
Added comments in the stripped down Rx and Tx processors as a reminder to add phase adjustment code, when these processors are going to be used.
