### PR TITLE
bugfix spectrum display

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -96,7 +96,7 @@ static arm_iir_lattice_instance_f32	IIR_AntiAlias;
 //
 // variables for RX manual notch IIR filter
 //static float32_t		iir_notch_state[4];
-//static arm_biquad_casd_df1_inst_f32	IIR_Notch;
+static arm_biquad_casd_df1_inst_f32	IIR_Notch;
 
 /*+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
  * Manual Notch init [DD4WH, april 2016]
@@ -196,19 +196,18 @@ IIR_Notch.pState = (float32_t *)&iir_notch_state;					// point to state array fo
 
 static arm_biquad_casd_df1_inst_f32 IIR_Notch = {
 		.numStages = 1,
-		.pCoeffs = (float32_t *)(const float32_t [])
-		{ 1,0,0,0,0
-
-/*
-			0.003467332208447815,
+		.pCoeffs = (float32_t *)(float32_t [])
+		{
+			1,0,0,0,0
+/*			0.003467332208447815,
 			   0.003219363651146496,
 			   0.003467332208447815,
 			   1.852573355019514480,
-			   -0.862727383087556587*/
+			   -0.862727383087556587 */
 		},
 
-		.pState = (float32_t *)(const float32_t [])
-			{0.0 ,0.0 ,0.0 ,0.0}
+		.pState = (float32_t *)(float32_t [])
+			{0 ,0 ,0 ,0}
 };
 
 //
@@ -467,7 +466,64 @@ void audio_driver_set_rx_audio_filter(void)
     }
 	IIR_AntiAlias.pState = (float32_t *)&iir_aa_state;					// point to state array for IIR filter
 
+	// ############################################
+	// initialize Notch_Filter
+	float32_t b0,b1,b2,a1,a2;
+	float32_t coef[5];
 
+	b0 =	0.003467332208447815;
+	b1 = 		   0.003219363651146496;
+	b2 = 		   0.003467332208447815;
+	a1 = 		   1.852573355019514480;
+	a2 =		   -0.862727383087556587;
+/*
+	b0 =  0.067632527732130063;
+	b1 =  0.132704003843355428;
+	b2 =  0.067632527732130063;
+	a1 =  -1.146541271271349860;
+	a2 =  0.414510330578965303;
+*/
+	coef[0] = b0;
+	coef[1] = b1;
+	coef[2] = b2;
+	coef[3] = a1;
+	coef[4] = a2;
+
+	IIR_Notch.pCoeffs = coef;
+
+//	IIR_Notch.pCoeffs = coef;
+
+/*			(float32_t *)(float32_t [])
+					{
+						0.003467332208447815,
+						   0.003219363651146496,
+						   0.003467332208447815,
+						   1.852573355019514480,
+						   -0.862727383087556587
+					};
+					*/
+//	IIR_Notch.pState = (float32_t *)(float32_t [])
+//		{0.0 ,0.0 ,0.0 ,0.0};
+//	IIR_Notch.numStages = 1;
+
+// #######################################################################
+
+/*	static arm_biquad_casd_df1_inst_f32 IIR_Notch = {
+			.numStages = 1,
+			.pCoeffs = (float32_t *)(const float32_t [])
+			{
+				0.003467332208447815,
+				   0.003219363651146496,
+				   0.003467332208447815,
+				   1.852573355019514480,
+				   -0.862727383087556587
+			},
+
+			.pState = (float32_t *)(float32_t [])
+				{0.0 ,0.0 ,0.0 ,0.0}
+	};
+*/
+// #######################################################################
 
 	//
 	// Initialize high-pass filter used for the FM noise squelch

--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -95,121 +95,20 @@ static float32_t		iir_aa_state[FIR_RXAUDIO_BLOCK_SIZE + FIR_RXAUDIO_NUM_TAPS];
 static arm_iir_lattice_instance_f32	IIR_AntiAlias;
 //
 // variables for RX manual notch IIR filter
