### PR TITLE
Reworked RX-TX Switching code.

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -2789,16 +2789,16 @@ void I2S_RX_CallBack(int16_t *src, int16_t *dst, int16_t size, uint16_t ht)
 			to_tx = 0;							// caused by the content of the buffers from TX - used on return from SSB TX
 			arm_fill_q15(0, dst, size);
 			arm_fill_q15(0, src, size);
-		}
-		else	{
+		} else {
 			if(!ts.dvmode) {
 				// TODO: HACK: simply overwrite input buffer with USB data instead of using data from I2S bus
 				// I2S just delivers the "timing".
 				// needs to be used only if USB digital line in is selected.
 				audio_tx_processor(src,dst,size);
 			}
-			else
+			else {
 				audio_dv_tx_processor(src,dst,size);
+			}
 		}
 		//
 		to_rx = 1;		// Set flag to indicate that we WERE transmitting when we eventually go back to receive mode

--- a/mchf-eclipse/drivers/audio/codec/codec.c
+++ b/mchf-eclipse/drivers/audio/codec/codec.c
@@ -111,8 +111,8 @@ void Codec_Reset(uint32_t AudioFreq,ulong word_size)
 	Codec_WriteRegister(W8731_ACTIVE_CNTR,0x0001);
 }
 
-void Codec_MicBoostCheck() {
-  if(ts.txrx_mode == TRX_MODE_TX) {       // only adjust the hardware if in TX mode (it will kill RX otherwise!)
+void Codec_MicBoostCheck(uint8_t mode) {
+  if(mode == TRX_MODE_TX) {       // only adjust the hardware if in TX mode (it will kill RX otherwise!)
     // Set up microphone gain and adjust mic boost accordingly
     if(ts.tx_gain[TX_AUDIO_MIC] > 50)	{		// actively adjust microphone gain and microphone boost
       ts.mic_boost = 1;
@@ -150,12 +150,12 @@ void Codec_MicBoostCheck() {
 //* Functions called    :
 //*----------------------------------------------------------------------------
 
-void Codec_RX_TX(void)
+void Codec_RX_TX(uint8_t mode)
 {
 
 	uchar mute_count;
 
-	if(ts.txrx_mode == TRX_MODE_RX)
+	if(mode == TRX_MODE_RX)
 	{
 		// First step - mute sound
 		Codec_Volume(0);
@@ -193,20 +193,22 @@ void Codec_RX_TX(void)
 		//
 		if((ts.dmod_mode == DEMOD_CW) || ((ts.dmod_mode == DEMOD_CW) && ts.tune))	{	// Turn sidetone on for CW or TUNE mode in CW mode
 			//
-			Codec_SidetoneSetgain();	// set sidetone level
+			Codec_SidetoneSetgain(mode);	// set sidetone level
 			//
 		}
 		else if(ts.tune)	{	// Not in CW mode - but in TUNE mode
 			if(!ts.iq_freq_mode)	// Is translate mode *NOT* active?
-				Codec_SidetoneSetgain();	// yes, turn on sidetone in SSB-TUNE mode
+				Codec_SidetoneSetgain(mode);	// yes, turn on sidetone in SSB-TUNE mode
 		}
 		else	{	// Not CW or TUNE mode
 			//
-			for(mute_count = 0; mute_count < 8; mute_count++)		// Doing this seems to suppress the loud CLICK
+			for(mute_count = 0; mute_count < 8; mute_count++) {		// Doing this seems to suppress the loud CLICK
 				Codec_Volume(0);	// that occurs when going from RX to TX in modes other than CW
+			}
 				// This is probably because of the delay between the mute command, above, and the
 			//
 			non_os_delay();
+
 			//
 			// Select source or leave it as it is
 			// PHONE out is muted, normal exit routed to TX modulator
@@ -214,7 +216,7 @@ void Codec_RX_TX(void)
 
 			// TODO: MicBoost Code exists three times identical
 			if(ts.tx_audio_source == TX_AUDIO_MIC) {
-				Codec_MicBoostCheck();
+				Codec_MicBoostCheck(mode);
 			} else {
 				Codec_Line_Gain_Adj(ts.tx_gain[ts.tx_audio_source]);	// set LINE input gain if in LINE in mode
 			}
@@ -231,7 +233,7 @@ void Codec_RX_TX(void)
 //* Output Parameters   :
 //* Functions called    :
 //*----------------------------------------------------------------------------
-void Codec_SidetoneSetgain(void)
+void Codec_SidetoneSetgain(uint8_t mode)
 {
 float vcalc, vcalc1;
 
@@ -242,29 +244,27 @@ float vcalc, vcalc1;
 //
 // Note that this function is called from places OTHER than Codec_RX_TX(), above!
 
-	// bail out if not in transmit mode
-	if(ts.txrx_mode != TRX_MODE_TX)		// bail out if not in transmit mode
-		return;
-	//
-	if(ts.st_gain)	{	// calculate if the sidetone gain is non-zero
-		vcalc = (float)ts.tx_power_factor;	// get TX scaling power factor
-		vcalc *= vcalc;
-		vcalc = 1/vcalc;		// invert it since we are calculating attenuation of the original signal (assuming normalization to 1.0)
-		vcalc = log10f(vcalc);	// get the log
-		vcalc *= 10;			// convert to deciBels and calibrate for the per-step value of the codec
-		vcalc1 = (float)ts.st_gain;		// get the sidetone gain (level) setting
-		vcalc1 *= 6;			// offset by # of dB the desired sidetone gain
-		vcalc += vcalc1;		// add the calculated gain to the desired sidetone gain
-		if(vcalc > 127)			// enforce limits of calculation to range of attenuator
-			vcalc = 127;
-		else if	(vcalc < 0)
-			vcalc = 0;
-	}
-	else						// mute if zero value
-		vcalc = 0;
-	//
-	Codec_Volume((uchar)vcalc);		// set the calculated sidetone volume
-	//
+  if(mode == TRX_MODE_TX) {		// bail out if not in transmit mode
+    //
+    if(ts.st_gain)	{	// calculate if the sidetone gain is non-zero
+      vcalc = (float)ts.tx_power_factor;	// get TX scaling power factor
+      vcalc *= vcalc;
+      vcalc = 1/vcalc;		// invert it since we are calculating attenuation of the original signal (assuming normalization to 1.0)
+      vcalc = log10f(vcalc);	// get the log
+      vcalc *= 10;			// convert to deciBels and calibrate for the per-step value of the codec
+      vcalc1 = (float)ts.st_gain;		// get the sidetone gain (level) setting
+      vcalc1 *= 6;			// offset by # of dB the desired sidetone gain
+      vcalc += vcalc1;		// add the calculated gain to the desired sidetone gain
+      if(vcalc > 127) {			// enforce limits of calculation to range of attenuator
+        vcalc = 127;
+      } else if	(vcalc < 0)
+      {	vcalc = 0; }
+    }
+    else {						// mute if zero value
+      vcalc = 0;
+    }
+    Codec_Volume((uchar)vcalc);		// set the calculated sidetone volume
+  }
 }
 
 

--- a/mchf-eclipse/drivers/audio/codec/codec.h
+++ b/mchf-eclipse/drivers/audio/codec/codec.h
@@ -88,7 +88,7 @@
 //
 
 uint32_t Codec_Init(uint32_t AudioFreq,ulong word_size);
-void 	 Codec_RX_TX(void);
+void 	 Codec_RX_TX(uint8_t mode);
 void 	 Codec_Volume(uchar vol);
 void 	Codec_Line_Gain_Adj(uchar gain);
 void 	 Codec_Mute(uchar state);
@@ -97,7 +97,7 @@ void     Codec_AudioInterface_Init(uint32_t AudioFreq);
 void     Codec_Reset(uint32_t AudioFreq,ulong word_size);
 uint32_t Codec_WriteRegister(uint8_t RegisterAddr, uint16_t RegisterValue);
 void     Codec_GPIO_Init(void);
-void Codec_SidetoneSetgain(void);
-void Codec_MicBoostCheck();
+void Codec_SidetoneSetgain(uint8_t mode);
+void Codec_MicBoostCheck(uint8_t mode);
 
 #endif

--- a/mchf-eclipse/drivers/ui/ui_driver.h
+++ b/mchf-eclipse/drivers/ui/ui_driver.h
@@ -508,7 +508,7 @@ typedef struct EepromSave
 // Exports
 void 	ui_driver_init(void);
 void 	ui_driver_thread(void);
-void 	ui_driver_toggle_tx(void);
+void 	ui_driver_toggle_tx(uint8_t mode);
 void 	UiDriverLoadFilterValue(void);
 void 	UiSpectrumClearDisplay(void);
 //
@@ -578,13 +578,13 @@ STATE_S_METER = 0,				//
 STATE_SWR_METER,				//
 STATE_HANDLE_POWERSUPPLY,		//
 STATE_LO_TEMPERATURE,			//
+STATE_SWITCH_OFF_PTT,            //
 STATE_TASK_CHECK,				//
 STATE_CHECK_ENC_ONE,			//
 STATE_CHECK_ENC_TWO,			//
 STATE_CHECK_ENC_THREE,			//
 STATE_UPDATE_FREQUENCY,			//
 STATE_PROCESS_KEYBOARD,			//
-STATE_SWITCH_OFF_PTT			//
 };
 //
 // Used for press-and-hold "temporary" step size adjust

--- a/mchf-eclipse/drivers/ui/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/ui_menu.c
@@ -1229,7 +1229,7 @@ bool __attribute__ ((noinline)) UiDriverMenuBandPowerAdjust(int var, uint8_t mod
 		if(tchange)	{		// did something change?
 			UiDriverSetBandPowerFactor(ts.band);	// yes, update the power factor
 			if(!ts.iq_freq_mode)	// Is translate mode *NOT* active?
-				Codec_SidetoneSetgain();				// adjust the sidetone gain
+				Codec_SidetoneSetgain(ts.txrx_mode);				// adjust the sidetone gain
 		}
 	}
 	else	// not enabled
@@ -1703,7 +1703,7 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode, int pos)
 							);
 		}
 		if(fchange)	{
-			Codec_MicBoostCheck();
+			Codec_MicBoostCheck(ts.txrx_mode);
 		}
 		//
 		if(fchange)	{		// update on-screen info if there was a change


### PR DESCRIPTION
Some things did not happen in the right order,
so that an visible (and possibly) audible strong noise
was generate when switching to TX. Also caused the first
morse dit or dah to be distorted.

Right now a delay of 100ms exists before TX starts in
FM and AM after closing the PTT switch. As far as I can see,
the noise is gone.

CW has less latency in most cases, DAH starts roughly
after 30ms, but here some initial unwanted noise at the beginning
is still there.
However, it is not the switching noise, it is a very short
start of a morse dit/dah, which is restarted after around 10ms.

Needs further investigation how to get rid of this.

NEEDS TESTING ESPECIALLY IN CW MODE.
