### PR TITLE
Important Changes (User visible and Internally)

### DIFF
--- a/mchf-eclipse/drivers/cat/cat_driver.c
+++ b/mchf-eclipse/drivers/cat/cat_driver.c
@@ -253,7 +253,7 @@ void CatDriverFT817CheckAndExecute() {
 			
 			if(ts.xlat == 0)
 			    {
-			    fdelta = (ts.tx_audio_source == TX_AUDIO_DIGIQ)?audio_driver_xlate_freq()*4:0;
+			    fdelta = (ts.tx_audio_source == TX_AUDIO_DIGIQ)?audio_driver_xlate_freq()*TUNE_MULT:0;
 			    // If we are in DIGITAL IQ Output mode, send real tune frequency frequency instead
 			    // translated RX frequency
 			    }

--- a/mchf-eclipse/drivers/ui/oscillator/ui_si570.h
+++ b/mchf-eclipse/drivers/ui/oscillator/ui_si570.h
@@ -101,12 +101,12 @@ typedef struct OscillatorState
 
 
 typedef enum {
-    SI570_OK = 0,
-    SI570_LARGE_STEP,
-    SI570_TUNE_IMPOSSIBLE,
-    SI570_TUNE_LIMITED,
-    SI570_I2C_ERROR,
-    SI570_ERROR_VERIFY
+    SI570_OK = 0, // tuning ok
+    SI570_TUNE_LIMITED, // tuning to freq close to desired freq, still ok
+    SI570_TUNE_IMPOSSIBLE, // did not tune, tune freq unknown
+    SI570_I2C_ERROR, // could not talk to Si570, tune freq unknown
+    SI570_ERROR_VERIFY, // register do not match, tune freq unknown
+    SI570_LARGE_STEP, // did not tune, just checking
 
 } Si570_ResultCodes;
 

--- a/mchf-eclipse/drivers/ui/ui_configuration.h
+++ b/mchf-eclipse/drivers/ui/ui_configuration.h
@@ -60,7 +60,7 @@ uint16_t    UiConfiguration_SaveEepromValues(void);
 #define CW_OFFSET_MAX       8       // Maximum menu setting
 #define CW_OFFSET_MODE_DEFAULT  0   // Default CW offset setting
 //
-#define USB_FREQ_THRESHOLD  40000000    // LO frequency at and above which the default is USB, Hz*4  (e.g. 10 MHz = 40 MHz)
+#define USB_FREQ_THRESHOLD  (10000000*TUNE_MULT)    // LO frequency at and above which the default is USB, Hz*4  (e.g. 10 MHz = 40 MHz)
 //
 #define MAX_RF_ATTEN        15      // Maximum setting for RF attenuation
 //

--- a/mchf-eclipse/hardware/mchf_board.h
+++ b/mchf-eclipse/hardware/mchf_board.h
@@ -484,7 +484,10 @@ extern const ButtonMap  bm[BUTTON_NUM];
 #define	MAX_BANDS			17		// Highest band number:  17 = General coverage (RX only) band
 #define	MAX_BAND_NUM		(MAX_BANDS+1)		// Number of Bands
 
-#define	KHZ_MULT			4000	// multiplier to convert oscillator frequency or band size to display kHz, used below
+//  multiplier to convert between dial_freq and tune_freq
+#define TUNE_MULT 4
+
+#define	KHZ_MULT			(TUNE_MULT*1000)	// multiplier to convert oscillator frequency or band size to display kHz, used below
 //
 // Bands definition
 // - ID
@@ -987,6 +990,9 @@ typedef struct TransceiverState
 	//
 	bool	frequency_lock;				// TRUE if frequency knob is locked
 	//
+#define TX_DISABLE_ALWAYS       1
+#define TX_DISABLE_USER         2
+#define TX_DISABLE_OUTOFRANGE	4
 	uchar	tx_disable;					// TRUE if transmit is to be disabled
 	//
     #define MISC_FLAGS1_TX_AUTOSWITCH_UI_DISABLE 0x01


### PR DESCRIPTION
User visible:
- If outside tunable range or oscillator is not working ok, NO TX
- If outside tunable range Frequency is Orange
- If osicallator is not working Frequency is Red
- If tuning is pending Frequency is Blue (you should
  not be able to see this, is there only for a few ms)

Internally:
- Started to replace all *4 and /4 conversions with *TUNE_MULT and /TUNE_MULT
  This will allow a later migration to a more flexible approach.
  I might have missed spots, so please go in and find out places where
  dial and tune frequencies are converted into each other.
- Merged both frequency change (normal/fast) functions into one by factoring
  out the display part and putting a single optimization into "normal" change.
  Disabling/Enabling the TX in case of tuning problems is also done here.
  (functions name is RadioManagement_ChangeFrequency in ui_driver.c)

Further minor changes have happend.
