### PR TITLE
clean filter definitions

### DIFF
--- a/mchf-eclipse/drivers/audio/filters/iq_rx_filter.c
+++ b/mchf-eclipse/drivers/audio/filters/iq_rx_filter.c
@@ -208,6 +208,7 @@ const float q_rx_coeffs[Q_NUM_TAPS] =
 		-0.0012327055287524,
 		-0.00034491431846579
 };
+#if 0
 //
 // Same as above, but set to 89.50 degrees
 //
@@ -399,3 +400,4 @@ const float q_rx_coeffs_plus[Q_NUM_TAPS] =
 		-0.00122815169948919,
 		-0.0003457857
 };
+#endif

--- a/mchf-eclipse/drivers/audio/filters/iq_rx_filter_10k0.c
+++ b/mchf-eclipse/drivers/audio/filters/iq_rx_filter_10k0.c
@@ -221,6 +221,7 @@ const float q_rx_10k_coeffs[Q_NUM_TAPS] =
 		 0.000173370254281586,
 		 0.000202900475979578,
 };
+#if 0
 //
 // Same as above, but set to -89.50 degrees
 //
@@ -413,3 +414,4 @@ const float q_rx_10k_coeffs_plus[Q_NUM_TAPS] =
 		 0.000202455664859689
 };
 
+#endif

--- a/mchf-eclipse/drivers/audio/filters/iq_rx_filter_3k6.c
+++ b/mchf-eclipse/drivers/audio/filters/iq_rx_filter_3k6.c
@@ -221,6 +221,7 @@ const float q_rx_3k6_coeffs[Q_NUM_TAPS] =
 		 0.000430038513938061,
 		 0.000294806871446770
 };
+#if 0
 //
 // Same as above, but set to -89.50 degrees
 //
@@ -412,3 +413,4 @@ const float q_rx_3k6_coeffs_plus[Q_NUM_TAPS] =
 		 0.000431750013359228,
 		 0.000296380721462188
 };
+#endif

--- a/mchf-eclipse/drivers/audio/filters/iq_rx_filter_4k5.c
+++ b/mchf-eclipse/drivers/audio/filters/iq_rx_filter_4k5.c
@@ -229,6 +229,8 @@ const float q_rx_4k5_coeffs[Q_NUM_TAPS] =
 
 
 };
+
+#if 0
 // -89.5 degrees
 const float q_rx_4k5_coeffs_minus[Q_NUM_TAPS] =
 {
@@ -419,3 +421,4 @@ const float q_rx_4k5_coeffs_plus[Q_NUM_TAPS] =
 		 0.000419784959544385
 
 };
+#endif

--- a/mchf-eclipse/drivers/audio/filters/iq_rx_filter_5k0.c
+++ b/mchf-eclipse/drivers/audio/filters/iq_rx_filter_5k0.c
@@ -222,6 +222,7 @@ const float q_rx_5k_coeffs[Q_NUM_TAPS] =
 		0.000347789813473593,
 		0.000244980985528699
 };
+#if 0
 // -89.5 degrees
 const float q_rx_5k_coeffs_minus[Q_NUM_TAPS] =
 {
@@ -408,3 +409,4 @@ const float q_rx_5k_coeffs_plus[Q_NUM_TAPS] =
 		0.000347795713461264,
 		0.000245350075079334
 };
+#endif

--- a/mchf-eclipse/drivers/audio/filters/iq_rx_filter_6k0.c
+++ b/mchf-eclipse/drivers/audio/filters/iq_rx_filter_6k0.c
@@ -222,6 +222,7 @@ const float q_rx_6k_coeffs[Q_NUM_TAPS] =
 		0.000330908629757325,
 		0.000251931484270503
 };
+#if 0
 // -89.5 degrees
 const float q_rx_6k_coeffs_minus[Q_NUM_TAPS] =
 {
@@ -408,3 +409,4 @@ const float q_rx_6k_coeffs_plus[Q_NUM_TAPS] =
 		0.000330562893588452,
 		0.000252119559524394
 };
+#endif

--- a/mchf-eclipse/drivers/audio/filters/iq_rx_filter_7k5.c
+++ b/mchf-eclipse/drivers/audio/filters/iq_rx_filter_7k5.c
@@ -221,6 +221,7 @@ const float q_rx_7k5_coeffs[Q_NUM_TAPS] =
 		0.000253972242871382,
 		0.000133595279188209
 };
+#if 0
 // -89.5 degrees
 const float q_rx_7k5_coeffs_minus[Q_NUM_TAPS] =
 {
@@ -407,3 +408,4 @@ const float q_rx_7k5_coeffs_plus[Q_NUM_TAPS] =
 		0.000254921199404576,
 		0.000134001024940527
 };
+#endif

--- a/mchf-eclipse/drivers/audio/filters/q_tx_filter.h
+++ b/mchf-eclipse/drivers/audio/filters/q_tx_filter.h
@@ -125,7 +125,7 @@ const float q_tx_coeffs[Q_NUM_TAPS] =
 		-0.000048495992345297,
 		-0.0003506543
 };
-
+#if 0
 //
 // Same as above, but set to 89.50 degrees
 //
@@ -320,7 +320,7 @@ const float q_tx_coeffs_plus[Q_NUM_TAPS] =
 		-0.000035020356392576,
 		-0.000338712
 };
-
+#endif
 //static float32_t 		FirState_Q_TX[128];
 //arm_fir_instance_f32 	FIR_Q_TX;
 


### PR DESCRIPTION
commented out unused filter coefficients.
Now saved a total of 9kB of compiled code ;-)
