### PR TITLE
Peak Filter & AM path optimization

### DIFF
--- a/mchf-eclipse/.settings/language.settings.xml
+++ b/mchf-eclipse/.settings/language.settings.xml
@@ -5,7 +5,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="523115887035188341" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings Cross ARM" parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="282819359284089773" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings Cross ARM" parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>
@@ -16,7 +16,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="465052449034263675" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings Cross ARM" parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="224755921283165107" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings Cross ARM" parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>

--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -472,13 +472,13 @@ void audio_driver_set_rx_audio_filter(void)
        // peak filter
   	  	 // the shape is fine, but we want 0dB gain! --> BPF, see below
     	f0 = ts.peak_frequency;
-        Q = 10; //
+        Q = 15; //
         w0 = 2 * PI * f0 / FSdec;
         alpha = sin(w0) / (2 * Q);
         //A = 1; // gain = 1
         //        A = 3; // 10^(10/40); 15dB gain
-        A = 1.4125; // 10^(6/40); 6dB gain
-
+//        A = 1.4125; // 10^(6/40); 6dB gain
+        A = 2.0;
         b0 = 1 + (alpha * A);
         b1 = - 2 * cos(w0);
         b2 = 1 - (alpha * A);

--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -471,14 +471,15 @@ void audio_driver_set_rx_audio_filter(void)
     // the peak filter is in biquad 1 and works at the decimated sample rate FSdec
     if(ts.peak_enabled)
     {
- /*       // peak filter
+       // peak filter
   	  	 // the shape is fine, but we want 0dB gain! --> BPF, see below
         f0 = ts.peak_frequency;
         Q = 10; //
         w0 = 2 * PI * f0 / FSdec;
         alpha = sin(w0) / (2 * Q);
-        A = 1; // gain = 1
+        //A = 1; // gain = 1
         //        A = 3; // 10^(10/40); 15dB gain
+        A = 1.4125; // 10^(6/40); 6dB gain
 
         b0 = 1 + (alpha * A);
         b1 = - 2 * cos(w0);
@@ -486,10 +487,11 @@ void audio_driver_set_rx_audio_filter(void)
         a0 = 1 + (alpha / A);
         a1 = 2 * cos(w0); // already negated!
         a2 = (alpha/A) - 1; // already negated!
-*/
-        // test the BPF coefficients, because actually we want a "peak" filter without gain!
+
+/*        // test the BPF coefficients, because actually we want a "peak" filter without gain!
     	// Bandpass filter 0dB gain
     	// = CW peak filter = APF
+    	// this filter was tested: "should have more gain and less Q"
     	f0 = ts.peak_frequency;
         Q = 20; //
         w0 = 2 * PI * f0 / FSdec;
@@ -503,7 +505,7 @@ void audio_driver_set_rx_audio_filter(void)
         a0 = 1 + alpha;
         a1 = 2 * cos(w0); // already negated!
         a2 = alpha - 1; // already negated!
-
+*/
 
 
         // scaling the coefficients for gain

--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -419,13 +419,11 @@ void audio_driver_set_rx_audio_filter(void)
     //
     //
     float32_t FSdec; // we need the sampling rate in the decimated path for calculation of the coefficients
-    if (FilterPathInfo[ts.filter_path].sample_rate_dec == RX_DECIMATION_RATE_24KHZ)
-        FSdec = 24000;
-    if (FilterPathInfo[ts.filter_path].sample_rate_dec == RX_DECIMATION_RATE_12KHZ)
-        FSdec = 12000;
-
     float32_t FS = 48000; // we need this for the treble filter
-
+    if (FilterPathInfo[ts.filter_path].sample_rate_dec == RX_DECIMATION_RATE_24KHZ)
+        FSdec = 24000.0;
+    if (FilterPathInfo[ts.filter_path].sample_rate_dec == RX_DECIMATION_RATE_12KHZ)
+        FSdec = 12000.0;
     // the notch filter is in biquad 1 and works at the decimated sample rate FSdec
     float32_t f0 = ts.notch_frequency;
     float32_t Q = 10; // larger Q gives narrower notch
@@ -473,7 +471,7 @@ void audio_driver_set_rx_audio_filter(void)
     {
        // peak filter
   	  	 // the shape is fine, but we want 0dB gain! --> BPF, see below
-        f0 = ts.peak_frequency;
+    	f0 = ts.peak_frequency;
         Q = 10; //
         w0 = 2 * PI * f0 / FSdec;
         alpha = sin(w0) / (2 * Q);
@@ -538,7 +536,7 @@ void audio_driver_set_rx_audio_filter(void)
     //
     f0 = 250;
     w0 = 2 * PI * f0 / FSdec;
-    A = powf(10.0,(ts.bass_gain/40.0)); // gain ranges from -12 to 12
+    A = powf(10.0,(ts.bass_gain/40.0)); // gain ranges from -20 to 20
     S = 0.7; // shelf slope, 1 is maximum value
     alpha = sin(w0) / 2 * sqrt( (A + 1/A) * (1/S - 1) + 2 );
     float32_t cosw0 = cos(w0);
@@ -588,7 +586,7 @@ void audio_driver_set_rx_audio_filter(void)
     f0 = 4500;
     FS = 48000;
     w0 = 2 * PI * f0 / FS;
-    A = powf(10.0,(ts.treble_gain/40.0)); // gain ranges from -12 to 12
+    A = powf(10.0,(ts.treble_gain/40.0)); // gain ranges from -20 to 20
     S = 0.9; // shelf slope, 1 is maximum value
     alpha = sin(w0) / 2 * sqrt( (A + 1/A) * (1/S - 1) + 2 );
     cosw0 = cos(w0);

--- a/mchf-eclipse/drivers/audio/audio_driver.h
+++ b/mchf-eclipse/drivers/audio/audio_driver.h
@@ -227,8 +227,8 @@ typedef struct SMeter
 //
 #define	POST_AGC_GAIN_SCALING_DECIMATE_2	(POST_AGC_GAIN_SCALING_DECIMATE_4 * 0.6)	// Scales audio from decimation/interpolation-by-2 process
 //
-#define	AM_SCALING		2		// Amount of gain multiplication to apply to audio and AGC to make recovery equal to that of SSB
-#define	AM_AUDIO_SCALING	1.4	// Additional correction factor applied to audio demodulation to make amplitude equal to that of SSB demodulation
+#define	AM_SCALING		1.0		// was 2.0 // Amount of gain multiplication to apply to audio and AGC to make recovery equal to that of SSB
+#define	AM_AUDIO_SCALING	1.4	// was 1.4 // Additional correction factor applied to audio demodulation to make amplitude equal to that of SSB demodulation
 //
 #define	AGC_GAIN_CAL	155000//22440		// multiplier value (linear, not DB) to calibrate the S-Meter reading to the AGC value
 //

--- a/mchf-eclipse/drivers/audio/audio_driver.h
+++ b/mchf-eclipse/drivers/audio/audio_driver.h
@@ -188,6 +188,13 @@ typedef struct SMeter
 
 } SMeter;
 //
+//
+#define MAX_BASS 		 	20
+#define MIN_BASS 			-20
+#define MAX_TREBLE 			20
+#define MIN_TREBLE			-20
+#define MIN_PEAK_NOTCH_FREQ 200
+//
 // AGC Time constants
 // C. Turner, KA7OEI
 //

--- a/mchf-eclipse/drivers/audio/audio_filter.c
+++ b/mchf-eclipse/drivers/audio/audio_filter.c
@@ -588,13 +588,13 @@ const FilterPathDescriptor FilterPathInfo[AUDIO_FILTER_PATH_NUM] =
     },
 
     {
-        AUDIO_2P1KHZ, "AM", FILTER_MASK_AM, 1, Q_NUM_TAPS, iq_rx_am_2k3_coeffs, iq_rx_am_2k3_coeffs, &FirRxDecimate,
+        AUDIO_2P1KHZ, "AM", FILTER_MASK_AM, 1, Q_NUM_TAPS, iq_rx_am_3k6_coeffs, iq_rx_am_2k3_coeffs, &FirRxDecimate,
         RX_DECIMATION_RATE_12KHZ, &IIR_3k6_LPF,
         &FirRxInterpolate_4_5k, &IIR_aa_5k
     },
 
     {
-        AUDIO_2P3KHZ, "AM", FILTER_MASK_AM, 1, Q_NUM_TAPS, iq_rx_am_2k3_coeffs, iq_rx_am_2k3_coeffs, &FirRxDecimate,
+        AUDIO_2P3KHZ, "AM", FILTER_MASK_AM, 1, Q_NUM_TAPS, iq_rx_am_3k6_coeffs, iq_rx_am_2k3_coeffs, &FirRxDecimate,
         RX_DECIMATION_RATE_12KHZ, &IIR_4k2_LPF,
         &FirRxInterpolate_4_5k, &IIR_aa_5k
     },