-//static float32_t		iir_notch_state[4];
-static arm_biquad_casd_df1_inst_f32	IIR_Notch;
-
-/*+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
- * Manual Notch init [DD4WH, april 2016]
- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*/
-/*//
-//	Initialize IIR biquad filter for manual notch
-//
-// it is only a lightweight filter with one stage (= 2nd order IIR)
-// but nonetheless very effective
-//
-// now it is time for the DSP Audio-EQ-cookbook for generating the coeffs of the notch filter on the fly
-// www.musicdsp.org/files/Audio-EQ-Cookbook.txt  [by Robert Bristow-Johnson]
-//
-#define SAMPLING_FREQ 48000; // should this become a global variable?
-float32_t f0 = 2000.0; // notch frequency --> TODO: will be set by encoder2
-float32_t Q = 100.0; // larger Q gives narrower notch
-float32_t w0 = 2.0 * PI * f0 / SAMPLING_FREQ;
-float32_t alpha = sin(w0) / (2.0 * Q);
-float32_t a0 = 1.0; // gain scaling
-float32_t b0,b1,b2,a1,a2;
-
-//
-// the ARM algorithm assumes the biquad form
-// y[n] = b0 * x[n] + b1 * x[n-1] + b2 * x[n-2] + a1 * y[n-1] + a2 * y[n-2]
-//
-// However, the cookbook formulae by Robert Bristow-Johnson AND the Iowa Hills IIR Filter designer
-// use this formula:
-//
-// y[n] = b0 * x[n] + b1 * x[n-1] + b2 * x[n-2] - a1 * y[n-1] - a2 * y[n-2]
-//
-// Therefore, we have to use negated a1 and a2 for use with the ARM function
-// notch implementation
-b0 = 1.0;
-b1 = - 2.0 * cos(w0);
-b2 = 1.0;
-a0 = 1.0 + alpha;
-a1 = 2.0 * cos(w0); // already negated!
-a2 = alpha - 1.0; // already negated!
-
-w0 = 0.2617993877
-alpha = 0.001294095225
-
-1.0, //b0
--1.931851653, //b1
-1.0, //b2
-1.931851653, //a1
--0.9987059048 // a2
-
-0.998707577,
--1.929354884,
-0.998707577,
-1.929354884,
--0.997415155
-
-// scaling the coefficients for gain
-b0 = b0/a0;
-b1 = b1/a0;
-b2 = b2/a0;
-a1 = a1/a0;
-a2 = a2/a0;
-
-// moderate lowpass filter
-a1 =  -1.146541271271349860;
-a2 =  0.414510330578965303;
-b0 =  0.067632527732130063;
-b1 =  0.132704003843355428;
-b2 =  0.067632527732130063;
-
-// notch filter 5kHz, width 100Hz
-a1 =  1.576037749778233190;
-a2 =  -0.986392502758464240;
-b0  = 0.993196251379232065;
-b1  = -1.576037749778233190;
-b2 =  0.993196251379232065;
-
-	// passthru
-a1 = 0.0; a2 = 0.0;
-b1 = 0.0; b2 = 0.0;
-b0 = 1.0; */
-// order of coeffs: b0, b1, b2, a1, a2
-//
-
-//	IIR_Notch.pCoeffs = (float32_t*)&{b0,b1,b2,a1,a2};
-//	IIR_Notch.numStages = 1;
-/*
-    for(i = 0; i < 4; i++)	{	// no. of state variables = numStages * 4
-	// initialize state buffer to zeroes
-	iir_notch_state[i] = 0;
-}
-
-IIR_Notch.pState = (float32_t *)&iir_notch_state;					// point to state array for IIR filter
-*/
-/*+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
- * End of Manual Notch init
- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*/
-
-
 static arm_biquad_casd_df1_inst_f32 IIR_Notch = {
 		.numStages = 1,
 		.pCoeffs = (float32_t *)(float32_t [])
 		{
-			1,0,0,0,0
-/*			0.003467332208447815,
+			0.003467332208447815,
 			   0.003219363651146496,
 			   0.003467332208447815,
 			   1.852573355019514480,
-			   -0.862727383087556587 */
+			   -0.862727383087556587
 		},
 
 		.pState = (float32_t *)(float32_t [])
 			{0 ,0 ,0 ,0}
 };
