### PR TITLE
optimized AGC for dbm display with two time constants & S-Meter now with option to be based on dbm calculation

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.h
+++ b/mchf-eclipse/drivers/audio/audio_driver.h
@@ -183,6 +183,8 @@ typedef struct SMeter
     ulong	s_count;
     float	gain_calc;
     int		curr_max;
+    float32_t dbm;
+    float32_t dbmhz;
 
 } SMeter;
 //

--- a/mchf-eclipse/drivers/ui/ui_configuration.c
+++ b/mchf-eclipse/drivers/ui/ui_configuration.c
@@ -536,6 +536,7 @@ const ConfigEntryDescriptor ConfigEntryInfo[] =
     { ConfigEntry_UInt8, EEPROM_CAT_XLAT,&ts.xlat,1,0,1},
     { ConfigEntry_UInt32_16, EEPROM_MANUAL_NOTCH,&ts.notch_frequency,800,200,5000},
     { ConfigEntry_UInt32_16, EEPROM_MANUAL_PEAK,&ts.peak_frequency,750,200,5000},
+    { ConfigEntry_UInt8, EEPROM_DISPLAY_DBM,&ts.display_dbm,2,0,6},
     UI_C_EEPROM_BAND_5W_PF( 0,80,m)
     UI_C_EEPROM_BAND_5W_PF(1,60,m)
     UI_C_EEPROM_BAND_5W_PF(2,40,m)

--- a/mchf-eclipse/drivers/ui/ui_configuration.h
+++ b/mchf-eclipse/drivers/ui/ui_configuration.h
@@ -501,7 +501,8 @@ uint16_t    UiConfiguration_SaveEepromValues(void);
 #define EEPROM_MANUAL_NOTCH				356
 #define EEPROM_MANUAL_PEAK				357
 #define EEPROM_RX_IQ_AM_PHASE_BALANCE   358     // IQ Gain balance for AM reception
-#define EEPROM_FIRST_UNUSED 			359  // change this if new value ids are introduced
+#define EEPROM_DISPLAY_DBM				359		// dbm display & S-Meter configuration
+#define EEPROM_FIRST_UNUSED 			360  // change this if new value ids are introduced
 
 // Note: EEPROM addresses up to 383 are currently defined. If this value is passed you
 // need to modify virtual EEPROM routines otherwise system may crash

--- a/mchf-eclipse/drivers/ui/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/ui_menu.c
@@ -551,7 +551,7 @@ const MenuDescriptor displayGroup[] =
     { MENU_DISPLAY, MENU_ITEM, MENU_WFALL_OFFSET,"112","Wfall Brightness"},
     { MENU_DISPLAY, MENU_ITEM, MENU_WFALL_CONTRAST,"113","Wfall Contrast"},
     { MENU_DISPLAY, MENU_ITEM, MENU_WFALL_NOSIG_ADJUST,"116","Wfall NoSig Adj."},
-    { MENU_DISPLAY, MENU_ITEM, MENU_DBM_DISPLAY,"120","dBm display"},
+    { MENU_DISPLAY, MENU_ITEM, MENU_DBM_DISPLAY,"120","dBm displ./S-Meter"},
 	{ MENU_DISPLAY, MENU_STOP, 0, "   " , NULL }
 };
 
@@ -2558,23 +2558,33 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode, int pos)
     case    MENU_DBM_DISPLAY:
         fchange = UiDriverMenuItemChangeUInt8(var, mode, &ts.display_dbm,
                                               0,
-                                              2,
+                                              6,
                                               0,
                                               1
                                              );
 
-
-//    	UiDriverMenuItemChangeDisableOnOff(var, mode, &ts.display_dbm,0,options,&clr);
        switch(ts.display_dbm)
         {
         case 1:		//
-            txt_ptr = "    dBm";		//
+            txt_ptr = "   dBm / os";		// dbm display and old school S-Meter
             break;
         case 2:	//
-            txt_ptr = " dBm/Hz";		//
+            txt_ptr = " dBmHz / os";		// dbm/Hz display and old school S-Meter
+            break;
+        case 3:	//
+            txt_ptr = "  dBm / dBm";		// dbm display and dbm S-Meter
+            break;
+        case 4:	//
+            txt_ptr = " dBmHz /dBm";		// dbm/Hz display and dbm S-Meter
+            break;
+        case 5:	//
+            txt_ptr = "dBmHz/dBmHz";		// dbm/Hz display and dbm/Hz S-Meter
+            break;
+        case 6:	//
+            txt_ptr = "  OFF / dBm";		// dbm display OFF and dbm S-Meter
             break;
         default:
-        txt_ptr =  "  OFF";		//
+        txt_ptr =  "   OFF / os";		// dbm display off and oldschool S-Meter
         	break;
         }
         break;


### PR DESCRIPTION
1.) dbm display now reacts faster to an increase in signal level (attack: time constant 10ms) and reacts slower to a decrease in signal level (decay: time constant 500ms) 
idea taken from Wheatley 2011: CuteSDR Technical Manual page 45
2.) S-Meter can now be based on dBm calculation or can be the oldschool S-Meter with the same reaction as usual.
3.) User can choose between these options in the display menu:
dbm display OFF / S-Meter old school (= os)
dbm display ON / S-Meter old school (= os)
dbm/Hz display / S-Meter old school (= os) [DEFAULT]
dbm display / S-Meter based on dbm
dbm/Hz display / S-Meter based on dbm
dbm/Hz display / S-Meter based on dbm/Hz
dbm display OFF / S-Meter based on dbm
4.) User choice is stored in EEPROM
