### PR TITLE
Timeout for CAT buffer and number of small changes, most do not change anything

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.h
+++ b/mchf-eclipse/drivers/audio/audio_driver.h
@@ -67,13 +67,13 @@ typedef struct AudioDriverState
     float32_t					i_buffer[IQ_BUFSZ+1];
     float32_t 					q_buffer[IQ_BUFSZ+1];
     float32_t 					a_buffer[IQ_BUFSZ+1];
-    float32_t 					a2_buffer[IQ_BUFSZ+1];
-    float32_t 					a3_buffer[IQ_BUFSZ+1];
+
     float32_t 					b_buffer[(IQ_BUFSZ*2)+1];	// this is larger since we need interleaved data for magnitude calculation in AM demod and thus, twice as much space
+
     float32_t					c_buffer[IQ_BUFSZ+1];
-    float32_t					d_buffer[IQ_BUFSZ+1];
-    float32_t					e_buffer[IQ_BUFSZ+1];
-    float32_t					f_buffer[IQ_BUFSZ+1];
+    float32_t					d_buffer[IQ_BUFSZ+1]; // only used in one place ( translate )
+    float32_t					e_buffer[IQ_BUFSZ+1]; // only used in briefly used in two places rx_proc / tx_proc
+    float32_t					f_buffer[IQ_BUFSZ+1]; // only used in briefly used in two places rx_proc / tx_proc
     //
     float32_t					Osc_I_buffer[IQ_BUFSZ+1];
     float32_t					Osc_Q_buffer[IQ_BUFSZ+1];

--- a/mchf-eclipse/drivers/cat/cat_driver.h
+++ b/mchf-eclipse/drivers/cat/cat_driver.h
@@ -34,8 +34,11 @@ typedef struct CatDriver
     uchar	enabled;
     CatInterfaceState state;
     CatInterfaceProtocol protocol;
+    uint32_t lastbufferadd_time;
 
 } CatDriver;
+
+extern __IO CatDriver kd;
 
 // Exports
 void cat_driver_init(void);

--- a/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
@@ -1705,7 +1705,7 @@ static void UiSpectrum_FrequencyBarText()
         const static int idx2pos[] = {0,26,58,90,122,154,186,218,242};
         const static int centerIdx2pos[] = {62,94,130,160,192};
 
-        sprintf(txt, "  %lu  ", freq_calc+(centerIdx*grat)); // build string for center frequency
+        snprintf(txt,16, "  %lu  ", freq_calc+(centerIdx*grat)); // build string for center frequency
         i = centerIdx2pos[centerIdx+2] -((strlen(txt)-2)*4);    // calculate position of center frequency text
         UiLcdHy28_PrintText((POS_SPECTRUM_IND_X + i),(POS_SPECTRUM_IND_Y + POS_SPECTRUM_FREQ_BAR_Y),txt,clr,Black,4);
 
@@ -1716,7 +1716,7 @@ static void UiSpectrum_FrequencyBarText()
             int pos = idx2pos[idx+4];
             if (idx != centerIdx)
             {
-                sprintf(txt, " %lu ", freq_calc+(idx*grat));   // build string for middle-left frequency
+                snprintf(txt,16, " %lu ", freq_calc+(idx*grat));   // build string for middle-left frequency
                 c = &txt[strlen(txt)-3];  // point at 2nd character from the end
                 UiLcdHy28_PrintText((POS_SPECTRUM_IND_X +  pos),(POS_SPECTRUM_IND_Y + POS_SPECTRUM_FREQ_BAR_Y),c,clr,Black,4);
             }

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -662,7 +662,7 @@ void UiDriver_HandleTouchScreen()
     if (ts.show_tp_coordinates)					// show coordinates for coding purposes
     {
         char text[10];
-        sprintf(text,"%02d%s%02d%s",ts.tp_x," : ",ts.tp_y,"  ");
+        snprintf(text,10,"%02d%s%02d%s",ts.tp_x," : ",ts.tp_y,"  ");
         UiLcdHy28_PrintText(POS_PWR_NUM_IND_X,POS_PWR_NUM_IND_Y,text,White,Black,0);
     }
     if(!ts.menu_mode)						// normal operational screen
@@ -3179,7 +3179,7 @@ static void UiDriverCreateSMeter()
             {
                 if(i)
                 {
-                    sprintf(num,"%d",(i*2));
+                    snprintf(num,20,"%d",(i*2));
                     // Text
                     UiLcdHy28_PrintText(((POS_SM_IND_X + 18) - 3 + i*10),(POS_SM_IND_Y + 59 - BTM_MINUS),num,White,Black,4);
 
@@ -3209,7 +3209,7 @@ static void UiDriverCreateSMeter()
             {
                 if(i)
                 {
-                    sprintf(num,"%d",(i*2)-20);
+                    snprintf(num,20,"%d",(i*2)-20);
                     // Text
                     UiLcdHy28_PrintText(((POS_SM_IND_X + 18) - 3 + i*10),(POS_SM_IND_Y + 59 - BTM_MINUS),num,White,Black,4);
 
@@ -5060,18 +5060,20 @@ static void UiDriver_DisplayCmpLevel(bool encoder_active)
 {
     ushort 	color = encoder_active?White:Grey;
     char	temp[5];
+    const char* outs;
 
     if(ts.tx_comp_level < TX_AUDIO_COMPRESSION_MAX)	 	// 	display numbers for all but the highest value
     {
-        sprintf(temp," %02d",ts.tx_comp_level);
+        snprintf(temp,5,"%02d",ts.tx_comp_level);
+        outs = temp;
     }
     else	 				// show "CUS" (Custom Value) for highest value
     {
-        strcpy(temp, "CUS");
+        outs ="CUS";
         color = Yellow;	// Custom value - use yellow
     }
 
-    UiDriverEncoderDisplay(1,0,"CMP" , encoder_active, temp, color);
+    UiDriverEncoderDisplay(1,0,"CMP" , encoder_active, outs, color);
 }
 
 uint32_t dsp_nr_color_map()
@@ -5254,7 +5256,7 @@ static void UiDriver_DisplayKeyerSpeed(bool encoder_active)
         color = White;
 
     txt = "WPM";
-    sprintf(txt_buf,"%2d",ts.keyer_speed);
+    snprintf(txt_buf,5,"%2d",ts.keyer_speed);
 
     UiDriverEncoderDisplay(1,2,txt, encoder_active, txt_buf, color);
 }
@@ -5294,7 +5296,7 @@ static void UiDriver_DisplayLineInModeAndGain(bool encoder_active)
         txt = "???";
     }
 
-    sprintf(txt_buf,"%2d",ts.tx_gain[ts.tx_audio_source]);
+    snprintf(txt_buf,5,"%2d",ts.tx_gain[ts.tx_audio_source]);
 
     UiDriverEncoderDisplay(1,2,txt, encoder_active, txt_buf, color);
 }
@@ -5336,7 +5338,7 @@ static void UiDriver_DisplayRfGain(bool encoder_active)
         value = ts.fm_sql_threshold;
     }
 
