### PR TITLE
Improved responsiveness of buttons and knobs. Added Minimal Event Profiling

### DIFF
--- a/mchf-eclipse/Makefile
+++ b/mchf-eclipse/Makefile
@@ -193,6 +193,7 @@ SRC =  \
     misc/v_eprom/eeprom.c  \
     misc/config_storage.c  \
     misc/serial_eeprom.c  \
+    misc/profiling.c  \
     \
     stdio/printf.c  \
     syscalls/syscalls.c  \

--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -14,6 +14,7 @@
 
 // Common
 #include "mchf_board.h"
+#include "profiling.h"
 
 #include <stdio.h>
 
@@ -3065,10 +3066,13 @@ void I2S_RX_CallBack(int16_t *src, int16_t *dst, int16_t size, uint16_t ht)
     static bool to_rx = 0;	// used as a flag to clear the RX buffer
     static bool to_tx = 0;	// used as a flag to clear the TX buffer
     static ulong tcount = 0;
-    
-    if(ts.show_tp_coordinates)
-  	  mchf_board_green_led(1);
 
+    profileEvent(EnterAudioInterrupt);
+
+    if(ts.show_tp_coordinates)
+    {
+  	  mchf_board_green_led(1);
+    }
     if((ts.txrx_mode == TRX_MODE_RX))
     {
         if((to_rx) || (ts.buffer_clear))	 	// the first time back to RX, clear the buffers to reduce the "crash"

--- a/mchf-eclipse/firmware.coproj
+++ b/mchf-eclipse/firmware.coproj
@@ -376,6 +376,8 @@
     <File name="misc/config_storage.c" path="misc/config_storage.c" type="1"/>
     <File name="misc/serial_eeprom.h" path="misc/serial_eeprom.h" type="1"/>
     <File name="misc/serial_eeprom.c" path="misc/serial_eeprom.c" type="1"/>
+    <File name="misc/profiling.h" path="misc/profiling.h" type="1"/>
+    <File name="misc/profiling.c" path="misc/profiling.c" type="1"/>
     <File name="misc/v_eprom/eeprom.h" path="misc/v_eprom/eeprom.h" type="1"/>
     <File name="drivers/ui/ui_configuration.h" path="drivers/ui/ui_configuration.h" type="1"/>
     <File name="drivers/ui/oscillator/ui_si570.h" path="drivers/ui/oscillator/ui_si570.h" type="1"/>

--- a/mchf-eclipse/misc/profiling.c
+++ b/mchf-eclipse/misc/profiling.c
@@ -1,0 +1,24 @@
+/*  -*-  mode: c; tab-width: 4; indent-tabs-mode: t; c-basic-offset: 4; coding: utf-8  -*-  */
+/************************************************************************************
+ **                                                                                 **
+ **                               mcHF QRP Transceiver                              **
+ **                             K Atanassov - M0NKA 2014                            **
+ **                                                                                 **
+ **---------------------------------------------------------------------------------**
+ **                                                                                 **
+ **  File name:                                                                     **
+ **  Description:                                                                   **
+ **  Last Modified:                                                                 **
+ **  Licence:       CC BY-NC-SA 3.0                                                **
+ ************************************************************************************/
+
+// Common
+#include "mchf_board.h"
+#include "profiling.h"
+
+/*
+ * In order to read the counters here, you'll need to connect
+ * using a real-time debugger, pause execution and read values.
+ * Not a big deal with ST-Link and Eclipse or gdb.
+ */
+EventProfile_t eventProfile;

--- a/mchf-eclipse/misc/profiling.h
+++ b/mchf-eclipse/misc/profiling.h
@@ -1,0 +1,44 @@
+/*  -*-  mode: c; tab-width: 4; indent-tabs-mode: t; c-basic-offset: 4; coding: utf-8  -*-  */
+/************************************************************************************
+**                                                                                 **
+**                               mcHF QRP Transceiver                              **
+**                             K Atanassov - M0NKA 2014                            **
+**                                                                                 **
+**---------------------------------------------------------------------------------**
+**                                                                                 **
+**  File name:                                                                     **
+**  Description: Simple Timing Profiler                                                                   **
+**  Last Modified:                                                                 **
+**  Licence:        CC BY-NC-SA 3.0                                                **
+************************************************************************************/
+
+#ifndef __PROFILING_H
+#define __PROFILING_H
+
+typedef enum {
+    EnterAudioInterrupt = 0,
+    EnterLO,
+    EnterPTT,
+    EnterDriverThread,
+    EnterSMeter,
+    EnterVoltage,
+    EventProfileMax
+} ProfiledEventNames;
+
+typedef struct {
+    uint32_t count[EventProfileMax];
+} EventProfile_t;
+
+extern EventProfile_t eventProfile;
+
+#define PROFILE_EVENTS
+
+inline void profileEvent(ProfiledEventNames pe) {
+#ifdef PROFILE_EVENTS
+    if (pe<EventProfileMax && pe >= 0) {
+        eventProfile.count[pe]++;
+    }
+#endif
+}
+
+#endif


### PR DESCRIPTION
Response time is now no longer depending
on CPU load (e.g. DSP, waterfall/scope settings).

What was done: Modified main loop to handle buttons and knobs at
a fixed rate of 100 Hz. Less important task still have variable
timing based on the time it takes to do the graphics (Waterfall/Scope).

Added some simple profiling support, which basically counts events.
If disabled, zero overhead is present. If enabled, next to zero overhead is present.
To read the data, use the real-time debugger (such as ST-LINK).
