### PR TITLE
Improved error reporting in the Si570 code.

### DIFF
--- a/mchf-eclipse/drivers/ui/oscillator/ui_si570.c
+++ b/mchf-eclipse/drivers/ui/oscillator/ui_si570.c
@@ -52,34 +52,37 @@ static uchar ui_si570_setbits(unsigned char original, unsigned char reset_mask, 
 	return ((original & reset_mask) | new_val);
 }
 
-//*----------------------------------------------------------------------------
-//* Function Name       : ui_si570_verify_frequency
-//* Object              : read regs and verify freq change
-//* Input Parameters    :
-//* Output Parameters   :
-//* Functions called    :
-//*----------------------------------------------------------------------------
-static uchar ui_si570_verify_frequency(void)
+/*
+ * @brief reads Si570 registers and verifies match with local copy of settings
+ * @returns SI570_OK if matching, SI570_I2C_ERROR if I2C is not working, SI570_ERROR otherwise
+ */
+static Si570_ResultCodes ui_si570_verify_frequency(void)
 {
-	uchar	i, res;
-	uchar	regs[10];
+    Si570_ResultCodes retval = SI570_OK;
+    uchar	i, res;
+    uchar	regs[10];
 
-	// Read all regs
-	for(i = 0; i < 6; i++)
-	{
-		res = mchf_hw_i2c_ReadRegister(os.si570_address, (os.base_reg + i), &regs[i]);
-		if(res != 0)
-			return(0);
-	}
+    // Read all regs
+    for(i = 0; i < 6; i++)
+    {
+        res = mchf_hw_i2c_ReadRegister(os.si570_address, (os.base_reg + i), &regs[i]);
+        if(res != 0) {
+            retval = SI570_I2C_ERROR;
+            break;
+        }
+    }
 
-	// Not working - need fix
-	// memset(regs, 0, 6);
-	// trx4m_hw_i2c_ReadData(os.si570_address, 7, regs, 5);
+    if (retval == SI570_OK) {
+        // Not working - need fix
+        // memset(regs, 0, 6);
+        // trx4m_hw_i2c_ReadData(os.si570_address, 7, regs, 5);
 
-	if(memcmp(regs, (uchar*)os.regs, 6) != 0)
-		return 1;
+        if(memcmp(regs, (uchar*)os.regs, 6) != 0) {
+            retval = SI570_ERROR_VERIFY;
+        }
+    }
 
-	return 0;
+    return retval;
 }
 
 //*----------------------------------------------------------------------------
@@ -89,47 +92,32 @@ static uchar ui_si570_verify_frequency(void)
 //* Output Parameters   :
 //* Functions called    :
 //*----------------------------------------------------------------------------
-static uchar ui_si570_small_frequency_change(void)
+static Si570_ResultCodes ui_si570_small_frequency_change(void)
 {
-	uint16_t ret;
-	uchar reg_135;
-	uchar unfreeze = 0;
+    uint16_t ret;
+    Si570_ResultCodes retval = SI570_OK;
+    uchar reg_135;
 
-	// Read current
-	ret = mchf_hw_i2c_ReadRegister(os.si570_address, SI570_REG_135, &reg_135);
-	if(ret)
-		goto critical;
+    // Read current
+    ret = mchf_hw_i2c_ReadRegister(os.si570_address, SI570_REG_135, &reg_135);
 
-	// Write to freeze M bit
-	ret = mchf_hw_i2c_WriteRegister(os.si570_address, SI570_REG_135, (reg_135|SI570_FREEZE_M));
-	if(ret)
-		goto critical;
+    if (ret == 0) {
+        // Write to freeze M bit
+        ret = mchf_hw_i2c_WriteRegister(os.si570_address, SI570_REG_135, (reg_135|SI570_FREEZE_M));
+        if (ret == 0) {
 
-	// Write as block, registers 7-12
-	ret = mchf_hw_i2c_WriteBlock(os.si570_address, os.base_reg, (uchar*)os.regs, 6);
-	if(ret)
-	{
-		unfreeze = 1;
-		goto critical;
-	}
+            // Write as block, registers 7-12
+            ret = mchf_hw_i2c_WriteBlock(os.si570_address, os.base_reg, (uchar*)os.regs, 6);
+            if (ret == 0) {
+                retval = ui_si570_verify_frequency();
+            } else {
+                retval = SI570_I2C_ERROR;
+            }
+        }
+    }
+    mchf_hw_i2c_WriteRegister(os.si570_address, SI570_REG_135, (reg_135 & ~SI570_FREEZE_M));
 
-	// Verify
-	ret = ui_si570_verify_frequency();
-	if(ret)
-	{
-		unfreeze = 1;
-		goto critical;
-	}
-
-	// Write to unfreeze M
-	mchf_hw_i2c_WriteRegister(os.si570_address, SI570_REG_135, (reg_135 & ~SI570_FREEZE_M));
-
-	return 0;
-
-	critical:
-	// CriticalError(100);
-	if(unfreeze) mchf_hw_i2c_WriteRegister(os.si570_address, SI570_REG_135, (reg_135 & ~SI570_FREEZE_M));
-	return 1;
+    return retval;
 }
 
 //*----------------------------------------------------------------------------