-    sprintf(temp," %02ld",value);
+    snprintf(temp,5," %02ld",value);
 
     UiDriverEncoderDisplay(0,1,label, encoder_active, temp, color);
 
@@ -5434,16 +5436,10 @@ static void UiDriver_DisplayTone(bool encoder_active)
 static void UiDriver_DisplayRit(bool encoder_active)
 {
     char	temp[5];
-    uint32_t color;
-    if(ts.rit_value)
-        color = Green;
-    else
-        color = encoder_active?White:Grey;
 
-    if(ts.rit_value)
-        sprintf(temp,"%+3i", ts.rit_value);
-    else
-        sprintf(temp,"%3i", ts.rit_value);
+    uint32_t color = ts.rit_value? Green : (encoder_active ? White:Grey);
+
+    snprintf(temp,5,ts.rit_value?"%+3i":"%3i", ts.rit_value);
 
     UiDriverEncoderDisplay(0,2,"RIT", encoder_active, temp, color);
 }
@@ -5919,7 +5915,7 @@ static void UiDriverHandleTXMeters()
             rev_pwr_avg = rev_pwr_avg * (1-PWR_DAMPENING_FACTOR);	// apply IIR smoothing to reverse power reading
             rev_pwr_avg += swrm.rev_pwr * PWR_DAMPENING_FACTOR;
 
-            sprintf(txt, "%d,%d   ", (int)(fwd_pwr_avg*1000), (int)(rev_pwr_avg*1000));		// scale to display power in milliwatts
+            snprintf(txt,32, "%d,%d   ", (int)(fwd_pwr_avg*1000), (int)(rev_pwr_avg*1000));		// scale to display power in milliwatts
             UiLcdHy28_PrintText    (POS_PWR_NUM_IND_X, POS_PWR_NUM_IND_Y,txt,Grey,Black,0);
             swrm.pwr_meter_was_disp = 1;	// indicate the power meter WAS displayed
         }
@@ -6583,14 +6579,7 @@ void UiDriver_KeyTestScreen()
 			}
 			if(t != ENC_MAX)
 			{
-				char encnum[3];
-				sprintf(txt_buf,"%s"," Encoder ");		// building string for encoders
-				sprintf(encnum,"%d",t+1);
-				strcat(txt_buf,encnum);
-				if(direction > 0)
-					strcat(txt_buf," <right>");
-				else
-					strcat(txt_buf," <left> ");
+				snprintf(txt_buf,40," Encoder %d <%s>", t+1, direction>0 ? "right":"left");		// building string for encoders
 				j = 18+t;					// add encoders behind buttons;
 			}
 
@@ -6663,7 +6652,7 @@ void UiDriver_KeyTestScreen()
 
 			    if (UiLcdHy28_TouchscreenHasProcessableCoordinates())
 			    {
-					sprintf(txt_buf,"Touchscr. x:%02d y:%02d",ts.tp_x,ts.tp_y);	//show touched coordinates
+					snprintf(txt_buf,40,"Touchscr. x:%02d y:%02d",ts.tp_x,ts.tp_y);	//show touched coordinates
 					txt = txt_buf;
 				}
 				else
@@ -6695,7 +6684,7 @@ void UiDriver_KeyTestScreen()
 			{
 				UiLcdHy28_PrintText(10,120,txt,White,Blue,1);			// identify button on screen
 			}
-			sprintf(txt_buf, "# of buttons pressed: %d  ", (int)k);
+			snprintf(txt_buf,40, "# of buttons pressed: %d  ", (int)k);
 			UiLcdHy28_PrintText(75,160,txt_buf,White,Blue,0);			// show number of buttons pressed on screen
 
 			if(p_o_state == 1)
@@ -6877,12 +6866,12 @@ void UiDriver_DoCrossCheck(char cross[],char* xt_corr, char* yt_corr)
                 *xt_corr += (ts.tp_x - cross[0]);
                 *yt_corr += (ts.tp_y - cross[1]);
                 clr_fg = Green;
-                sprintf(txt_buf,"Try (%d) error: x = %+d / y = %+d       ",datavalid,ts.tp_x-cross[0],ts.tp_y-cross[1]);	//show misajustments
+                snprintf(txt_buf,40,"Try (%d) error: x = %+d / y = %+d       ",datavalid,ts.tp_x-cross[0],ts.tp_y-cross[1]);	//show misajustments
             }
             else
             {
                 clr_fg = Red;
-                sprintf(txt_buf,"Try (%d) BIG error: x = %+d / y = %+d",samples,ts.tp_x-cross[0],ts.tp_y-cross[1]);	//show misajustments
+                snprintf(txt_buf,40,"Try (%d) BIG error: x = %+d / y = %+d",samples,ts.tp_x-cross[0],ts.tp_y-cross[1]);	//show misajustments
             }
             samples++;
             UiLcdHy28_PrintText(10,70,txt_buf,clr_fg,clr_bg,0);
@@ -6906,11 +6895,11 @@ void UiDriver_ShowStartUpScreen(ulong hold_time)
 
     non_os_delay();
     // Show first line