@@ -630,7 +630,7 @@ const FilterPathDescriptor FilterPathInfo[AUDIO_FILTER_PATH_NUM] =
     },
 
     {
-        AUDIO_3P6KHZ, "AM", FILTER_MASK_AM, 1, Q_NUM_TAPS, iq_rx_am_3k6_coeffs, iq_rx_am_3k6_coeffs, &FirRxDecimateMinLPF,
+        AUDIO_3P6KHZ, "AM", FILTER_MASK_AM, 1, Q_NUM_TAPS, iq_rx_am_4k5_coeffs, iq_rx_am_3k6_coeffs, &FirRxDecimateMinLPF,
         RX_DECIMATION_RATE_24KHZ, &IIR_7k_LPF,
         &FirRxInterpolate10KHZ, NULL
     },

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -1917,6 +1917,8 @@ static void UiDriverProcessKeyboard()
             case BUTTON_G3_PRESSED:		 	// Press-and-hold button G3
             {
                 UiInitRxParms();			// generate "reference" for sidetone frequency
+                if(ts.AM_experiment) ts.AM_experiment = 0;
+                else ts.AM_experiment = 1;
                 /*				if (ts.notch_enabled) {
                 				    ts.notch_enabled = 0; // switch off notch filter
                 				    UiDriverChangeRfGain(1);

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -4481,6 +4481,12 @@ static bool UiDriverCheckFrequencyEncoder()
             {
                 enc_multiplier = 10;    // turning medium speed -> increase speed by 10
             }
+
+            if ((enc_speed_avg > 160) || (enc_speed_avg < (-160)))
+            {
+                enc_multiplier = 40;    //turning fast speed -> increase speed by 100
+            }
+
             if ((enc_speed_avg > 300) || (enc_speed_avg < (-300)))
             {
                 enc_multiplier = 100;    //turning fast speed -> increase speed by 100
@@ -4620,23 +4626,60 @@ static void UiDriverCheckEncoderOne()
 static void UiDriverCheckEncoderTwo()
 {
     //char 	temp[10];
-    int 	pot_diff;
+	float32_t MAX_FREQ;
+	int 	pot_diff;
+    if (FilterPathInfo[ts.filter_path].sample_rate_dec == RX_DECIMATION_RATE_24KHZ)
+        MAX_FREQ = 10000.0;
+    if (FilterPathInfo[ts.filter_path].sample_rate_dec == RX_DECIMATION_RATE_12KHZ)
+        MAX_FREQ = 5000.0;
 
     pot_diff = UiDriverEncoderRead(ENC2);
+// +++++++++++++++++++++++++++++++++++
+    int		enc_multiplier;
+    static float 	enc_speed_avg = 0.0;  //keeps the averaged encoder speed
+    int		delta_t, enc_speed;
 
-    if (pot_diff)
+    if (pot_diff != 0)
     {
+        delta_t = ts.audio_int_counter;  // get ticker difference since last enc. change
+        ts.audio_int_counter = 0;		 //reset tick counter
+
         UiDriver_LcdBlankingStartTimer();	// calculate/process LCD blanking timing
 
-        // I have taken the freedom to free encoder 2 from filter path
-        // in order to free it for the notch frequency adjustment
-        /*    if (filter_path_change) {
-              if(!ts.notch_enabled){
-            	AudioFilter_NextApplicableFilterPath(PATH_NEXT_BANDWIDTH | (pot_diff < 0?PATH_DOWN:PATH_UP),AudioFilter_GetFilterModeFromDemodMode(ts.dmod_mode),ts.filter_path);
-            	UiInitRxParms();
-              }
-            } else
-          */
+    if (delta_t > 300)
+    {
+        enc_speed_avg = 0;    //when leaving speedy turning set avg_speed to 0
+    }
+
+    enc_speed = div(4000,delta_t).quot*pot_diff;  // app. 4000 tics per second -> calc. enc. speed.
+
+    if (enc_speed > 500)
+    {
+        enc_speed = 500;    //limit calculated enc. speed
+    }
+    if (enc_speed < -500)
+    {
+        enc_speed = -500;
+    }
+
+    enc_speed_avg = 0.1*enc_speed + 0.9*enc_speed_avg; // averaging to smooth encoder speed
+
+    enc_multiplier = 1; //set standard speed
+
+        if ((enc_speed_avg > 80) || (enc_speed_avg < (-80)))
+        {
+            enc_multiplier = 20;    // turning medium speed -> increase speed by 10
+        }
+        if ((enc_speed_avg > 150) || (enc_speed_avg < (-150)))
+        {
+            enc_multiplier = 80;    //turning fast speed -> increase speed by 100
+        }
+        if ((enc_speed_avg > 300) || (enc_speed_avg < (-300)))
+        {
+            enc_multiplier = 200;    //turning fast speed -> increase speed by 100
+        }
+
+
         if(ts.menu_mode)
         {
             UiMenu_RenderChangeItem(pot_diff);
@@ -4737,14 +4780,14 @@ static void UiDriverCheckEncoderTwo()
                     {
                         if(pot_diff < 0)
                         {
-                            ts.notch_frequency = ts.notch_frequency - 10;
+                            ts.notch_frequency = ts.notch_frequency - 5 * enc_multiplier;
                         }
                         if(pot_diff > 0)
                         {
-                            ts.notch_frequency = ts.notch_frequency + 10;
+                            ts.notch_frequency = ts.notch_frequency + 5 * enc_multiplier;
                         }
-                        if (ts.notch_frequency < 200) ts.notch_frequency = 200;
-                        if (ts.notch_frequency > 12000) ts.notch_frequency = 12000;
+                        if(ts.notch_frequency > MAX_FREQ) ts.notch_frequency = MAX_FREQ;
+                        if(ts.notch_frequency < MIN_PEAK_NOTCH_FREQ) ts.notch_frequency = MIN_PEAK_NOTCH_FREQ;
                         // display notch frequency
                         UiDriverDisplayNotch(1);
                         // set notch filter instance
@@ -4762,8 +4805,8 @@ static void UiDriverCheckEncoderTwo()
                     {
                         ts.bass_gain = ts.bass_gain + 1;
                     }
-                    if (ts.bass_gain < -20) ts.bass_gain = -20;
-                    if (ts.bass_gain > 20) ts.bass_gain = 20;
+                    if (ts.bass_gain < MIN_BASS) ts.bass_gain = MIN_BASS;
+                    if (ts.bass_gain > MAX_BASS) ts.bass_gain = MAX_BASS;
                     // display bass gain
                     UiDriverDisplayBass();
                     // set filter instance
@@ -4780,8 +4823,8 @@ static void UiDriverCheckEncoderTwo()
                     {
                         ts.treble_gain = ts.treble_gain + 1;
                     }
-                    if (ts.treble_gain < -20) ts.treble_gain = -20;
-                    if (ts.treble_gain > 20) ts.treble_gain = 20;
+                    if (ts.treble_gain < MIN_TREBLE) ts.treble_gain = MIN_TREBLE;
+                    if (ts.treble_gain > MAX_TREBLE) ts.treble_gain = MAX_TREBLE;
                     // display treble gain
                     UiDriverDisplayBass();
                     // set filter instance
@@ -4794,14 +4837,14 @@ static void UiDriverCheckEncoderTwo()
                     {
                         if(pot_diff < 0)
                         {
-                            ts.peak_frequency = ts.peak_frequency - 10;
+                            ts.peak_frequency = ts.peak_frequency - 5 * enc_multiplier;
                         }
                         if(pot_diff > 0)
                         {
-                            ts.peak_frequency = ts.peak_frequency + 10;
+                            ts.peak_frequency = ts.peak_frequency + 5 * enc_multiplier;
                         }
-                        if (ts.peak_frequency < 200) ts.peak_frequency = 200;
-                        if (ts.peak_frequency > 12000) ts.peak_frequency = 12000;
+                        if(ts.peak_frequency > MAX_FREQ) ts.peak_frequency = MAX_FREQ;
+                        if(ts.peak_frequency < MIN_PEAK_NOTCH_FREQ) ts.peak_frequency = MIN_PEAK_NOTCH_FREQ;
                         // display peak frequency
                         UiDriverDisplayNotch(1);
                         // set notch filter instance
@@ -4860,13 +4903,13 @@ static void UiDriverCheckEncoderThree()
                     if(pot_diff < 0)
                     {
                         ts.rit_value -= 1;
-                        if(ts.rit_value < -50)
+                        if(ts.rit_value < MIN_RIT_VALUE)
                             ts.rit_value = MIN_RIT_VALUE;
                     }
                     else
                     {
                         ts.rit_value += 1;
-                        if(ts.rit_value > 50)
+                        if(ts.rit_value > MAX_RIT_VALUE)
                             ts.rit_value = MAX_RIT_VALUE;
                     }
 
@@ -4894,7 +4937,7 @@ static void UiDriverCheckEncoderThree()
                     else
                     {
                         ts.keyer_speed++;
-                        if(ts.keyer_speed > 48)
+                        if(ts.keyer_speed > MAX_KEYER_SPEED)
                             ts.keyer_speed = MAX_KEYER_SPEED;
                     }
 

--- a/mchf-eclipse/hardware/mchf_board.h
+++ b/mchf-eclipse/hardware/mchf_board.h
@@ -1124,6 +1124,7 @@ typedef struct TransceiverState
     ulong	peak_frequency;			// frequency of the manual peak filter
     int		bass_gain;				// gain of the low shelf EQ filter
     int		treble_gain;			// gain of the high shelf EQ filter
+    bool	AM_experiment;			// for AM demodulation experiments, not for "public" use
 
     uint8_t display_type;           // existence/identification of display type
     uint32_t audio_int_counter;		// used for encoder timing - test DL2FW

--- a/mchf-eclipse/main.c
+++ b/mchf-eclipse/main.c
@@ -532,6 +532,7 @@ void TransceiverStateInit(void)
     ts.peak_frequency = 750;				// peak start frequency
     ts.bass_gain = 2;						// gain of the low shelf EQ filter
     ts.treble_gain = 0;						// gain of the high shelf EQ filter
+    ts.AM_experiment = 0;					// for AM demodulation experiments, not for "public" use
 }
 
 //*----------------------------------------------------------------------------


### PR DESCRIPTION
Peak Filter now: 12dB gain, Q = 15
Added dynamic tuning for notch & peak frequency adjustment & now in 5Hz-steps.
Added another step for dynamic tuning of frequency.
RX path is now muted during filter adjustments, coefficient calculations and filter initializations: does reduce pops a little little bit, but not overly effective.
AM-Filter-Path: now takes into account, that the 2k3 FIR filter has in fact a cutoff frequency of 1.8kHz!!
AM demodulator now uses arm_sqrt_f32 instead of first interleaving and then using arm_cmplx_mag, possibly a performance advantage ?? probably, but dont know . . .
