### PR TITLE
Closing race condition: Sometimes dial frequency remains same

### DIFF
--- a/mchf-eclipse/drivers/ui/encoder/ui_rotary.h
+++ b/mchf-eclipse/drivers/ui/encoder/ui_rotary.h
@@ -31,8 +31,8 @@ typedef struct DialFrequency
     // pot values
     //
     // SI570 actual frequency
-    ulong	tune_old;			// previous value
-    ulong	tune_new;			// most current value
+    ulong	tune_old;			// current value
+    ulong	tune_new;			// requested value
 
     // Current tuning step
     ulong	tuning_step;		// selected step by user

--- a/mchf-eclipse/hardware/mchf_board.h
+++ b/mchf-eclipse/hardware/mchf_board.h
@@ -852,7 +852,7 @@ typedef struct TransceiverState
 
     // Frequency synthesizer
     ulong	tune_freq;			// main synthesizer frequency
-    // ulong	tune_freq_old;		// used to detect change of main synthesizer frequency
+    ulong	tune_freq_req;		// used to detect change of main synthesizer frequency
 
     // Transceiver calibration mode flag
     //uchar	calib_mode;


### PR DESCRIPTION
but tune frequency changes. In this case, if the change happens to fast,
we cannot not execute the change immediately so we need to know
that we have to retry the tuning ASAP