-    sprintf(tx,"%s",DEVICE_STRING);
+    snprintf(tx,100,"%s",DEVICE_STRING);
     UiLcdHy28_PrintText(0,30,tx,Cyan,Black,1);       // Position with original text size:  78,40
 
     // Show second line
-    sprintf(tx,"%s",AUTHOR_STRING);
+    snprintf(tx,100,"%s",AUTHOR_STRING);
     UiLcdHy28_PrintText(36,60,tx,White,Black,0);     // 60,60
 
 	// looking for bootloader version, only works or DF8OE bootloader
@@ -6924,20 +6913,20 @@ void UiDriver_ShowStartUpScreen(ulong hold_time)
   	  && *(__IO uint8_t*)(begin+i+3) == 0x73 && *(__IO uint8_t*)(begin+i+4) == 0x69 && *(__IO uint8_t*)(begin+i+5) == 0x6f
   	  && *(__IO uint8_t*)(begin+i+6) == 0x6e && *(__IO uint8_t*)(begin+i+7) == 0x3a && *(__IO uint8_t*)(begin+i+8) == 0x20)
   		{
-  		sprintf(bootloader, "%s", (__IO char*)(begin+i+9));
+  		snprintf(bootloader,12, "%s", (__IO char*)(begin+i+9));
   		}
   	  }
   	  if(bootloader[0] == 0)
   		{
-  		sprintf(bootloader, "%s", "no DF8OE BL");
+  		snprintf(bootloader,12, "%s", "no DF8OE BL");
   		}
 
     // Show third line
-    sprintf(tx,"FW: %d.%d.%d / BL: %s",TRX4M_VER_MAJOR,TRX4M_VER_MINOR,TRX4M_VER_RELEASE,bootloader);
+    snprintf(tx,100,"FW: %d.%d.%d / BL: %s",TRX4M_VER_MAJOR,TRX4M_VER_MINOR,TRX4M_VER_RELEASE,bootloader);
     UiLcdHy28_PrintText(80,80,tx,Grey3,Black,0);
 
     // Show fourth line
-    sprintf(tx,"Build on %s%s%s%s",__DATE__," at ",__TIME__, " CEST");
+    snprintf(tx,100,"Build on %s%s%s%s",__DATE__," at ",__TIME__, " CEST");
     UiLcdHy28_PrintText(15,100,tx,Yellow,Black,0);
 
     ConfigStorage_ReadVariable(EEPROM_FREQ_CONV_MODE, &i);  // get setting of frequency translation mode

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -346,8 +346,6 @@ __IO PowerMeter					pwmt;
 // LO Tcxo
 __IO LoTcxo						lo;
 
-// CAT driver state
-__IO CatDriver					kd;
 
 // move to struct ??
 __IO ulong 						unmute_delay = 0;
@@ -990,7 +988,7 @@ void RadioManagement_SwitchTxRx(uint8_t txrx_mode, bool tune_mode)
     uint32_t tune_new;
     bool tx_ok = false;
 
-	ts.last_tuning = 0;					// prevents transmitting on wrong frequency during "RX bk phases"
+	// ts.last_tuning = 0;					// prevents transmitting on wrong frequency during "RX bk phases"
 
     if(is_splitmode())                  // is SPLIT mode active?
     {

--- a/mchf-eclipse/drivers/ui/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/ui_menu.c
@@ -1185,8 +1185,10 @@ void UiMenu_UpdateMenuEntry(const MenuDescriptor* entry, uchar mode, uint8_t pos
                     }
                 }
             }
-            strcpy(out,UiMenu_GroupIsUnfolded(entry)?"HIDE":"SHOW");
-            UiMenu_DisplayValue(out,m_clr,pos);
+
+            UiMenu_DisplayValue(
+                    UiMenu_GroupIsUnfolded(entry)?"HIDE":"SHOW",
+                    m_clr,pos);
             break;
         }
     }
@@ -1536,7 +1538,6 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode, int pos)
 {
     char options[32];
     const char* txt_ptr = NULL; // if filled, we use this string for display, otherwise options
-    ulong opt_pos;			// y position of option cursor
     uchar select;
     ulong	clr;
     uchar temp_var;
@@ -1558,7 +1559,6 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode, int pos)
         ts.menu_var = 0;		// clear encoder change detect
     }
     strcpy(options, "ERROR");	// pre-load to catch error condition
-    opt_pos = pos;
 
     switch(select)	 		//  DSP_NR_STRENGTH_MAX
     {
@@ -1593,7 +1593,7 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode, int pos)
                 clr = Yellow;
         }
         //
-        sprintf(options, "  %u", ts.dsp_nr_strength);
+        snprintf(options,32, "  %u", ts.dsp_nr_strength);
         break;
     case MENU_AM_DISABLE: // AM mode enable/disable
         UiDriverMenuItemChangeDisableOnOff(var, mode, &ts.am_mode_disable,0,options,&clr);
@@ -1665,11 +1665,11 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode, int pos)
             a *= 10;		// "a" now has Hz*100 with 10ths removed
             b -= a;			// "b" now has 10ths of Hz
             a /= 10;		// "a" is back to units of Hz
-            sprintf(options, "  %d.%dHz", a, b);
+            snprintf(options,32, "  %d.%dHz", a, b);
         }
         else	 							// tone is off
         {
-            sprintf(options, "     OFF");		// make it dislay "off"
+            snprintf(options,32, "     OFF");		// make it dislay "off"
             ads.fm_subaudible_tone_word = 0;	// set word to 0 to turn it off
         }
         //
@@ -1696,11 +1696,11 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode, int pos)
             a *= 10;		// "a" now has Hz*100 with 10ths removed
             b -= a;			// "b" now has 10ths of Hz
             a /= 10;		// "a" is back to units of Hz
-            sprintf(options, "  %d.%dHz", a, b);
+            snprintf(options,32, "  %d.%dHz", a, b);
         }
         else	 							// tone is off
         {
-            sprintf(options, "     OFF");		// make it dislay "off"
+            snprintf(options,32, "     OFF");		// make it dislay "off"
             ads.fm_subaudible_tone_word = 0;	// set word to 0 to turn it off
         }
         //