-
 //
 // variables for FM squelch IIR filters
 static float32_t		iir_squelch_rx_state[FIR_RXAUDIO_BLOCK_SIZE + FIR_RXAUDIO_NUM_TAPS];
@@ -444,7 +343,6 @@ void audio_driver_set_rx_audio_filter(void)
     	iir_rx_state[i] = 0;
     }
 	IIR_PreFilter.pState = (float32_t *)&iir_rx_state;					// point to state array for IIR filter
-//
 	//
 	// Initialize IIR antialias filter state buffer
  	//
@@ -466,65 +364,57 @@ void audio_driver_set_rx_audio_filter(void)
     }
 	IIR_AntiAlias.pState = (float32_t *)&iir_aa_state;					// point to state array for IIR filter
 
-	// ############################################
-	// initialize Notch_Filter
+	/*+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+	 * Manual Notch [DD4WH, april 2016]
+	 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*/
+	// it is only a lightweight filter with one stage (= 2nd order IIR)
+	// but nonetheless very effective
+	//
+	// now it is time for the DSP Audio-EQ-cookbook for generating the coeffs of the notch filter on the fly
+	// www.musicdsp.org/files/Audio-EQ-Cookbook.txt  [by Robert Bristow-Johnson]
+	//
+	float32_t FS = 48000; // should this become a global variable?
+	float32_t f0 = 2000; // notch frequency --> TODO: will be set by encoder2
+	float32_t Q = 200; // larger Q gives narrower notch
+	float32_t w0 = 2 * PI * f0 / FS;
+	float32_t alpha = sin(w0) / (2 * Q);
+	float32_t a0 = 1; // gain scaling
 	float32_t b0,b1,b2,a1,a2;
-	float32_t coef[5];
+	//
+	// the ARM algorithm assumes the biquad form
+	// y[n] = b0 * x[n] + b1 * x[n-1] + b2 * x[n-2] + a1 * y[n-1] + a2 * y[n-2]
+	//
+	// However, the cookbook formulae by Robert Bristow-Johnson AND the Iowa Hills IIR Filter designer
+	// use this formula:
+	//
+	// y[n] = b0 * x[n] + b1 * x[n-1] + b2 * x[n-2] - a1 * y[n-1] - a2 * y[n-2]
+	//
+	// Therefore, we have to use negated a1 and a2 for use with the ARM function
+	// notch implementation
+	//
+	b0 = 1;
+	b1 = - 2 * cos(w0);
+	b2 = 1;
+	a0 = 1 + alpha;
+	a1 = 2 * cos(w0); // already negated!
+	a2 = alpha - 1; // already negated!
 
-	b0 =	0.003467332208447815;
-	b1 = 		   0.003219363651146496;
-	b2 = 		   0.003467332208447815;
-	a1 = 		   1.852573355019514480;
-	a2 =		   -0.862727383087556587;
-/*
-	b0 =  0.067632527732130063;
-	b1 =  0.132704003843355428;
-	b2 =  0.067632527732130063;
-	a1 =  -1.146541271271349860;
-	a2 =  0.414510330578965303;
-*/
-	coef[0] = b0;
-	coef[1] = b1;
-	coef[2] = b2;
-	coef[3] = a1;
-	coef[4] = a2;
+	// scaling the coefficients for gain
+	b0 = b0/a0;
+	b1 = b1/a0;
+	b2 = b2/a0;
+	a1 = a1/a0;
+	a2 = a2/a0;
 
-	IIR_Notch.pCoeffs = coef;
+	IIR_Notch.pCoeffs[0] = b0;
+	IIR_Notch.pCoeffs[1] = b1;
+	IIR_Notch.pCoeffs[2] = b2;
+	IIR_Notch.pCoeffs[3] = a1;
+	IIR_Notch.pCoeffs[4] = a2;
 
