### PR TITLE
Securing CAT frame sizes to 5 byte packets

### DIFF
--- a/mchf-eclipse/drivers/cat/usb/usbd_cdc_vcp.c
+++ b/mchf-eclipse/drivers/cat/usb/usbd_cdc_vcp.c
@@ -226,7 +226,7 @@ uint16_t VCP_DataTx (uint8_t* Buf, uint32_t Len)
   *
   * @param  Buf: Buffer of data to be received
   * @param  Len: Number of data received (in bytes)
-  * @retval Result of the opeartion: USBD_OK if all operations are OK else VCP_FAIL
+  * @retval Result of the operation: USBD_OK if all operations are OK else VCP_FAIL
   */
 uint16_t VCP_DataRx (uint8_t* Buf, uint32_t Len)
 {

--- a/mchf-eclipse/drivers/cat/usb/usbd_conf.h
+++ b/mchf-eclipse/drivers/cat/usb/usbd_conf.h
@@ -62,7 +62,7 @@
 #define AUDIO_TOTAL_IF_NUM 				0x03
 
 
-/* CDC Endpoints parameters: you can fine tune these values depending on the needed baudrates and performance. */
+/* CDC endpoint parameters: you can fine tune these values depending on the needed baudrates and performance. */
 #ifdef USE_USB_OTG_HS
 #define CDC_DATA_MAX_PACKET_SIZE       64  /* Endpoint IN & OUT Packet size */
 #define CDC_CMD_PACKET_SZE             8    /* Control Endpoint Packet size */


### PR DESCRIPTION
In the situation where USB buffers are filled with numbers other than
multiples of five, it is likely that the bytes have been added in front.
The bytes in the beginning of the buffers are probably left-overs from
previous sessions or non CAT programs accessing the serial port.
By this fix the first bytes of the USB read buffer is flushed as long as
the rest of the buffer-size divided by five is not zero. The
calculation time is normally minimal.

In addition I modified some returns of functions to be more useful in a later optimization of buffer handling. And some typos are fixed.