@@ -1792,12 +1792,10 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode, int pos)
             {
                 txt_ptr = "+-2k5 (Nar)";		// Not set - 2.5 kHz
             }
-            strncpy(options,txt_ptr,32);
-            txt_ptr = NULL;
         }
         else	 	// translate mode is off - NO FM!!!
         {
-            strncpy(options, "  OFF",32);		// Say that it is OFF!
+            txt_ptr = "  OFF";		// Say that it is OFF!
             clr = Red;
         }
         break;
@@ -1904,7 +1902,7 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode, int pos)
         {
             clr = Red;
         }
-        sprintf(options, "  %d", ts.agc_custom_decay);
+        snprintf(options,32, "  %d", ts.agc_custom_decay);
         break;
     // A/D Codec Gain/Mode setting/adjust
     case MENU_CODEC_GAIN_MODE:
@@ -1919,7 +1917,7 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode, int pos)
             strcpy(options, " AUTO");
         else	 	// if anything other than "Auto" give a warning in RED
         {
-            sprintf(options,"> %u <", ts.rf_codec_gain);
+            snprintf(options,32,"> %u <", ts.rf_codec_gain);
             clr = Red;
         }
         break;
@@ -2042,7 +2040,7 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode, int pos)
             clr = Orange;
         }
 
-        sprintf(options, "   %u", ts.tx_gain[TX_AUDIO_MIC]);
+        snprintf(options,32, "   %u", ts.tx_gain[TX_AUDIO_MIC]);
         break;
     case MENU_LINE_GAIN:	// Line Gain setting
 
@@ -2074,11 +2072,11 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode, int pos)
         if(ts.tx_audio_source == TX_AUDIO_MIC)	// Orange if in MIC mode
         {
             clr = Orange;
-            sprintf(options, "  %u", ts.tx_gain[TX_AUDIO_LINEIN_L]);
+            snprintf(options,32, "  %u", ts.tx_gain[TX_AUDIO_LINEIN_L]);
         }
         else
         {
-            sprintf(options, "  %u", ts.tx_gain[ts.tx_audio_source]);
+            snprintf(options,32, "  %u", ts.tx_gain[ts.tx_audio_source]);
         }
         break;
     case MENU_ALC_RELEASE:		// ALC Release adjust
@@ -2106,7 +2104,7 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode, int pos)
         {
             ts.alc_decay = ts.alc_decay_var;	// yes, save new value
         }
-        sprintf(options, "  %d", (int)ts.alc_decay_var);
+        snprintf(options,32, "  %d", (int)ts.alc_decay_var);
         break;
     case MENU_ALC_POSTFILT_GAIN:		// ALC TX Post-filter gain (Compressor level)
         if(ts.tx_comp_level == TX_AUDIO_COMPRESSION_MAX)
@@ -2136,7 +2134,7 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode, int pos)
             ts.alc_tx_postfilt_gain = ts.alc_tx_postfilt_gain_var;	// yes, save new value
         }
 
-        sprintf(options, "  %d", (int)ts.alc_tx_postfilt_gain_var);
+        snprintf(options,32, "  %d", (int)ts.alc_tx_postfilt_gain_var);
         break;
     case MENU_TX_COMPRESSION_LEVEL:		// ALC TX Post-filter gain (Compressor level)
         fchange = UiDriverMenuItemChangeUInt8(var, mode, &ts.tx_comp_level,
@@ -2158,11 +2156,11 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode, int pos)
 
         if(ts.tx_comp_level < TX_AUDIO_COMPRESSION_SV)	// 	display numbers for all but the highest value
         {
-            sprintf(options,"    %d",ts.tx_comp_level);
+            snprintf(options,32,"  %d",ts.tx_comp_level);
         }
         else					// show "CUSTOM" (Stored Value) for highest value
         {
-            strcpy(options, "CUSTOM");
+            txt_ptr = "CUSTOM";
         }
         break;
     case MENU_KEYER_MODE:	// Keyer mode
@@ -2200,7 +2198,7 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode, int pos)
             cw_set_speed(); // make sure keyerspeed is being used
             UiDriver_RefreshEncoderDisplay(); // maybe shown on encoder boxes
         }
-        sprintf(options, "  %u", ts.keyer_speed);
+        snprintf(options,32, "  %u", ts.keyer_speed);
         break;
     case MENU_SIDETONE_GAIN:	// sidetone gain
         fchange = UiDriverMenuItemChangeUInt8(var, mode, &ts.st_gain,
@@ -2213,7 +2211,7 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode, int pos)
         {
             UiDriver_RefreshEncoderDisplay(); // maybe shown on encoder boxes
         }
-        sprintf(options, "  %u", ts.st_gain);
+        snprintf(options,32, "  %u", ts.st_gain);
         break;
     case MENU_SIDETONE_FREQUENCY:	// sidetone frequency
         fchange = UiDriverMenuItemChangeUInt32(var, mode, &ts.sidetone_freq,
@@ -2228,7 +2226,7 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode, int pos)
             softdds_setfreq((float)ts.sidetone_freq,ts.samp_rate,0);
             UiDriver_FrequencyUpdateLOandDisplay(false);
         }
-        sprintf(options, "  %uHz", (uint)ts.sidetone_freq);
+        snprintf(options,32, "  %uHz", (uint)ts.sidetone_freq);
         break;
 
     case MENU_PADDLE_REVERSE:	// CW Paddle reverse
@@ -2242,7 +2240,7 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode, int pos)
                                               1
                                              );
 
-        sprintf(options, "  %u", ts.cw_rx_delay);
+        snprintf(options,32, "  %u", ts.cw_rx_delay);
         break;
 
     case MENU_CW_OFFSET_MODE:	// CW offset mode (e.g. USB, LSB, etc.)
@@ -2383,11 +2381,11 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode, int pos)
                                              );
         if(ts.scope_speed)
         {
-            sprintf(options, "  %u", ts.scope_speed);
+            snprintf(options,32, "  %u", ts.scope_speed);
         }
         else
         {
-            strcpy(options, "OFF");
+            txt_ptr = "OFF";
         }
         break;
     case MENU_SPECTRUM_FILTER_STRENGTH:	// spectrum filter strength