-//	IIR_Notch.pCoeffs = coef;
-
-/*			(float32_t *)(float32_t [])
-					{
-						0.003467332208447815,
-						   0.003219363651146496,
-						   0.003467332208447815,
-						   1.852573355019514480,
-						   -0.862727383087556587
-					};
-					*/
-//	IIR_Notch.pState = (float32_t *)(float32_t [])
-//		{0.0 ,0.0 ,0.0 ,0.0};
-//	IIR_Notch.numStages = 1;
-
-// #######################################################################
-
-/*	static arm_biquad_casd_df1_inst_f32 IIR_Notch = {
-			.numStages = 1,
-			.pCoeffs = (float32_t *)(const float32_t [])
-			{
-				0.003467332208447815,
-				   0.003219363651146496,
-				   0.003467332208447815,
-				   1.852573355019514480,
-				   -0.862727383087556587
-			},
-
-			.pState = (float32_t *)(float32_t [])
-				{0.0 ,0.0 ,0.0 ,0.0}
-	};
-*/
-// #######################################################################
-
+	/*+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+	 * End of Manual Notch coefficient calculation and setting
+	 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*/
 	//
 	// Initialize high-pass filter used for the FM noise squelch
 	//

--- a/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
@@ -444,7 +444,7 @@ void    UiSpectrumDrawSpectrum(q15_t *fft_old, q15_t *fft_new, const ushort colo
 	int spec_height = SPECTRUM_HEIGHT; //x
 	int spec_start_y = SPECTRUM_START_Y;
 
-	if (ts.spectrum_light){
+	if (ts.spectrum_light && ts.waterfall_size == WATERFALL_BIG){
 		spec_height = spec_height + SPEC_LIGHT_MORE_POINTS;
 		spec_start_y = spec_start_y - SPEC_LIGHT_MORE_POINTS;
 	}
@@ -762,7 +762,7 @@ static void UiSpectrum_InitSpectrumDisplay()
 void UiSpectrumReDrawScopeDisplay()
 {
 	int spec_height = SPECTRUM_HEIGHT;
-	if (ts.spectrum_light)
+	if (ts.spectrum_light && ts.waterfall_size == WATERFALL_BIG)
 		spec_height = spec_height + SPEC_LIGHT_MORE_POINTS;
 		ulong i, spec_width;
 	uint32_t	max_ptr;	// throw-away pointer for ARM maxval and minval functions

--- a/mchf-eclipse/hardware/mchf_board.h
+++ b/mchf-eclipse/hardware/mchf_board.h
@@ -595,7 +595,8 @@ extern const ButtonMap  bm[BUTTON_NUM];
 // encoder two
 #define ENC_TWO_MODE_RF_GAIN		0
 #define ENC_TWO_MODE_SIG_PROC		1
-#define ENC_TWO_MAX_MODE		2
+#define ENC_TWO_MODE_NOTCH_F		2
+#define ENC_TWO_MAX_MODE		3
 //
 // encoder three
 #define ENC_THREE_MODE_RIT		0

--- a/mchf-eclipse/hardware/mchf_board.h
+++ b/mchf-eclipse/hardware/mchf_board.h
@@ -1101,6 +1101,7 @@ typedef struct TransceiverState
 	bool	spectrum_light;			// light-weight spectrum display
 	uchar	xlat;					// CAT <> IQ-Audio
 	bool	dynamic_tuning_active;	// dynamic tuning active by estimating the encoder speed
+	ulong	notch_frequency;		// frequency of the manual notch filter
 
 	uint8_t display_type;           // existence/identification of display type
 	uint32_t audio_int_counter;		// used for encoder timing - test DL2FW


### PR DESCRIPTION
Spectrum light does not plot over grey bar any more.
Preparation for manual notch filter (not yet adjustable - hard coded as 2kHz, Q=200 notch, try long press G3).
