### PR TITLE
Repurposed TX->RX Delay:

### DIFF
--- a/mchf-eclipse/drivers/audio/cw/cw_gen.c
+++ b/mchf-eclipse/drivers/audio/cw/cw_gen.c
@@ -47,6 +47,12 @@ void cw_set_speed()
 {
     ps.dit_time         = 1650/ts.keyer_speed;      //100;
 }
+
+void cw_gen_set_break_time()
+{
+    ps.break_timer = ts.cw_rx_delay*50;      // break timer value
+}
+
 void cw_gen_init(void)
 {
 
@@ -56,7 +62,7 @@ void cw_gen_init(void)
     {
         // do not change if currently in CW transmit
         ps.cw_state         = CW_IDLE;
-        ps.break_timer = CW_BREAK;      // break timer value
+        cw_gen_set_break_time();
         ps.key_timer		= 0;
     }
 
@@ -361,8 +367,8 @@ ulong cw_gen_process_iamb(float32_t *i_buffer,float32_t *q_buffer,ulong size)
         }
         else
         {
-            ps.break_timer = CW_BREAK;      // break timer value
             ps.cw_state  = CW_IDLE;
+            cw_gen_set_break_time();
         }
     }
     break;
@@ -426,8 +432,8 @@ ulong cw_gen_process_iamb(float32_t *i_buffer,float32_t *q_buffer,ulong size)
             else
             {
                 ps.port_state &= ~(CW_DAH_L);
-                ps.break_timer = CW_BREAK;      // break timer value
                 ps.cw_state    = CW_IDLE;
+                cw_gen_set_break_time();
             }
         }
     }
@@ -458,7 +464,7 @@ void cw_gen_dah_IRQ(void)
         {
             ps.sm_tbl_ptr  = 0;				// smooth table start
             ps.key_timer   = 24;			// smooth steps * 2
-            ps.break_timer = CW_BREAK;		// break timer value
+            cw_gen_set_break_time();
         }
     }
 }

--- a/mchf-eclipse/drivers/audio/cw/cw_gen.h
+++ b/mchf-eclipse/drivers/audio/cw/cw_gen.h
@@ -18,9 +18,6 @@
 #ifndef __CW_GEN_H
 #define __UI_GEN_H
 
-// Break timeout on straight key
-#define CW_BREAK			800
-
 // States
 #define	CW_IDLE				0
 #define	CW_DIT_CHECK		1

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -4044,6 +4044,7 @@ static void UiDriverTimeScheduler()
             // TR->RX audio un-muting timer and Audio/AGC De-Glitching handler
             if(ts.audio_unmute)	 						// are we returning from TX with muted audio?
             {
+#if 0
                 if(ts.dmod_mode == DEMOD_CW)	 		// yes - was it CW mode?
                 {
                     ts.unmute_delay_count = (ulong)ts.cw_rx_delay + 1;	// yes - get CW TX->RX delay timing
@@ -4051,6 +4052,7 @@ static void UiDriverTimeScheduler()
                     ts.unmute_delay_count *= 40;	// rescale value and limit minimum delay value
                 }
                 else  								// SSB mode
+#endif
                 {
                     ts.unmute_delay_count = SSB_RX_DELAY;	// set time delay in SSB mode
                     ts.buffer_clear = 1;


### PR DESCRIPTION
It now controls the CW Break Time for both straight and iambic mode.
Previously straight mode had a fixed break time, iambic had none.
Now both have the same break time and it can be configured.
The TX->RX Delay itself is still there, and uses the same fixed time
as the SSB TX->RX. If this is not a good value, we can easily
use a different value in CW mode.