@@ -2397,7 +2395,7 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode, int pos)
                                               SPECTRUM_FILTER_DEFAULT,
                                               1
                                              );
-        sprintf(options, "  %u", ts.spectrum_filter);
+        snprintf(options,32, "  %u", ts.spectrum_filter);
         break;
     case MENU_SCOPE_TRACE_COLOUR:	// spectrum scope trace colour
         fchange = UiDriverMenuItemChangeUInt8(var, mode, &ts.scope_trace_colour,
@@ -2442,7 +2440,7 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode, int pos)
             sd.agc_rate = (float)ts.scope_agc_rate;	// calculate agc rate
             sd.agc_rate = sd.agc_rate/SPECTRUM_AGC_SCALING;
         }
-        sprintf(options, "  %u", ts.scope_agc_rate);
+        snprintf(options,32, "  %u", ts.scope_agc_rate);
         break;
     case MENU_SCOPE_DB_DIVISION:	// Adjustment of dB/division of spectrum scope
         fchange = UiDriverMenuItemChangeUInt8(var, mode, &ts.spectrum_db_scale,
@@ -2604,7 +2602,7 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode, int pos)
                                     WATERFALL_STEP_SIZE_DEFAULT,
                                     1
                                    );
-        sprintf(options, "  %u", ts.waterfall_vert_step_size);
+        snprintf(options,32, "  %u", ts.waterfall_vert_step_size);
         break;
     case MENU_WFALL_OFFSET:	// set step size of of waterfall display?
         UiDriverMenuItemChangeUInt32(var, mode, &ts.waterfall_offset,
@@ -2613,7 +2611,7 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode, int pos)
                                      WATERFALL_OFFSET_DEFAULT,
                                      1
                                     );
-        sprintf(options, "  %u", (unsigned int)ts.waterfall_offset);
+        snprintf(options,32, "  %u", (unsigned int)ts.waterfall_offset);
         break;
     case MENU_WFALL_CONTRAST:	// set step size of of waterfall display?
         UiDriverMenuItemChangeUInt32(var, mode, &ts.waterfall_contrast,
@@ -2622,7 +2620,7 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode, int pos)
                                      WATERFALL_CONTRAST_DEFAULT,
                                      2
                                     );
-        sprintf(options, "  %u", (unsigned int)ts.waterfall_contrast);
+        snprintf(options,32, "  %u", (unsigned int)ts.waterfall_contrast);
         break;
     case MENU_WFALL_SPEED:	// set step size of of waterfall display?
         UiDriverMenuItemChangeUInt8(var, mode, &ts.waterfall_speed,
@@ -2647,7 +2645,7 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode, int pos)
                 clr = Yellow;
         }
 
-        sprintf(options, "  %u", ts.waterfall_speed);
+        snprintf(options,32, "  %u", ts.waterfall_speed);
         break;
     case MENU_SCOPE_NOSIG_ADJUST:	// set step size of of waterfall display?
         UiDriverMenuItemChangeUInt8(var, mode, &ts.spectrum_scope_nosig_adjust,
@@ -2656,7 +2654,7 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode, int pos)
                                     SPECTRUM_SCOPE_NOSIG_ADJUST_DEFAULT,
                                     1
                                    );
-        sprintf(options, "  %u", ts.spectrum_scope_nosig_adjust);
+        snprintf(options,32, "  %u", ts.spectrum_scope_nosig_adjust);
         break;
     case MENU_WFALL_NOSIG_ADJUST:	// set step size of of waterfall display?
         UiDriverMenuItemChangeUInt8(var, mode, &ts.waterfall_nosig_adjust,
@@ -2665,7 +2663,7 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode, int pos)
                                     WATERFALL_NOSIG_ADJUST_DEFAULT,
                                     1
                                    );
-        sprintf(options, "  %u", ts.waterfall_nosig_adjust);
+        snprintf(options,32, "  %u", ts.waterfall_nosig_adjust);
         break;
     case MENU_SPECTRUM_SIZE:	// set step size of of waterfall display?
         UiDriverMenuItemChangeUInt8(var, mode, &ts.spectrum_size,
@@ -2694,7 +2692,7 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode, int pos)
             clr = White;
             if(var>=1)
             {
-                UiMenu_DisplayValue("Working",Red,opt_pos);
+                UiMenu_DisplayValue("Working",Red,pos);
                 ConfigStorage_CopySerial2Flash();
                 txt_ptr = " Done...";
                 clr = Green;
@@ -2710,7 +2708,7 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode, int pos)
             if(var>=1)
             {
 
-                UiMenu_DisplayValue("Working",Red,opt_pos);
+                UiMenu_DisplayValue("Working",Red,pos);
                 ConfigStorage_CopyFlash2Serial();
                 mchf_reboot();
             }
@@ -2722,23 +2720,23 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode, int pos)
         if(var>=1)
         {
 
-            UiMenu_DisplayValue("Restart",Red,opt_pos);
+            UiMenu_DisplayValue("Restart",Red,pos);
             Codec_RestartI2S();
             var = 0;
         }
         break;
     default:						// Move to this location if we get to the bottom of the table!
-        strncpy(options, "ERROR!",32);
+        txt_ptr= "ERROR!";
         break;
     }
     if (txt_ptr == NULL)
     {
         txt_ptr = options;
     }
-    UiMenu_DisplayValue(txt_ptr,clr,opt_pos);
+    UiMenu_DisplayValue(txt_ptr,clr,pos);
     if(mode == MENU_PROCESS_VALUE_CHANGE)
     {
-        UiMenu_MoveCursor(opt_pos);
+        UiMenu_MoveCursor(pos);
     }
     return;
 }
@@ -2756,7 +2754,6 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
 {
     char options[32];
     const char* txt_ptr = NULL;
-    ulong opt_pos;					// y position of option
     uchar select;
     ulong	clr;
     uchar	temp_var;
@@ -2775,7 +2772,6 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
         var = ts.menu_var;		// change from encoder
         ts.menu_var = 0;		// clear encoder change detect
     }
