### PR TITLE
Fixed issue that mcHF seems to be partially crashed in TX with DIQ + CW 

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -2241,7 +2241,9 @@ static void audio_tx_processor(int16_t *src, int16_t *dst, int16_t size)
 	// -----------------------------
 	// TUNE mode handler for DIGIQ mode
 	//
-	if (!ts.tune && ts.tx_audio_source == TX_AUDIO_DIGIQ) {
+	if (!ts.tune && ts.tx_audio_source == TX_AUDIO_DIGIQ && ts.dmod_mode != DEMOD_CW) {
+	  // If in CW mode, DIQ audio input is ignored and the paddles provide the input so that
+	  // you can use your keyer etc.
 		// Output I and Q as stereo, fill buffer and leave
 		for(i = 0; i < size/2; i++)	{				// Copy to single buffer
 			ads.i_buffer[i] = (float)*src++;

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -5799,8 +5799,8 @@ static void UiDriverSwitchOffPtt(void)
 	if(kd.enabled)
 		goto unmute_only;
 
-	// PTT off
-	if((ts.dmod_mode == DEMOD_USB)||(ts.dmod_mode == DEMOD_LSB) || (ts.dmod_mode == DEMOD_AM) || (ts.dmod_mode == DEMOD_FM))
+	// PTT off for all non-CW modes
+	if(ts.dmod_mode != DEMOD_CW)
 	{
 		// PTT flag on ?
 		if(ts.txrx_mode == TRX_MODE_TX)
@@ -6414,6 +6414,7 @@ void UiDriver_DoCrossCheck(char cross[],char* xt_corr, char* yt_corr)
 	while(UiDriver_IsButtonPressed(TOUCHSCREEN_ACTIVE) == true){ non_os_delay(); }
     }while(datavalid < 3);
 
-    for(i = 0; i < 100; i++)
+    for(i = 0; i < 100; i++) {
 	non_os_delay();
+    }
 }


### PR DESCRIPTION
When doing TX in CW modes and audio input is set to DIQ / DIGITAL IQ
via USB mcHF no longer responds to some keys. 
Now the digital input is ignored in this mode, CW keyer / paddles will
generate TX signal on mcHF displayed frequency. All is good now.