@@ -139,67 +127,57 @@ static uchar ui_si570_small_frequency_change(void)
 //* Output Parameters   :
 //* Functions called    :
 //*----------------------------------------------------------------------------
-static uchar ui_si570_large_frequency_change(void)
+static Si570_ResultCodes ui_si570_large_frequency_change(void)
 {
-	uchar ret, reg_135, reg_137;
-	uchar unfreeze = 0;
+    uint16_t ret;
+    uint8_t reg_135, reg_137;
+    bool unfreeze = false;
+    Si570_ResultCodes retval = SI570_OK;
 
-	// Read the current state of Register 137
-	ret = mchf_hw_i2c_ReadRegister(os.si570_address, SI570_REG_137, &reg_137);
-	if(ret)
-		goto critical;
+    // Read the current state of Register 137
+    ret = mchf_hw_i2c_ReadRegister(os.si570_address, SI570_REG_137, &reg_137);
+    if (ret == 0) {
+        // Set the Freeze DCO bit
+        ret = mchf_hw_i2c_WriteRegister(os.si570_address, SI570_REG_137, (reg_137|SI570_FREEZE_DCO));
+        if (ret == 0) {
+            // Write as block, registers 7-12
+            ret = mchf_hw_i2c_WriteBlock(os.si570_address, os.base_reg, (uchar*)os.regs, 6);
+            if(ret)
+            {
+                unfreeze = 1;
+            } else {
+                retval = ui_si570_verify_frequency();
+                if(retval != SI570_OK)
+                {
+                    unfreeze = 1;
+                } else {
+                    // Clear the Freeze DCO bit
+                    ret = mchf_hw_i2c_WriteRegister(os.si570_address, SI570_REG_137, (reg_137 & ~SI570_FREEZE_DCO));
+                    if (ret == 0) {
+                        // Read current
+                        ret = mchf_hw_i2c_ReadRegister(os.si570_address, SI570_REG_135, &reg_135);
+                        if (ret == 0) {
+                            // Set the NewFreq bit
+                            ret = mchf_hw_i2c_WriteRegister(os.si570_address, SI570_REG_135, (reg_135|SI570_NEW_FREQ));
+                            if (ret == 0) {
+                                // Wait for action completed
+                                reg_135 = SI570_NEW_FREQ;
+                                while(ret == 0 && (reg_135 & SI570_NEW_FREQ))
+                                {
+                                    ret = mchf_hw_i2c_ReadRegister(os.si570_address, SI570_REG_135, &reg_135);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 
-	// Set the Freeze DCO bit
-	ret = mchf_hw_i2c_WriteRegister(os.si570_address, SI570_REG_137, (reg_137|SI570_FREEZE_DCO));
-	if(ret)
-		goto critical;
-
-	// Write as block, registers 7-12
-	ret = mchf_hw_i2c_WriteBlock(os.si570_address, os.base_reg, (uchar*)os.regs, 6);
-	if(ret)
-	{
-		unfreeze = 1;
-		goto critical;
-	}
-
-	// Verify
-	ret = ui_si570_verify_frequency();
-	if(ret)
-	{
-		unfreeze = 1;
-		goto critical;
-	}
-
-	// Clear the Freeze DCO bit
-	ret = mchf_hw_i2c_WriteRegister(os.si570_address, SI570_REG_137, (reg_137 & ~SI570_FREEZE_DCO));
-	if(ret)
-		goto critical;
-
-	// Read current
-	ret = mchf_hw_i2c_ReadRegister(os.si570_address, SI570_REG_135, &reg_135);
-	if(ret)
-		goto critical;
-
-	// Set the NewFreq bit
-	ret = mchf_hw_i2c_WriteRegister(os.si570_address, SI570_REG_135, (reg_135|SI570_NEW_FREQ));
-	if(ret)
-		goto critical;
-
-	// Wait for action completed
-	reg_135 = SI570_NEW_FREQ;
-	while(reg_135 & SI570_NEW_FREQ)
-	{
-		ret = mchf_hw_i2c_ReadRegister(os.si570_address, SI570_REG_135, &reg_135);
-		if(ret)
-			goto critical;
-	}
-
-	return 0;
-
-	critical:
-	// CriticalError(101);
-	if(unfreeze) mchf_hw_i2c_WriteRegister(os.si570_address, SI570_REG_137, (reg_137 & ~SI570_FREEZE_DCO));
-	return 1;
+    if(unfreeze) {
+        mchf_hw_i2c_WriteRegister(os.si570_address, SI570_REG_137, (reg_137 & ~SI570_FREEZE_DCO));
+    }
+    return ret!=0?SI570_I2C_ERROR:retval;
 }
 
 //*----------------------------------------------------------------------------
@@ -209,22 +187,23 @@ static uchar ui_si570_large_frequency_change(void)
 //* Output Parameters   :
 //* Functions called    :
 //*----------------------------------------------------------------------------
-static uchar ui_si570_is_large_change(void)
+static bool ui_si570_is_large_change(void)
 {
-	long double	delta_rfreq;
+    long double	delta_rfreq;
+    bool retval = false;
 
-	if(os.rfreq_old == os.rfreq)
-		return 0;
+    if(os.rfreq_old != os.rfreq) {
+        if(os.rfreq_old < os.rfreq) {
+            delta_rfreq = os.rfreq - os.rfreq_old;
+        } else {
+            delta_rfreq = os.rfreq_old - os.rfreq;
+        }
 
-	if(os.rfreq_old < os.rfreq)
-		delta_rfreq = os.rfreq - os.rfreq_old;
-	else
-		delta_rfreq = os.rfreq_old - os.rfreq;
-
-	if((delta_rfreq / os.rfreq_old) <= 0.0035)
-		return 0;
-
-	return 1;
+        if((delta_rfreq / os.rfreq_old) > 0.0035) {
+            retval = true;
+        }
+    }
+    return retval;
 }
 
 //*----------------------------------------------------------------------------
@@ -328,132 +307,144 @@ uchar ui_si570_get_configuration(void)
 //* Output Parameters   :
 //* Functions called    :
 //*----------------------------------------------------------------------------
-static uchar ui_si570_change_frequency(float new_freq, uchar test)
+static Si570_ResultCodes ui_si570_change_frequency(float new_freq, uchar test)
 {
-	uchar	i, res = 0;
-	ushort	divider_max, curr_div, whole;
+    uchar	i;
+    ushort	divider_max, curr_div, whole;
 
-	float	curr_n1;
-	float	n1_tmp;
+    float	curr_n1;
+    float	n1_tmp;
 
-	ulong	frac_bits;
+    ulong	frac_bits;
+    bool    is_large = false;
+    Si570_ResultCodes retval = SI570_OK;
 
 #ifdef LOWER_PRECISION
-	float	ratio = 0;
-	ulong	final_rfreq_long;
+    float	ratio = 0;
+    ulong	final_rfreq_long;
 #endif
 
-	uchar	n1;
-	uchar	hsdiv;
+    uchar	n1;
+    uchar	hsdiv;
 
-	divider_max = (ushort)floorf(fdco_max / new_freq);
-	curr_div	= (ushort)ceilf (fdco_min / new_freq);
+    divider_max = (ushort)floorf(fdco_max / new_freq);
+    curr_div	= (ushort)ceilf (fdco_min / new_freq);
 
-	bool found;
-	for (found = false;(curr_div <= divider_max) && !found; curr_div++)
-	{
-		for(i = 0; i < 6; i++)
-		{
-			hsdiv = hs_div[i];
-			curr_n1 = (float)(curr_div) / (float)(hsdiv);
+    bool found;
+    for (found = false;(curr_div <= divider_max) && !found; curr_div++)
+    {
+        for(i = 0; i < 6; i++)
+        {
+            hsdiv = hs_div[i];
+            curr_n1 = (float)(curr_div) / (float)(hsdiv);
 
-			n1_tmp = floorf(curr_n1);
-			n1_tmp = curr_n1 - n1_tmp;
+            n1_tmp = floorf(curr_n1);
+            n1_tmp = curr_n1 - n1_tmp;
 
-			if(n1_tmp == 0.0)
-			{
-				n1 = (uchar)curr_n1;
-				if((n1 == 1) || ((n1 & 1) == 0))
-				{
-					found = true;
-					break;
-				}
-			}
-		}
-	}
+            if(n1_tmp == 0.0)
+            {
+                n1 = (uchar)curr_n1;
+                if((n1 == 1) || ((n1 & 1) == 0))
+                {
+                    found = true;
+                    break;
+                }
+            }
+        }
+    }
 
-	if (!found) {
-		CriticalError(102);
-	}
-	else
-	{
-		// New RFREQ calculation
-		os.rfreq = ((long double)new_freq * (long double)(n1 * hsdiv)) / os.fxtal;
+    if (!found) {
+        CriticalError(102);
+    }
+    else
+    {
+        // New RFREQ calculation
+        os.rfreq = ((long double)new_freq * (long double)(n1 * hsdiv)) / os.fxtal;
+        is_large = ui_si570_is_large_change();
+        // check to see if this tuning will result in a "large" tuning step, without setting the frequency yet;
+        if (!test) {
+#ifdef LOWER_PRECISION
+            ratio = new_freq / fout0;
+            ratio = ratio * (((float)n1)/((float)os.init_n1));
+            ratio = ratio * (((float)hsdiv)/((float)os.init_hsdiv));
+            final_rfreq_long = ratio * os.init_rfreq;
+#endif
 
-	#ifdef LOWER_PRECISION
-		ratio = new_freq / fout0;
-		ratio = ratio * (((float)n1)/((float)os.init_n1));
-		ratio = ratio * (((float)hsdiv)/((float)os.init_hsdiv));
-		final_rfreq_long = ratio * os.init_rfreq;
-	#endif
+            for(i = 0; i < 6; i++) {
+                os.regs[i] = 0;
+            }
 
-		for(i = 0; i < 6; i++)
-			os.regs[i] = 0;
+            hsdiv = hsdiv - 4;
+            os.regs[0] = (hsdiv << 5);
 
-		hsdiv = hsdiv - 4;
-		os.regs[0] = (hsdiv << 5);
+            if(n1 == 1) {
+                n1 = 0;
+            } else if((n1 & 1) == 0) {
+                n1 = n1 - 1;
+            }
 
-		if(n1 == 1)
-			n1 = 0;
-		else if((n1 & 1) == 0)
-			n1 = n1 - 1;
+            os.regs[0] = ui_si570_setbits(os.regs[0], 0xE0, (n1 >> 2));
+            os.regs[1] = (n1 & 3) << 6;
 
-		os.regs[0] = ui_si570_setbits(os.regs[0], 0xE0, (n1 >> 2));
-		os.regs[1] = (n1 & 3) << 6;
+#ifdef LOWER_PRECISION
+            os.regs[1] = os.regs[1] | (final_rfreq_long >> 30);
+            os.regs[2] = final_rfreq_long >> 22;
+            os.regs[3] = final_rfreq_long >> 14;
+            os.regs[4] = final_rfreq_long >> 6;
+            os.regs[5] = final_rfreq_long << 2;
+#endif
 
-	#ifdef LOWER_PRECISION
-		os.regs[1] = os.regs[1] | (final_rfreq_long >> 30);
-		os.regs[2] = final_rfreq_long >> 22;
-		os.regs[3] = final_rfreq_long >> 14;
-		os.regs[4] = final_rfreq_long >> 6;
-		os.regs[5] = final_rfreq_long << 2;
-	#endif
+#ifdef HIGHER_PRECISION
+            whole = floorf(os.rfreq);
+            frac_bits = floorf((os.rfreq - whole) * POW_2_28);
 
-	#ifdef HIGHER_PRECISION
-		whole = floorf(os.rfreq);
-		frac_bits = floorf((os.rfreq - whole) * POW_2_28);
+            for(i = 5; i >= 3; i--)
+            {
+                os.regs[i] = frac_bits & 0xFF;
+                frac_bits = frac_bits >> 8;
+            }
 
-		for(i = 5; i >= 3; i--)
-		{
-			os.regs[i] = frac_bits & 0xFF;
-			frac_bits = frac_bits >> 8;
-		}
+            os.regs[2] = ui_si570_setbits(os.regs[2], 0xF0, (frac_bits & 0xF));
+            os.regs[2] = ui_si570_setbits(os.regs[2], 0x0F, (whole & 0xF) << 4);
+            os.regs[1] = ui_si570_setbits(os.regs[1], 0xC0, (whole >> 4) & 0x3F);
+#endif
 
-		os.regs[2] = ui_si570_setbits(os.regs[2], 0xF0, (frac_bits & 0xF));
-		os.regs[2] = ui_si570_setbits(os.regs[2], 0x0F, (whole & 0xF) << 4);
-		os.regs[1] = ui_si570_setbits(os.regs[1], 0xC0, (whole >> 4) & 0x3F);
-	#endif
 
-		// check to see if this tuning will result in a "large" tuning step, without setting the frequency
-		if(test)
-			return(ui_si570_is_large_change());
+            //
+            if(is_large)
+            {
+                retval = ui_si570_large_frequency_change();
+            }
+            else
+            {
+                retval = ui_si570_small_frequency_change();
+                if (retval != SI570_OK) {
+                    // Maybe large change was needed, let's try it
+                    retval = ui_si570_large_frequency_change();
+                }
+            }
+            if(retval == SI570_OK) {
 
-		//
-		if(ui_si570_is_large_change())
-		{
-			res = ui_si570_large_frequency_change();
-		}
-		else
-		{
-			res = ui_si570_small_frequency_change();
-
-			// Maybe large change was needed, let's try it
-			if(res)	{
-				res = ui_si570_large_frequency_change();
-			}
-		}
-
-		if(res)
-			return res;
-
-		// Verify second time - we might be transmitting, so
-		// it is absolutely unacceptable to be on startup
-		// SI570 frequency if any I2C error or chip reset occurs!
-		res = ui_si570_verify_frequency();
-		if(res == 0)
-			os.rfreq_old = os.rfreq;
-	}
-	return res;
+                // Verify second time - we might be transmitting, so
+                // it is absolutely unacceptable to be on startup
+                // SI570 frequency if any I2C error or chip reset occurs!
+                retval = ui_si570_verify_frequency();
+                if(retval == SI570_OK) {
+                    os.rfreq_old = os.rfreq;
+                }
+            }
+        } else {
+            if (is_large) {
+                retval = SI570_LARGE_STEP;
+            }
+        }
+    }
+    if (SI570_ERROR_VERIFY) {
+        // make sure to generate a large step
+        // in order to recover on next tune attempt
+        os.rfreq_old = 0.0;
+    }
+    return retval;
 }
 
 //*----------------------------------------------------------------------------
@@ -463,9 +454,9 @@ static uchar ui_si570_change_frequency(float new_freq, uchar test)
 //* Output Parameters   :
 //* Functions called    :
 //*----------------------------------------------------------------------------
-uchar ui_si570_set_frequency(ulong freq, int calib, int temp_factor, uchar test)
+Si570_ResultCodes ui_si570_set_frequency(ulong freq, int calib, int temp_factor, uchar test)
 {
-	uchar retval;
+	Si570_ResultCodes retval = SI570_OK;
 	long double d;
 	float		si_freq, freq_calc, freq_scale, temp_scale, temp;
 
@@ -498,7 +489,7 @@ uchar ui_si570_set_frequency(ulong freq, int calib, int temp_factor, uchar test)
 	else if (si_freq <= SI570_HARD_MAX_FREQ / 1000000 && si_freq >= SI570_HARD_MIN_FREQ / 1000000)	{
 		// tuning outside specs, inside hard limits --> tuning with gaps, color yellow
 		ui_si570_change_frequency(si_freq, test);
-		retval = 2;
+		retval = SI570_TUNE_LIMITED;
 	}
 	else	{
 		// tuning outside hard limits, tuning bad, color red
@@ -507,7 +498,7 @@ uchar ui_si570_set_frequency(ulong freq, int calib, int temp_factor, uchar test)
 		if (si_freq < SI570_MIN_FREQ / 1000000)
 			si_freq = SI570_MIN_FREQ / 1000000;
 		ui_si570_change_frequency(si_freq, test);
-		retval = 1;
+		retval = SI570_TUNE_IMPOSSIBLE;
 	}
 
 	return retval;

--- a/mchf-eclipse/drivers/ui/oscillator/ui_si570.h
+++ b/mchf-eclipse/drivers/ui/oscillator/ui_si570.h
@@ -99,12 +99,24 @@ typedef struct OscillatorState
 
 } OscillatorState;
 
+
+typedef enum {
+    SI570_OK = 0,
+    SI570_LARGE_STEP,
+    SI570_TUNE_IMPOSSIBLE,
+    SI570_TUNE_LIMITED,
+    SI570_I2C_ERROR,
+    SI570_ERROR_VERIFY
+
+} Si570_ResultCodes;
+
 // -------------------------------------------------------------------------------------
 // Exports
 // ------------------
 
+
 uchar 	ui_si570_get_configuration(void);
-uchar 	ui_si570_set_frequency(ulong freq, int calib, int temp_factor, uchar test);
+Si570_ResultCodes 	ui_si570_set_frequency(ulong freq, int calib, int temp_factor, uchar test);
 
 uchar 	ui_si570_init_temp_sensor(void);
 uchar 	ui_si570_read_temp(int *temp);

--- a/mchf-eclipse/drivers/ui/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/ui_menu.c
@@ -2311,9 +2311,7 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode, int pos)
 
 			    UiMenu_DisplayValue("Working",Red,opt_pos);
 			    copy_virt2ser();
-			    ui_si570_get_configuration();		// restore SI570 to factory default
-			    *(__IO uint32_t*)(SRAM2_BASE) = 0x55;
-			    NVIC_SystemReset();			// restart mcHF
+			    mchf_reboot();
 			  }
 			}
 			break;

--- a/mchf-eclipse/hardware/mchf_board.c
+++ b/mchf-eclipse/hardware/mchf_board.c
@@ -1018,3 +1018,9 @@ void verify_servirt(void)
 			ts.ser_eeprom_in_use = 0x05;	// mark data copy as faulty
 	}
 }
+
+void mchf_reboot() {
+    ui_si570_get_configuration();       // restore SI570 to factory default
+    *(__IO uint32_t*)(SRAM2_BASE) = 0x55;
+    NVIC_SystemReset();         // restart mcHF
+}

--- a/mchf-eclipse/hardware/mchf_board.h
+++ b/mchf-eclipse/hardware/mchf_board.h
@@ -37,6 +37,7 @@
 #include "stm32f4xx.h"
 #include "mchf_types.h"
 #include "audio_filter.h"
+#include "ui_si570.h"
 //
 //
 //
@@ -1101,7 +1102,7 @@ typedef struct TransceiverState
 	bool USE_NEW_PHASE_CORRECTION; 	// used to test new phase correction
 	bool encoder3state;
 	uchar c_line;					// position of center line
-	ushort last_lo_result;			// used in dynamic tuning to hold frequency color
+	Si570_ResultCodes last_lo_result;			// used in dynamic tuning to hold frequency color
 } TransceiverState;
 //
 extern __IO TransceiverState ts;
@@ -1143,6 +1144,7 @@ uint16_t Write_SerEEPROM(uint16_t addr, uint16_t value);
 void copy_virt2ser(void);
 void copy_ser2virt(void);
 void verify_servirt(void);
+void mchf_reboot();
 
 // in main.c
 void CriticalError(ulong error);


### PR DESCRIPTION
Uncovered an issue where sometimes the Si570 will not tune
successfully. Workaround being implemented and seems to work ok.

Other than that used the more detailled Si570 error reporting to
improved color codes  of frequency display:
Red is used now only if there is a "real" problem with the Si570
(missing etc.)
If used tuning range, Orange is used instead of Red.