-    opt_pos = pos;
 
 
     strcpy(options, "ERROR");	// pre-load to catch error condition
@@ -2886,7 +2882,7 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
                                     0,
                                     1
                                    );
-        sprintf(options, "    %u", ts.tx_audio_muting_timing);
+        snprintf(options,32, "    %u", ts.tx_audio_muting_timing);
         break;
     case CONFIG_LCD_AUTO_OFF_MODE:	// LCD auto-off mode control
         temp_var = ts.lcd_backlight_blanking;		// get control variable
@@ -2912,9 +2908,9 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
         }
         //
         if(ts.lcd_backlight_blanking & LCD_BLANKING_ENABLE)			// timed auto-blanking enabled?
-            sprintf(options,"%02d sec",ts.lcd_backlight_blanking & LCD_BLANKING_TIMEMASK);	// yes - Update screen indicator with number of seconds
+            snprintf(options,32,"%02d sec",ts.lcd_backlight_blanking & LCD_BLANKING_TIMEMASK);	// yes - Update screen indicator with number of seconds
         else
-            sprintf(options,"   OFF");						// Or if turned off
+            snprintf(options,32,"   OFF");						// Or if turned off
         break;
     case CONFIG_VOLTMETER_CALIBRATION:		// Voltmeter calibration
         tchange = UiDriverMenuItemChangeUInt32(var, mode, &ts.voltmeter_calibrate,
@@ -2923,7 +2919,7 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
                                                POWER_VOLTMETER_CALIBRATE_DEFAULT,
                                                1
                                               );
-        sprintf(options, "  %u", (unsigned int)ts.voltmeter_calibrate);
+        snprintf(options,32, "  %u", (unsigned int)ts.voltmeter_calibrate);
         break;
     case CONFIG_DISP_FILTER_BANDWIDTH: // Display filter bandwidth
         tchange = UiDriverMenuItemChangeUInt8(var, mode, &ts.filter_disp_colour,
@@ -2947,7 +2943,7 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
             ts.rx_gain[RX_AUDIO_SPKR].value = ts.rx_gain[RX_AUDIO_SPKR].max;		// yes - force the volume to the new value
             UiDriver_RefreshEncoderDisplay(); // maybe shown on encoder boxes
         }
-        sprintf(options, "    %u", ts.rx_gain[RX_AUDIO_SPKR].max);
+        snprintf(options,32, "    %u", ts.rx_gain[RX_AUDIO_SPKR].max);
         //
         if(ts.rx_gain[RX_AUDIO_SPKR].max <= MAX_VOL_RED_THRESH)			// Indicate that gain has been reduced by changing color
             clr = Red;
@@ -2965,7 +2961,7 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
         {
             AudioManagement_CalcAGCVals();	// calculate new internal AGC values from user settings
         }
-        sprintf(options, "    %u", ts.max_rf_gain);
+        snprintf(options,32, "    %u", ts.max_rf_gain);
         break;
     case CONFIG_BEEP_ENABLE:	//
         temp_var = ts.flags2 & FLAGS2_KEY_BEEP_ENABLE;
@@ -2995,7 +2991,7 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
         }
         else	// beep not enabled - display frequency in red
             clr = Orange;
-        sprintf(options, "   %uHz", (uint)ts.beep_frequency);	// casted to int because display errors if uint32_t
+        snprintf(options,32, "   %uHz", (uint)ts.beep_frequency);	// casted to int because display errors if uint32_t
         break;
     //
     case CONFIG_BEEP_VOLUME:	// beep loudness
@@ -3009,7 +3005,7 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
             AudioManagement_LoadBeepFreq();	// calculate new beep loudness values
             AudioManagement_KeyBeep();		// make beep to demonstrate loudness
         }
-        sprintf(options, "    %u", ts.beep_loudness);
+        snprintf(options,32, "    %u", ts.beep_loudness);
         break;
     //
     //
@@ -3064,7 +3060,7 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
         {
             UiDriverUpdateFrequency(true,UFM_AUTOMATIC);	// Update LO frequency without checking encoder but overriding "frequency didn't change" detect
         }
-        sprintf(options, "   %d", ts.freq_cal);
+        snprintf(options,32, "   %d", ts.freq_cal);
         break;
     //
     case CONFIG_FREQ_LIMIT_RELAX:	// Enable/disable Frequency tuning limits
@@ -3110,7 +3106,7 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
         }
         else		// Orange if not in RX and/or correct mode
             clr = Orange;
-        sprintf(options, "   %d", ts.rx_iq_lsb_gain_balance);
+        snprintf(options,32, "   %d", ts.rx_iq_lsb_gain_balance);
         break;
     case CONFIG_LSB_RX_IQ_PHASE_BAL:		// LSB RX IQ Phase balance
         if((ts.dmod_mode == DEMOD_LSB) && (ts.txrx_mode == TRX_MODE_RX))
@@ -3123,7 +3119,7 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
         }
         else		// Orange if not in RX and/or correct mode
             clr = Orange;
-        sprintf(options, "   %d", ts.rx_iq_lsb_phase_balance);
+        snprintf(options,32, "   %d", ts.rx_iq_lsb_phase_balance);
         break;
     case CONFIG_USB_RX_IQ_GAIN_BAL:		// USB/CW RX IQ Gain balance
         if(((ts.dmod_mode == DEMOD_USB) || (ts.dmod_mode == DEMOD_CW))  && (ts.txrx_mode == TRX_MODE_RX))
@@ -3138,7 +3134,7 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
         }
         else		// Orange if not in RX and/or correct mode
             clr = Orange;
-        sprintf(options, "   %d", ts.rx_iq_usb_gain_balance);
+        snprintf(options,32, "   %d", ts.rx_iq_usb_gain_balance);
         break;
     case CONFIG_USB_RX_IQ_PHASE_BAL:		// USB RX IQ Phase balance
         if(((ts.dmod_mode == DEMOD_USB)  || (ts.dmod_mode == DEMOD_CW)) && (ts.txrx_mode == TRX_MODE_RX))
@@ -3151,7 +3147,7 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
         }
         else		// Orange if not in RX and/or correct mode
             clr = Orange;
