### PR TITLE
Removed VFO_WORK. 

### DIFF
--- a/mchf-eclipse/drivers/ui/ui_configuration.c
+++ b/mchf-eclipse/drivers/ui/ui_configuration.c
@@ -745,7 +745,7 @@ void UiConfiguration_LoadEepromValues(void)
     //
     for(i = 0; i < MAX_BANDS; i++)
     {   // read from stored bands
-        UiReadSettingsBandMode(i,EEPROM_BAND0_MODE,EEPROM_BAND0_FREQ_HIGH,EEPROM_BAND0_FREQ_LOW, &vfo[VFO_WORK].band[i]);
+        // UiReadSettingsBandMode(i,EEPROM_BAND0_MODE,EEPROM_BAND0_FREQ_HIGH,EEPROM_BAND0_FREQ_LOW, &vfo[VFO_WORK].band[i]);
         UiReadSettingsBandMode(i,EEPROM_BAND0_MODE_A,EEPROM_BAND0_FREQ_HIGH_A,EEPROM_BAND0_FREQ_LOW_A, &vfo[VFO_A].band[i]);
         UiReadSettingsBandMode(i,EEPROM_BAND0_MODE_B,EEPROM_BAND0_FREQ_HIGH_B,EEPROM_BAND0_FREQ_LOW_B, &vfo[VFO_B].band[i]);
     }
@@ -994,17 +994,17 @@ uint16_t UiConfiguration_SaveEepromValues(void)
     // save current band/frequency/mode settings
     //
     // save frequency
-    vfo[VFO_WORK].band[ts.band].dial_value = df.tune_new;
+    vfo[is_vfo_b()?VFO_B:VFO_A].band[ts.band].dial_value = df.tune_new;
     // Save decode mode
-    vfo[VFO_WORK].band[ts.band].decod_mode = ts.dmod_mode;
+    vfo[is_vfo_b()?VFO_B:VFO_A].band[ts.band].decod_mode = ts.dmod_mode;
     // Save filter setting
-    vfo[VFO_WORK].band[ts.band].filter_mode = ts.filter_id;
+    vfo[is_vfo_b()?VFO_B:VFO_A].band[ts.band].filter_mode = ts.filter_id;
     //
     // Save stored band/mode/frequency memory from RAM
     //
 
     for(i = 0; i < MAX_BANDS; i++)  {   // scan through each band's frequency/mode data
-        UiReadWriteSettingsBandMode(i,EEPROM_BAND0_MODE,EEPROM_BAND0_FREQ_HIGH,EEPROM_BAND0_FREQ_LOW,  &vfo[VFO_WORK].band[i]);
+        // UiReadWriteSettingsBandMode(i,EEPROM_BAND0_MODE,EEPROM_BAND0_FREQ_HIGH,EEPROM_BAND0_FREQ_LOW,  &vfo[VFO_WORK].band[i]);
         UiReadWriteSettingsBandMode(i,EEPROM_BAND0_MODE_A,EEPROM_BAND0_FREQ_HIGH_A,EEPROM_BAND0_FREQ_LOW_A, &vfo[VFO_A].band[i]);
         UiReadWriteSettingsBandMode(i,EEPROM_BAND0_MODE_B,EEPROM_BAND0_FREQ_HIGH_B,EEPROM_BAND0_FREQ_LOW_B, &vfo[VFO_B].band[i]);
     }

--- a/mchf-eclipse/hardware/mchf_board.h
+++ b/mchf-eclipse/hardware/mchf_board.h
@@ -721,8 +721,8 @@ struct band_regs_s {
 typedef struct band_regs_s BandRegs;
 
 enum {
-    VFO_WORK = 0,
-    VFO_A,
+    // VFO_WORK = 0
+    VFO_A = 0,
     VFO_B,
     VFO_MAX
 };
@@ -992,6 +992,9 @@ typedef struct TransceiverState
 	bool	xvtr_adjust_flag;			// set TRUE if transverter offset adjustment is in process
 	bool	rx_muting;				// set TRUE if audio output is to be muted
 	ulong	rx_blanking_time;			// this is a timer used to delay the un-blanking of the audio after a large synthesizer tuning step
+
+#define VFO_MEM_MODE_SPLIT 0x80
+#define VFO_MEM_MODE_VFO_B 0x40
 	ulong	vfo_mem_mode;				// this is used to record the VFO/memory mode (0 = VFO "A" = backwards compatibility)
 							// LSB+6 (0x40):  0 = VFO A, 1 = VFO B
 							// LSB+7 (0x80): 0 = normal mode, 1 = Split mode (e.g. LSB=0:  RX=A, TX=B;  LSB=1:  RX=B, TX=A)
@@ -1094,5 +1097,7 @@ void verify_servirt(void);
 
 // in main.c
 void CriticalError(ulong error);
+
+bool is_vfo_b();
 
 #endif


### PR DESCRIPTION
Now all code directly access VFO_A or VFO_B depending
current vfo selection and mode.

This change may cause not the expected frequency for VFO A/VFO B being loaded on first use of this firmware. This is due to some issues in the old use of VFO_WORK. After first use of a band, everything should be as usual (frequency and mode last used on a band is restored on next use).
