### PR TITLE
Fix for issue #330 No TX Power close to the band borders

### DIFF
--- a/mchf-eclipse/drivers/ui/oscillator/ui_si570.c
+++ b/mchf-eclipse/drivers/ui/oscillator/ui_si570.c
@@ -383,6 +383,10 @@ static Si570_ResultCodes ui_si570_change_frequency(float new_freq, uchar test)
     }
     else
     {
+        uint8_t n1_regVal = n1 - 1;
+        uint8_t hsdiv_regVal = hsdiv - 4;
+        // the written value is n1 - 1, hsdiv -4 according to the datasheet
+
         // New RFREQ calculation
         os.rfreq = ((long double)new_freq * (long double)(n1 * hsdiv)) / os.fxtal;
         is_large = ui_si570_is_large_change();
@@ -401,20 +405,10 @@ static Si570_ResultCodes ui_si570_change_frequency(float new_freq, uchar test)
                 os.regs[i] = 0;
             }
 
-            hsdiv = hsdiv - 4;
-            os.regs[0] = (hsdiv << 5);
+            os.regs[0] = (hsdiv_regVal << 5);
 
-            if(n1 == 1)
-            {
-                n1 = 0;
-            }
-            else if((n1 & 1) == 0)
-            {
-                n1 = n1 - 1;
-            }
-
-            os.regs[0] = ui_si570_setbits(os.regs[0], 0xE0, (n1 >> 2));
-            os.regs[1] = (n1 & 3) << 6;
+            os.regs[0] = ui_si570_setbits(os.regs[0], 0xE0, (n1_regVal >> 2));
+            os.regs[1] = (n1_regVal & 3) << 6;
 
 #ifdef LOWER_PRECISION
             os.regs[1] = os.regs[1] | (final_rfreq_long >> 30);

--- a/mchf-eclipse/drivers/ui/ui_configuration.c
+++ b/mchf-eclipse/drivers/ui/ui_configuration.c
@@ -1010,6 +1010,8 @@ uint16_t UiConfiguration_SaveEepromValues(void)
             // Save decode mode
             vfo[is_vfo_b()?VFO_B:VFO_A].band[ts.band].decod_mode = ts.dmod_mode;
             // use the "real" demod mode, instead of the possibly changed one (FM gets USB during save)
+            // FIXME: Either we use demod_mode also here or we remove the special FM handling and use ts.dmod_mode everywehre
+            // FIXME: Right now it is inconsistent and should be left like this.
 
             // TODO: move value to a static variable, so that it can be read/written with standard approach
             UiWriteSettingEEPROM_UInt16(EEPROM_BAND_MODE,

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -1305,7 +1305,11 @@ void RadioManagement_SetBandPowerFactor(uchar band)
 
 
 
-
+/*
+ * @brief returns the band according to the given frequency
+ * @param freq  frequency to get band for. Unit is Hertz. This value is used without any further adjustments and should be the intended RX/TX frequency and NOT the IQ center frequency
+ *
+ */
 uint8_t RadioManagement_GetBand(ulong freq)
 {
     static uint8_t band_scan_old = 99;
@@ -1313,7 +1317,6 @@ uint8_t RadioManagement_GetBand(ulong freq)
 
     band_scan = 0;
 
-    freq -= audio_driver_xlate_freq();
     freq *= TUNE_MULT;
 
     // first try the last band, and see if it is an match


### PR DESCRIPTION
Issue was caused by using IQ center frequency instead of translated frequency ("the real one") for band calculation.

Some other minor cleanups are included, no functional change here.