-        sprintf(options, "   %d", ts.rx_iq_usb_phase_balance);
+        snprintf(options,32, "   %d", ts.rx_iq_usb_phase_balance);
         break;
     case 	CONFIG_AM_RX_GAIN_BAL:		// AM RX IQ Phase balance
         if((ts.dmod_mode == DEMOD_AM)  && (ts.txrx_mode == TRX_MODE_RX))
@@ -3166,7 +3162,7 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
         }
         else		// Orange if not in RX and/or correct mode
             clr = Orange;
-        sprintf(options, "   %d", ts.rx_iq_am_gain_balance);
+        snprintf(options,32, "   %d", ts.rx_iq_am_gain_balance);
         break;
     case 	CONFIG_AM_RX_PHASE_BAL:		// AM RX IQ Phase balance
         if((ts.dmod_mode == DEMOD_AM)  && (ts.txrx_mode == TRX_MODE_RX))
@@ -3179,7 +3175,7 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
         }
         else		// Orange if not in RX and/or correct mode
             clr = Orange;
-        sprintf(options, "   %d", ts.rx_iq_am_phase_balance);
+        snprintf(options,32, "   %d", ts.rx_iq_am_phase_balance);
         break;
     case 	CONFIG_FM_RX_GAIN_BAL:		// FM RX IQ Phase balance
         if((ts.dmod_mode == DEMOD_FM)  && (ts.txrx_mode == TRX_MODE_RX))
@@ -3194,7 +3190,7 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
         }
         else		// Orange if not in RX and/or correct mode
             clr = Orange;
-        sprintf(options, "   %d", ts.rx_iq_fm_gain_balance);
+        snprintf(options,32, "   %d", ts.rx_iq_fm_gain_balance);
         break;
     case CONFIG_LSB_TX_IQ_GAIN_BAL:		// LSB TX IQ Gain balance
         if((ts.dmod_mode == DEMOD_LSB) && (ts.txrx_mode == TRX_MODE_TX))
@@ -3213,7 +3209,7 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
         {
             clr = Orange;
         }
-        sprintf(options, "   %d", ts.tx_iq_lsb_gain_balance);
+        snprintf(options,32, "   %d", ts.tx_iq_lsb_gain_balance);
         break;
     case CONFIG_LSB_TX_IQ_PHASE_BAL:		// LSB TX IQ Phase balance
         if((ts.dmod_mode == DEMOD_LSB) && (ts.txrx_mode == TRX_MODE_TX))
@@ -3226,7 +3222,7 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
         }
         else		// Orange if not in TX and/or correct mode
             clr = Orange;
-        sprintf(options, "   %d", ts.tx_iq_lsb_phase_balance);
+        snprintf(options,32, "   %d", ts.tx_iq_lsb_phase_balance);
         break;
     case CONFIG_USB_TX_IQ_GAIN_BAL:		// USB/CW TX IQ Gain balance
         if(((ts.dmod_mode == DEMOD_USB) || (ts.dmod_mode == DEMOD_CW)) && (ts.txrx_mode == TRX_MODE_TX))
@@ -3245,7 +3241,7 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
         {
             clr = Orange;
         }
-        sprintf(options, "   %d", ts.tx_iq_usb_gain_balance);
+        snprintf(options,32, "   %d", ts.tx_iq_usb_gain_balance);
         break;
     case CONFIG_USB_TX_IQ_PHASE_BAL:		// USB TX IQ Phase balance
         if((ts.dmod_mode == DEMOD_USB) && (ts.txrx_mode == TRX_MODE_TX))
@@ -3261,7 +3257,7 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
             clr = Orange;
         }
         //
-        sprintf(options, "   %d", ts.tx_iq_usb_phase_balance);
+        snprintf(options,32, "   %d", ts.tx_iq_usb_phase_balance);
         break;
     //
     case 	CONFIG_AM_TX_GAIN_BAL:		// AM TX IQ Phase balance
@@ -3281,7 +3277,7 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
         {
             clr = Orange;
         }
-        sprintf(options, "   %d", ts.tx_iq_am_gain_balance);
+        snprintf(options,32, "   %d", ts.tx_iq_am_gain_balance);
         break;
     case 	CONFIG_FM_TX_GAIN_BAL:		// FM TX IQ Phase balance
         if((ts.dmod_mode == DEMOD_FM)  && (ts.txrx_mode == TRX_MODE_TX))
@@ -3300,7 +3296,7 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
         {
             clr = Orange;
         }
-        sprintf(options, "   %d", ts.tx_iq_fm_gain_balance);
+        snprintf(options,32, "   %d", ts.tx_iq_fm_gain_balance);
         break;
     case CONFIG_CW_PA_BIAS:		// CW PA Bias adjust
         if((ts.tune) || (ts.txrx_mode == TRX_MODE_TX))	 	// enable only in TUNE mode
@@ -3324,7 +3320,7 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
         {
             clr = Orange;
         }
-        sprintf(options, "  %u", ts.pa_cw_bias);
+        snprintf(options,32, "  %u", ts.pa_cw_bias);
         break;
     case CONFIG_PA_BIAS:		// PA Bias adjust (Including CW if CW bias == 0)
         if((ts.tune) || (ts.txrx_mode == TRX_MODE_TX))	 	// enable only in TUNE mode
@@ -3348,7 +3344,7 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
         {
             clr = Orange;
         }
-        sprintf(options, "  %u", ts.pa_bias);
+        snprintf(options,32, "  %u", ts.pa_bias);
         break;
     case CONFIG_FWD_REV_PWR_DISP:	// Enable/disable swap of FWD/REV A/D inputs on power sensor
         temp_var = swrm.pwr_meter_disp;
@@ -3372,7 +3368,7 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
         {
             clr = Orange;		// make it red to indicate that adjustment is NOT available
         }
-        sprintf(options, "  %u", swrm.sensor_null);
+        snprintf(options,32, "  %u", swrm.sensor_null);
         break;
     case CONFIG_FWD_REV_COUPLING_2200M_ADJ:		// RF power sensor coupling adjust (2200m)
         UiDriverMenuBandRevCouplingAdjust(var, mode, COUPLING_2200M, options, &clr);
