### PR TITLE
dBm display first calibration

### DIFF
--- a/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
@@ -1853,10 +1853,10 @@ static void calculate_dBm(void)
           {
           sum_db = sum_db + sd.FFT_Samples[c];
           }
-        // lowpass IIR filter !
-//        dbm = 0.001 * dbm + 0.999 * dbm_old;
         // these values have to be carefully empirically adjusted
-        dbm = 50.0 * log10 (sum_db/(float32_t)(((int)Ubin-(int)Lbin) * bin_BW)) - 190.0;
+        // these preliminary values have been calibrated with Perseus SDR
+        dbm = 22.0 * log10 (sum_db/(float32_t)(((int)Ubin-(int)Lbin) * bin_BW)) - 127.0;
+        // lowpass IIR filter !
         dbm = 0.1 * dbm + 0.9 * dbm_old;
         dbm_old = dbm;
         //            sum_db = log10 (sum_db);

--- a/mchf-eclipse/main.c
+++ b/mchf-eclipse/main.c
@@ -441,7 +441,7 @@ void TransceiverStateInit(void)
     ts.bass_gain = 2;						// gain of the low shelf EQ filter
     ts.treble_gain = 0;						// gain of the high shelf EQ filter
     ts.AM_experiment = 0;					// for AM demodulation experiments, not for "public" use
-    ts.dBm_Hz_Test = 0;						// for testing only
+    ts.dBm_Hz_Test = 1;						// for testing only
 	ts.dBm_count = 0;						// timer start
 
 // development setting for DF8OE


### PR DESCRIPTION
dBm display is now usable. This is an absolute measure of the signal power level.
It displays the signal power level inside the filter passband and relates that signal power to the filter bandwidth, so that every measurement is comparable irrespective of the chosen filter bandwidth.
Signal power level is displayed in dBm/Hz and has been calibrated with the help of a Perseus SDR, which has an accuracy of +-0.5dB.
Comparison has been made with measurements of the implemented dBm/Hz display and has proved to be accurate to +-2dBm/Hz. However, more measurements at different signal levels and at different frequencies have to be made in order to support or reject this.
More information will be written in the Wiki soon.
