### PR TITLE
bugfix amplitude adjustment TX

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -2444,9 +2444,6 @@ static void audio_tx_compressor(int16_t size, float gain_scaling)
 void audio_tx_final_iq_processing(float scaling, bool swap, int16_t* dst, int16_t size)
 {
     int16_t i;
-    // this is the IQ gain / amplitude adjustment
-    arm_scale_f32((float32_t*)ads.i_buffer, (float32_t)(ts.tx_power_factor * ts.tx_adj_gain_var_i * scaling), (float32_t*)ads.i_buffer, size/2);
-    arm_scale_f32((float32_t*)ads.q_buffer, (float32_t)(ts.tx_power_factor * ts.tx_adj_gain_var_q * scaling), (float32_t*)ads.q_buffer, size/2);
     // this is the IQ phase adjustment
     AudioDriver_IQPhaseAdjust(ts.dmod_mode,ts.txrx_mode,size);
 
@@ -2470,6 +2467,9 @@ void audio_tx_final_iq_processing(float scaling, bool swap, int16_t* dst, int16_
             *dst++ = (int16_t)ads.i_buffer[i];	// save right channel
         }
     }
+    // this is the IQ gain / amplitude adjustment
+    arm_scale_f32((float32_t*)ads.i_buffer, (float32_t)(ts.tx_power_factor * ts.tx_adj_gain_var_i * scaling), (float32_t*)ads.i_buffer, size/2);
+    arm_scale_f32((float32_t*)ads.q_buffer, (float32_t)(ts.tx_power_factor * ts.tx_adj_gain_var_q * scaling), (float32_t*)ads.q_buffer, size/2);
 }
 //*----------------------------------------------------------------------------
 //* Function Name       : audio_tx_processor
@@ -2511,7 +2511,7 @@ static void audio_tx_processor(int16_t *src, int16_t *dst, int16_t size)
         if (ts.tune)
         {
             softdds_runf((float32_t *)ads.i_buffer, (float32_t *)ads.q_buffer,size/2);      // generate tone/modulation for TUNE
-            // Equalize based on band and simultaneously apply I/Q gain adjustments
+            // Equalize based on band and simultaneously apply I/Q gain & phase adjustments
             audio_tx_final_iq_processing(1.0, ts.cw_lsb, dst, size);
         }
         else
@@ -2528,7 +2528,9 @@ static void audio_tx_processor(int16_t *src, int16_t *dst, int16_t size)
             }
             else
             {
-                // Equalize based on band and simultaneously apply I/Q gain adjustments
+                // Equalize based on band and simultaneously apply I/Q gain & phase adjustments
+            	// Wouldn´t it be necessary to include IF conversion here? DD4WH June 16th, 2016
+            	// Answer: NO, in CW that is done be changing the Si570 frequency during TX/RX switching . . .
                 audio_tx_final_iq_processing(1.0, ts.cw_lsb, dst, size);
             }
         }
@@ -2621,6 +2623,8 @@ static void audio_tx_processor(int16_t *src, int16_t *dst, int16_t size)
         audio_tx_compressor(size, SSB_ALC_GAIN_CORRECTION);	// Do the TX ALC and speech compression/processing
 
         if(ts.iq_freq_mode)	 		// is transmit frequency conversion to be done?
+        	// USB && (-6kHz || -12kHz) --> false, else true
+        	// LSB && (+6kHz || +12kHz) --> false, else true
         {
 
             bool swap = ts.dmod_mode == DEMOD_LSB && (ts.iq_freq_mode == FREQ_IQ_CONV_M6KHZ || ts.iq_freq_mode == FREQ_IQ_CONV_M12KHZ);
@@ -2628,8 +2632,7 @@ static void audio_tx_processor(int16_t *src, int16_t *dst, int16_t size)
             audio_rx_freq_conv(size, swap);
         }
         //
-        // Equalize based on band and simultaneously apply I/Q gain adjustments
-        //
+        // Equalize based on band and simultaneously apply I/Q gain & phase adjustments
         audio_tx_final_iq_processing(SSB_GAIN_COMP, ts.dmod_mode == DEMOD_LSB, dst, size);
     }
     // -----------------------------

--- a/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
@@ -427,8 +427,6 @@ static uint16_t UiSpectrum_Draw_GetCenterLineX()
 
 void    UiSpectrumDrawSpectrum(q15_t *fft_old, q15_t *fft_new, const ushort color_old, const ushort color_new, const ushort shift)
 {
-//	q15_t * fft_old_begin = fft_old;
-//	q15_t * fft_new_begin = fft_new;
 
     int spec_height = SPECTRUM_HEIGHT; //x
     int spec_start_y = SPECTRUM_START_Y;
@@ -484,6 +482,7 @@ void    UiSpectrumDrawSpectrum(q15_t *fft_old, q15_t *fft_new, const ushort colo
         for(x = (SPECTRUM_START_X + sh + 0); x < (POS_SPECTRUM_IND_X + SPECTRUM_WIDTH/2 + sh); x++)
         {
             if (ts.flags1 & FLAGS1_SCOPE_LIGHT_ENABLE)
+
             {
                 if ((idx > 1) && (idx < 254))
                 {
@@ -560,7 +559,8 @@ void    UiSpectrumDrawSpectrum(q15_t *fft_old, q15_t *fft_new, const ushort colo
                      UiLcdHy28_DrawStraightLine(x,y1_new,y1_new_minus - y1_new,LCD_DIR_VERTICAL,color_new);
 
             	 }
-            	 else {
+            	 else
+            	 {
             		  UiLcdHy28_DrawColorPoint (x, y1_new, color_new);
             	 }
 


### PR DESCRIPTION
possibly this fixes the problem that occured when adjusting amplitude for TX: adjustment in LSB was equal to that in USB, but with different sign (e.g. LSB: -15 and USB: +15). 
Hopefully this fixes it.
