### PR TITLE
FFT variables reduced to save RAM

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -1428,6 +1428,7 @@ static void audio_snap_carrier (void)
 	float32_t help_freq = (float32_t)df.tune_new / 4.0;
 	ulong freq; //
 	float32_t bin1, bin2, bin3;
+	float32_t help_sample;
 
 	int buff_len_int = FFT_IQ_BUFF_LEN2;
 	// init of FFT structure has been moved to audio_driver_init()
@@ -1486,12 +1487,14 @@ static void audio_snap_carrier (void)
 			// Hamming 1.22
 			//sc.FFT_Windat[i] = (float32_t)((0.53836 - (0.46164 * arm_cos_f32(PI*2 * (float32_t)i / (float32_t)(FFT_IQ_BUFF_LEN2-1)))) * sc.FFT_Samples[i]);
 			// Blackman 1.75
-			sc.FFT_Windat[i] = (0.42659 - (0.49656*arm_cos_f32((2.0*PI*(float32_t)i)/((float32_t)buff_len-1.0))) + (0.076849*arm_cos_f32((4.0*PI*(float32_t)i)/((float32_t)buff_len-1.0)))) * sc.FFT_Samples[i];
+			help_sample = (0.42659 - (0.49656*arm_cos_f32((2.0*PI*(float32_t)i)/((float32_t)buff_len-1.0))) + (0.076849*arm_cos_f32((4.0*PI*(float32_t)i)/((float32_t)buff_len-1.0)))) * sc.FFT_Samples[i];
+			sc.FFT_Samples[i] = help_sample;
 		}
 
 		// run FFT
 //		arm_rfft_f32((arm_rfft_instance_f32 *)&sc.S,(float32_t *)(sc.FFT_Windat),(float32_t *)(sc.FFT_Samples));	// Do FFT
-		arm_rfft_fast_f32((arm_rfft_fast_instance_f32 *)&sc.S,(float32_t *)(sc.FFT_Windat),(float32_t *)(sc.FFT_Samples),0);	// Do FFT
+//		arm_rfft_fast_f32((arm_rfft_fast_instance_f32 *)&sc.S,(float32_t *)(sc.FFT_Windat),(float32_t *)(sc.FFT_Samples),0);	// Do FFT
+		arm_rfft_fast_f32((arm_rfft_fast_instance_f32 *)&sc.S,(float32_t *)(sc.FFT_Samples),(float32_t *)(sc.FFT_Samples),0);	// Do FFT
 		//
 		// Calculate magnitude
 		// as I understand this, this takes two samples and calculates ONE magnitude from this --> length is FFT_IQ_BUFF_LEN2 / 2

--- a/mchf-eclipse/drivers/audio/audio_driver.h
+++ b/mchf-eclipse/drivers/audio/audio_driver.h
@@ -523,8 +523,8 @@ extern __IO		AudioDriverState	ads;
 extern __IO     SMeter              sm;
 extern __IO FilterCoeffs        fc;
 // change this to 2048 (=1024 tap FFT), if problems with spectrum display with 7k5 SAM mode persist!
-//#define FFT_IQ_BUFF_LEN2 2048
-#define FFT_IQ_BUFF_LEN2 4096 // = 2048 tap FFT !!! this is very very accurate
+#define FFT_IQ_BUFF_LEN2 2048
+//#define FFT_IQ_BUFF_LEN2 4096 // = 2048 tap FFT !!! this is very very accurate
 typedef struct SnapCarrier
 {
     // FFT state

--- a/mchf-eclipse/drivers/audio/audio_driver.h
+++ b/mchf-eclipse/drivers/audio/audio_driver.h
@@ -522,20 +522,21 @@ void I2S_RX_CallBack(int16_t *src, int16_t *dst, int16_t size, uint16_t ht);
 extern __IO		AudioDriverState	ads;
 extern __IO     SMeter              sm;
 extern __IO FilterCoeffs        fc;
-
-#define FFT_IQ_BUFF_LEN2 2048
+// change this to 2048 (=1024 tap FFT), if problems with spectrum display with 7k5 SAM mode persist!
+//#define FFT_IQ_BUFF_LEN2 2048
+#define FFT_IQ_BUFF_LEN2 4096 // = 2048 tap FFT !!! this is very very accurate
 typedef struct SnapCarrier
 {
     // FFT state
-//    arm_rfft_instance_f32           S;
-    arm_rfft_fast_instance_f32           S;
+//    arm_rfft_instance_f32           S; // old, depricated FFT routine, do not use
+//    arm_cfft_radix4_instance_f32    S_CFFT;  // old, depricated FFT routine, do not use
 
-//    arm_cfft_radix4_instance_f32    S_CFFT;
+    arm_rfft_fast_instance_f32           S; // new and faster real FFT routine
 
     // Samples buffer
     //
     float32_t   FFT_Samples[FFT_IQ_BUFF_LEN2];
-    float32_t   FFT_Windat[FFT_IQ_BUFF_LEN2];
+//    float32_t   FFT_Windat[FFT_IQ_BUFF_LEN2];
     float32_t   FFT_MagData[FFT_IQ_BUFF_LEN2/2];
     // Current data ptr
     ulong   samp_ptr;

--- a/mchf-eclipse/drivers/ui/lcd/ui_spectrum.h
+++ b/mchf-eclipse/drivers/ui/lcd/ui_spectrum.h
@@ -114,15 +114,15 @@ void UiSpectrumReDrawScopeDisplay();
 typedef struct SpectrumDisplay
 {
     // FFT state
-//    arm_rfft_instance_f32           S;
-	arm_cfft_instance_f32           C;
-//	arm_cfft_instance_f32 arm_cfft_sR_f32_len256;
-    arm_cfft_radix4_instance_f32    S_CFFT;
+//    arm_rfft_instance_f32           S;  // old, depricated FFT routine, do not use
+	arm_cfft_instance_f32           C; // new FFT routine for complex FFT
+
+//	arm_cfft_radix4_instance_f32    S_CFFT; // old, depricated FFT routine, do not use
 
     // Samples buffer
     //
     float32_t   FFT_Samples[FFT_IQ_BUFF_LEN];
-    float32_t   FFT_Windat[FFT_IQ_BUFF_LEN];
+//    float32_t   FFT_Windat[FFT_IQ_BUFF_LEN];
     float32_t   FFT_MagData[FFT_IQ_BUFF_LEN/2];
     q15_t   FFT_BkpData[FFT_IQ_BUFF_LEN];
     q15_t   FFT_DspData[FFT_IQ_BUFF_LEN];       // Rescaled and de-linearized display data


### PR DESCRIPTION
Reduced the use of RAM for snap carrier FFT and spectrum/waterfall display FFT by omitting some of the variables. Should save about 3kB of RAM usage.
Snap carrier could be accurate to +-1Hz, if we use 2048 tap FFT, however when in SAM 7k5 mode, we run into spectrum display performance problems, probably because of RAM shortage.
