### PR TITLE
Peak filter reworked / lowShelf/highShelf scaling improved

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -468,12 +468,14 @@ void audio_driver_set_rx_audio_filter(void)
     // the peak filter is in biquad 1 and works at the decimated sample rate FSdec
     if(ts.peak_enabled)
     {
-        // peak filter
+ /*       // peak filter
+  	  	 // the shape is fine, but we want 0dB gain! --> BPF, see below
         f0 = ts.peak_frequency;
-        Q = 15; //
+        Q = 10; //
         w0 = 2 * PI * f0 / FSdec;
         alpha = sin(w0) / (2 * Q);
-        A = 3; // 10^(10/40); 15dB gain
+        A = 1; // gain = 1
+        //        A = 3; // 10^(10/40); 15dB gain
 
         b0 = 1 + (alpha * A);
         b1 = - 2 * cos(w0);
@@ -481,6 +483,23 @@ void audio_driver_set_rx_audio_filter(void)
         a0 = 1 + (alpha / A);
         a1 = 2 * cos(w0); // already negated!
         a2 = (alpha/A) - 1; // already negated!
+*/
+        // test the BPF coefficients, because actually we want a "peak" filter without gain!
+        f0 = ts.peak_frequency;
+        Q = 20; //
+        w0 = 2 * PI * f0 / FSdec;
+        alpha = sin(w0) / (2 * Q);
+//        A = 1; // gain = 1
+        //        A = 3; // 10^(10/40); 15dB gain
+
+        b0 = alpha;
+        b1 = 0;
+        b2 = - alpha;
+        a0 = 1 + alpha;
+        a1 = 2 * cos(w0); // already negated!
+        a2 = alpha - 1; // already negated!
+
+
 
         // scaling the coefficients for gain
         b0 = b0/a0;


### PR DESCRIPTION
Peak filter is totally new and has no gain any more, so it can be used at the same volume setting as all other filters. Calculation of coeffcients now with BPF formulae instead of peak EQ formula.
Scaling for bass & treble filters improved, but still not perfect ;-)
