### PR TITLE
Changed Reset to Default Configuration Values Handling

### DIFF
--- a/mchf-eclipse/drivers/ui/ui_driver.h
+++ b/mchf-eclipse/drivers/ui/ui_driver.h
@@ -519,7 +519,6 @@ void 	UiSpectrumCreateDrawArea(void);
 void 	UiDriverUpdateFrequencyFast(void);
 void 	UiDriverSetBandPowerFactor(uchar band);
 void 	UiDrawSpectrumScopeFrequencyBarText(void);
-void 	UiCheckForEEPROMLoadDefaultRequest(void);
 //
 //void 	UiDriverChangeFilter(uchar ui_only_update);
 void 	UiDriverSetBandPowerFactor(uchar band);
@@ -546,9 +545,9 @@ void 	UiDriverChangeTuningStep(uchar is_up);
 //
 void 	uiCodecMute(uchar val);
 //
-uint16_t 	UiConfiguration_SaveEepromValues(void);
-void	UiCheckForEEPROMLoadFreqModeDefaultRequest(void);
-void	UiDriver_KeyTestScreen(void);
+
+void    UiDriver_LoadSavedConfigurationAtStartup();
+
 void	UiInitRxParms(void);
 //
 //

--- a/mchf-eclipse/main.c
+++ b/mchf-eclipse/main.c
@@ -875,11 +875,6 @@ int main(void)
 	ts.rx_gain[RX_AUDIO_SPKR].value_old = 99;		// Force update of volume control
 	uiCodecMute(0);					// make cure codec is un-muted
 
-	UiCheckForEEPROMLoadDefaultRequest();	// check - and act on - request for loading of EEPROM defaults, if any
-	//
-	UiCheckForEEPROMLoadFreqModeDefaultRequest();	// check - and act on - request for loading frequency/mode defaults, if any
-	//
-	UiDriver_KeyTestScreen();
 
 	if (ts.cat_mode_active)
 		cat_driver_init();


### PR DESCRIPTION
It is now essentially done at the point loading of the "normal" defaults
happens. In addition, it is now no longer storing the value directly
in EEPROM, it just loads them into the memory. User can now test that
defaults indeed are what he/she wants in operation. If ok, just save
with normal power off, otherwise cut the power at any point.
Less risky strategy. Helps when testing new firmwares as well.

Open: Improve the text shown to the user (layout and content).
