### PR TITLE
notch and peak filter implemented

### DIFF
--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -387,6 +387,7 @@ void UiDriver_HandleSwitchToNextDspMode()
 			ts.enc_two_mode = ENC_TWO_MODE_RF_GAIN;
 			UiDriverChangeRfGain(1);
 			UiDriverDisplayNotch(0); // display
+//			UiDriverDisplayBass();
 			break;
 		case DSP_SWITCH_NR:
 			ts.dsp_active |= DSP_NR_ENABLE; 	//on


### PR DESCRIPTION
Notch filter and peak filter now implemented.
Use G2 to choose among the DSP components. Adjust notch frequency and peak frequency with encoder2.
Q of notch and peak filter is fixed at 10.
WARNING: LOUD NOISE COULD OCCUR, these are still EXPERIMENTAL filters, if using headphones, adjust for small volume before testing!!!
Bass and treble shelve filters already working, but not yet adjustable, these are hard-coded for pass-thru.