@@ -3439,12 +3435,12 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
         //
         if(ts.xverter_mode)
         {
-            sprintf(options, " ON x%u", ts.xverter_mode);	// Display on/multiplication factor
+            snprintf(options,32, " ON x%u", ts.xverter_mode);	// Display on/multiplication factor
             clr = Red;
         }
         else
         {
-            strcpy(options, "    OFF");
+            txt_ptr = "    OFF";
         }
         break;
     case CONFIG_XVTR_FREQUENCY_OFFSET:		// Adjust transverter Frequency offset
@@ -3488,7 +3484,7 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
             clr = Red;		// make number red to alert user of this!
         }
 
-        sprintf(options, " %9uHz", (uint)ts.xverter_offset);	// print with nine digits
+        snprintf(options,32, " %9uHz", (uint)ts.xverter_offset);	// print with nine digits
         break;
 
 
@@ -3625,7 +3621,7 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
             clr = Orange;
         if(ts.dsp_nr_numtaps >= ts.dsp_nr_delaybuf_len)	// Warn if number of taps greater than/equal buffer length!
             clr = Red;
-        sprintf(options, "  %u", (uint)ts.dsp_nr_delaybuf_len);
+        snprintf(options,32, "  %u", (uint)ts.dsp_nr_delaybuf_len);
         break;
     case CONFIG_DSP_NR_FFT_NUMTAPS:		// Adjustment of DSP noise reduction de-correlation delay buffer length
         ts.dsp_nr_numtaps &= 0xf0;	// mask bottom nybble to enforce 16-count boundary
@@ -3647,7 +3643,7 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
             clr = Orange;
         if(ts.dsp_nr_numtaps >= ts.dsp_nr_delaybuf_len)	// Warn if number of taps greater than/equal buffer length!
             clr = Red;
-        sprintf(options, "  %u", ts.dsp_nr_numtaps);
+        snprintf(options,32, "  %u", ts.dsp_nr_numtaps);
         break;
     case CONFIG_DSP_NR_POST_AGC_SELECT:		// selection of location of DSP noise reduction - pre audio filter/AGC or post AGC/filter
         temp_var = ts.dsp_active & DSP_NR_POSTAGC_ENABLE;
@@ -3690,7 +3686,7 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
         {
             clr = Orange;
         }
-        sprintf(options, "  %u", ts.dsp_notch_mu);
+        snprintf(options,32, "  %u", ts.dsp_notch_mu);
         break;
     case CONFIG_DSP_NOTCH_DECORRELATOR_BUFFER_LENGTH:		// Adjustment of DSP noise reduction de-correlation delay buffer length
         tchange = UiDriverMenuItemChangeUInt8(var, mode, &ts.dsp_notch_delaybuf_len,
@@ -3719,7 +3715,7 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
         {
             clr = Red;
         }
-        sprintf(options, "  %u", (uint)ts.dsp_notch_delaybuf_len);
+        snprintf(options,32, "  %u", (uint)ts.dsp_notch_delaybuf_len);
         break;
     case CONFIG_DSP_NOTCH_FFT_NUMTAPS:		// Adjustment of DSP noise reduction de-correlation delay buffer length
         ts.dsp_notch_numtaps &= 0xf0;	// mask bottom nybble to enforce 16-count boundary
@@ -3745,7 +3741,7 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
         {
             clr = Red;
         }
-        sprintf(options, "  %u", ts.dsp_notch_numtaps);
+        snprintf(options,32, "  %u", ts.dsp_notch_numtaps);
         break;
     case CONFIG_AGC_TIME_CONSTANT:		// Adjustment of Noise Blanker AGC Time Constant
         tchange = UiDriverMenuItemChangeUInt8(var, mode, &ts.nb_agc_time_const,
@@ -3758,7 +3754,7 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
             AudioManagement_CalcNB_AGC();	// yes - recalculate new values for Noise Blanker AGC
         }
 
-        sprintf(options, "  %u", ts.nb_agc_time_const);
+        snprintf(options,32, "  %u", ts.nb_agc_time_const);
         break;
     case CONFIG_AM_TX_FILTER_DISABLE:	// Enable/disable AM TX audio filter
         temp_var = ts.flags1 & FLAGS1_AM_TX_FILTER_DISABLE;
@@ -3897,7 +3893,7 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
             if(var>=1)
             {
                 // clear EEPROM
-                UiMenu_DisplayValue("Working",Red,opt_pos);
+                UiMenu_DisplayValue("Working",Red,pos);
                 SerialEEPROM_Clear();
                 Si570_ResetConfiguration();		// restore SI570 to factory default
                 *(__IO uint32_t*)(SRAM2_BASE) = 0x55;
@@ -3958,18 +3954,17 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
         }
         break;
     default:						// Move to this location if we get to the bottom of the table!
-        strcpy(options, "ERROR!");
-        opt_pos = 5;
+        txt_ptr = "ERROR!";
         break;
     }
     if (txt_ptr == NULL)
     {
         txt_ptr = options;
     }
-    UiMenu_DisplayValue(txt_ptr,clr,opt_pos);
+    UiMenu_DisplayValue(txt_ptr,clr,pos);
     if(mode == MENU_PROCESS_VALUE_CHANGE)	 	// Shifted over
     {
-        UiMenu_MoveCursor(opt_pos);
+        UiMenu_MoveCursor(pos);
     }
     return;
 }

--- a/mchf-eclipse/misc/serial_eeprom.c
+++ b/mchf-eclipse/misc/serial_eeprom.c
@@ -128,7 +128,7 @@ const SerialEEPROM_EEPROMTypeDescriptor SerialEEPROM_eepromTypeDescs[SERIAL_EEPR
         // 15
         {
                 .size = 32*1024,
-                .supported = false,
+                .supported = true,
                 .pagesize = 64,
                 .name = "24xx256/32K"
         },


### PR DESCRIPTION
Changed cleanup approach  for CAT buffer to use  a timeout.
The 24C256 EEPROM is now being usable for data storage (again).
Most changes just clean up small things. 
