### PR TITLE
Bass lowShelf & treble highShelf audio filters implemented

### DIFF
--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -356,8 +356,8 @@ void UiDriver_HandleSwitchToNextDspMode()
 		// NR ON/OFF		ts.dsp_active |= DSP_NR_ENABLE;	 // 	ts.dsp_active &= ~DSP_NR_ENABLE;
 		// NOTCH ON/OFF		ts.dsp_active |= DSP_NOTCH_ENABLE; // 	ts.dsp_active &= ~DSP_NOTCH_ENABLE;
 		// Manual Notch		ts.notch_enabled = 1; // ts.notch_enabled = 0;
-		// BASS				ts.bass // always "ON", gain ranges from -12 to +12 dB, "OFF" = 0dB
-		// TREBLE			ts.treble // always "ON", gain ranges from -12 to +12 dB, "OFF" = 0dB
+		// BASS				ts.bass // always "ON", gain ranges from -20 to +20 dB, "OFF" = 0dB
+		// TREBLE			ts.treble // always "ON", gain ranges from -20 to +20 dB, "OFF" = 0dB
 
 		ts.dsp_mode ++; // switch mode
 		// 0 = everything OFF, 1 = NR, 2 = automatic NOTCH, 3 = NR + NOTCH, 4 = manual NOTCH, 5 = BASS adjustment, 6 = TREBLE adjustment
@@ -4166,8 +4166,8 @@ static void UiDriverCheckEncoderTwo()
         	if(pot_diff > 0) {
         		ts.bass_gain = ts.bass_gain + 1;
         	}
-        	if (ts.bass_gain < -12) ts.bass_gain = -12;
-        	if (ts.bass_gain > 12) ts.bass_gain = 12;
+        	if (ts.bass_gain < -20) ts.bass_gain = -20;
+        	if (ts.bass_gain > 20) ts.bass_gain = 20;
         	// display bass gain
         	UiDriverDisplayBass();
         	// set filter instance
@@ -4181,8 +4181,8 @@ static void UiDriverCheckEncoderTwo()
         	if(pot_diff > 0) {
         		ts.treble_gain = ts.treble_gain + 1;
         	}
-        	if (ts.treble_gain < -12) ts.treble_gain = -12;
-        	if (ts.treble_gain > 12) ts.treble_gain = 12;
+        	if (ts.treble_gain < -20) ts.treble_gain = -20;
+        	if (ts.treble_gain > 20) ts.treble_gain = 20;
         	// display treble gain
         	UiDriverDisplayBass();
         	// set filter instance


### PR DESCRIPTION
The biquad cascade is now complete. It consists of four filters:
1.) notch filter with adjustable notch frequency, Q = 10, notch bandwidth about 10Hz
2.) peak EQ filter with adjustable peak frequency, Q = 10, bandwidth not yet known, who wants to measure it?
3.) lowShelf filter for bass audio response adjustment +-20dB adjustable, shelf midpoint frequency 200Hz
4.) highShelf filter for treble audio response adjustment +-20dB adjustable, sehlf midpoint frequency 6000Hz
Numbers 1.) and 2.) can be "switched in" by pressing G2 --> in the DSP chain 
Numbers 3.) and 4.) are always enabled (flat when adjusted to 0)
All frequencies adjustable with encoder2
Listen and enjoy!
WARNING: EXPERIMENTAL filters: when wearing headphones, adjust AFG (volume) to SMALL levels first in order to save the life of your ears!
Feedback welcome.
