### PR TITLE
Shrunk CCM memory usage of waterfall display by several kBytes

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.h
+++ b/mchf-eclipse/drivers/audio/audio_driver.h
@@ -565,7 +565,7 @@ typedef struct SnapCarrier
 
 } SnapCarrier;
 
-__IO SnapCarrier sc;
+extern SnapCarrier sc;
 
 
 #endif

--- a/mchf-eclipse/drivers/ui/lcd/ui_spectrum.h
+++ b/mchf-eclipse/drivers/ui/lcd/ui_spectrum.h
@@ -171,7 +171,7 @@ typedef struct SpectrumDisplay
 
     ushort  waterfall_colours[NUMBER_WATERFALL_COLOURS+1];  // palette of colors for waterfall data
     float32_t   wfall_temp[FFT_IQ_BUFF_LEN/2];                  // temporary holder for rescaling screen
-    ushort  waterfall[SPECTRUM_HEIGHT + WFALL_MEDIUM_ADDITIONAL +16][FFT_IQ_BUFF_LEN/2];    // circular buffer used for storing waterfall data - remember to increase this if the waterfall is made larger!
+    uint8_t  waterfall[SPECTRUM_HEIGHT + WFALL_MEDIUM_ADDITIONAL +16][FFT_IQ_BUFF_LEN/2];    // circular buffer used for storing waterfall data - remember to increase this if the waterfall is made larger!
 
     uchar   wfall_line;                                     // pointer to current line of waterfall data
     uchar   wfall_size;                 // vertical size of the waterfall

--- a/mchf-eclipse/drivers/ui/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/ui_menu.c
@@ -707,6 +707,7 @@ enum MENU_INFO_ITEM
 {
     INFO_EEPROM,
     INFO_DISPLAY,
+    INFO_DISPLAY_CTRL,
     INFO_SI570,
     INFO_TP,
     INFO_RFMOD,
@@ -719,6 +720,7 @@ enum MENU_INFO_ITEM
 const MenuDescriptor infoGroup[] =
 {
     { MENU_HWINFO, MENU_INFO, INFO_DISPLAY,"I01","Display"},
+    { MENU_HWINFO, MENU_INFO, INFO_DISPLAY_CTRL,"I02","Disp. Controller"},
     { MENU_HWINFO, MENU_INFO, INFO_SI570,"I02","SI570"},
     { MENU_HWINFO, MENU_INFO, INFO_EEPROM,"I03","EEPROM"},
     { MENU_HWINFO, MENU_INFO, INFO_TP,"I04","Touchscreen"},
@@ -1303,30 +1305,34 @@ bool UiMenu_DisplayMoveSlotsForward(int16_t change)
 
 bool init_done = false;
 
+static const char* display_types[] = {
+     " ",
+     "HY28A SPI",
+     "HY28B SPI",
+     "HY28A/B Para."
+ };
+
 static void UiMenu_UpdateHWInfoLines(uchar index, uchar mode, int pos)
 {
-    char out[32], outa[10];
+    char out[32];
     const char* outs = NULL;
     uint32_t m_clr = White;
 
-    /*
-       static const char* display_types[] = {
-           " ",
-           "HY28A SPI Mode",
-           "HY28B SPI Mode",
-           "HY28A/B Para."
-       };
-    */
     switch (index)
     {
     case INFO_DISPLAY:
-        if(ts.display_type == 3)
-            sprintf(outa,"ILI%04x parallel",ts.DeviceCode);
-        else
-            sprintf(outa,"ILI%04x SPI",ts.DeviceCode);
-        outs = outa;
-//     outs = display_types[ts.display_type];
+    {
+        outs = display_types[ts.display_type];
         break;
+    }
+    case INFO_DISPLAY_CTRL:
+    {
+        // const char* disp_com = ts.display_type==3?"parallel":"SPI";
+        // snprintf(out,32,"ILI%04x %s",ts.DeviceCode,disp_com);
+        snprintf(out,32,"ILI%04x",ts.DeviceCode);
+        outs = out;
+        break;
+    }
     case INFO_SI570:
     {
         float suf = Si570_GetStartupFrequency();
@@ -1391,7 +1397,7 @@ static void UiMenu_UpdateHWInfoLines(uchar index, uchar mode, int pos)
             outs = "unknown";
             break;
         }
-        sprintf(out,"Serial EEPROM: %s",outs);
+        snprintf(out,32,"Serial EEPROM: %s",outs);
         switch(ts.ser_eeprom_in_use)
         {
         case SER_EEPROM_IN_USE_I2C:


### PR DESCRIPTION
 by using single byte to represent 65 values instead of 2 bytes (uint16_t).

This made it possible to move some other large data structures to CCM (the "extra" 64k RAM), which
in turn frees several kiloBytes of memory in the "main memory" (128k RAM) e.g. for use
with malloc/free (FreeDV) and/or display speed improvements or anything else. Currently about 32k of "main memory" are being used (see mchf-eclipse.map).
Due to recent change malloc/free is not entierly free of risk to use (you'll need to malloc 5k first thing you do, and never free that memory again). This will be fixed in future. 

I did change a tiny piece of code for the sake of make it look nicer (too me) and save a few lines and bytes (ui_spectrum.c). Changes in audio_driver.c result from moving several logical coupled data structures into a single one, which in turn was used to place the data in the CCM. 
