### PR TITLE
bugfix IQ phase & amplitude adjustment

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -1839,7 +1839,7 @@ static void AudioDriver_IQPhaseAdjust(uint8_t dmod_mode, uint8_t txrx_mode, int 
          break;
     default:
         // FM, SAM
-        iq_phase_balance = txrx_mode==TRX_MODE_RX?ts.rx_iq_lsb_phase_balance:0;
+        iq_phase_balance = txrx_mode==TRX_MODE_RX?ts.rx_iq_usb_phase_balance:0;
         break;
     }
     if (iq_phase_balance < 0)   // we only need to deal with I and put a little bit of it into Q
@@ -1970,11 +1970,11 @@ static void audio_rx_processor(int16_t *src, int16_t *dst, int16_t size)
         audio_snap_carrier(); // tunes the mcHF to the largest signal in the filterpassband
     }
 
-    AudioDriver_IQPhaseAdjust(ts.dmod_mode, ts.txrx_mode,size);
-
     // Apply gain corrections for I/Q amplitude correction
     arm_scale_f32((float32_t *)ads.i_buffer, (float32_t)ts.rx_adj_gain_var_i, (float32_t *)ads.i_buffer, size/2);
     arm_scale_f32((float32_t *)ads.q_buffer, (float32_t)ts.rx_adj_gain_var_q, (float32_t *)ads.q_buffer, size/2);
+
+    AudioDriver_IQPhaseAdjust(ts.dmod_mode, ts.txrx_mode,size);
 
     if(ts.iq_freq_mode)	 		// is receive frequency conversion to be done?
     {
@@ -2454,7 +2454,7 @@ void audio_tx_final_iq_processing(float scaling, bool swap, int16_t* dst, int16_
 {
     int16_t i;
 
-    AudioDriver_IQPhaseAdjust(ts.dmod_mode,ts.txrx_mode,size);
+//    AudioDriver_IQPhaseAdjust(ts.dmod_mode,ts.txrx_mode,size);
 
     // ------------------------
     // Output I and Q as stereo data

--- a/mchf-eclipse/drivers/audio/audio_management.c
+++ b/mchf-eclipse/drivers/audio/audio_management.c
@@ -142,15 +142,28 @@ void AudioManagement_CalcNB_AGC(void)
 //* Functions called    :
 //*----------------------------------------------------------------------------
 void AudioManagement_CalcRxIqGainAdj(void)
-{
-    if(ts.dmod_mode == DEMOD_AM)
-        ts.rx_adj_gain_var_i = (float)ts.rx_iq_am_gain_balance;         // get current gain adjustment for AM
-    if(ts.dmod_mode == DEMOD_FM)
+{ // please note that the RX adjustments for gain are negative
+	// and the adjustments for TX (in the function AudioManagement_CalcTxIqGainAdj) are positive
+
+    switch(ts.dmod_mode)
+    {
+    case DEMOD_FM:
         ts.rx_adj_gain_var_i = (float)ts.rx_iq_fm_gain_balance;         // get current gain adjustment for FM
-    else if(ts.dmod_mode == DEMOD_LSB)
+    	break;
+    case DEMOD_AM:
+        ts.rx_adj_gain_var_i = (float)ts.rx_iq_am_gain_balance;         // get current gain adjustment for AM
+        break;
+    case DEMOD_LSB:
         ts.rx_adj_gain_var_i = -(float)ts.rx_iq_lsb_gain_balance;        // get current gain adjustment setting for LSB
-    else
+    	break;
+    case DEMOD_USB:
         ts.rx_adj_gain_var_i = -(float)ts.rx_iq_usb_gain_balance;        // get current gain adjustment setting  USB and other modes
+    	break;
+    default:
+    	ts.rx_adj_gain_var_i = -(float)ts.rx_iq_usb_gain_balance;        // get current gain adjustment setting  USB and other modes
+    	break;
+    }
+
     //
     ts.rx_adj_gain_var_i /= SCALING_FACTOR_IQ_AMPLITUDE_ADJUST;       // fractionalize it
     ts.rx_adj_gain_var_q = -ts.rx_adj_gain_var_i;               // get "invert" of it
@@ -169,6 +182,8 @@ void AudioManagement_CalcTxIqGainAdj(void)
     // Note:  There is a fixed amount of offset due to the fact that the phase-added Hilbert (e.g. 0, 90) transforms are
     // slightly asymmetric that is added so that "zero" is closer to being the proper phase balance.
     //
+	// please note that the RX adjustments for gain are negative (in function AudioManagement_CalcRxIqGainAdj)
+	// and the adjustments for TX are positive
     if(ts.dmod_mode == DEMOD_AM)    // is it AM mode?
         ts.tx_adj_gain_var_i = (float)ts.tx_iq_am_gain_balance;     // get current gain balance adjustment setting for AM
     else if(ts.dmod_mode == DEMOD_FM)   // is it in FM mode?
@@ -219,7 +234,7 @@ static const AlcParams alc_params[] =
 
 void AudioManagement_CalcTxCompLevel(void)
 {
-    float tcalc;
+//    float tcalc;
     if (ts.tx_comp_level < 13)
     {
         ts.alc_tx_postfilt_gain_var = alc_params[ts.tx_comp_level].tx_postfilt_gain;      // restore "pristine" EEPROM values

--- a/mchf-eclipse/drivers/ui/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/ui_menu.c
@@ -3141,7 +3141,7 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
         sprintf(options, "   %d", ts.rx_iq_usb_gain_balance);
         break;
     case CONFIG_USB_RX_IQ_PHASE_BAL:		// USB RX IQ Phase balance
-        if((ts.dmod_mode == DEMOD_USB)  && (ts.txrx_mode == TRX_MODE_RX))
+        if(((ts.dmod_mode == DEMOD_USB)  || (ts.dmod_mode == DEMOD_CW)) && (ts.txrx_mode == TRX_MODE_RX))
         {
             tchange = UiDriverMenuItemChangeInt(var, mode, &ts.rx_iq_usb_phase_balance,
                                                 MIN_RX_IQ_PHASE_BALANCE,


### PR DESCRIPTION
- Deleted double phase adjustment in function audio_tx_final_iq_processing 
- took into account phase & gain adjustment in CW mode: takes/adjusts USB settings (formerly was taking LSB setting for amplitude and USB setting for phase . . . )
- changed RX: first amplitude correction, then phase adjustment
- unchanged TX: first amplitude correction, then phase adjustment
- changed if else if etc. to switch/case
- added some comments
