### PR TITLE
(Partially) concentrated generation of Hardware/System related inform…

### DIFF
--- a/mchf-eclipse/drivers/ui/oscillator/ui_si570.c
+++ b/mchf-eclipse/drivers/ui/oscillator/ui_si570.c
@@ -582,6 +582,7 @@ uchar Si570_ResetConfiguration()
 
     // Reset publics
     os.fxtal        = FACTORY_FXTAL;
+    os.present = false;
 
     res = mchf_hw_i2c_WriteRegister(os.si570_address, SI570_REG_135, SI570_RECALL);
     if(res != 0)
@@ -637,6 +638,7 @@ uchar Si570_ResetConfiguration()
     os.cur_config.hsdiv = hsdiv_curr;
     os.cur_config.fdco = Si570_GetFDCOForFreq(os.fout,n1_curr,hsdiv_curr);
 
+    os.present = true;
     return 0;
 }
 

--- a/mchf-eclipse/drivers/ui/oscillator/ui_si570.h
+++ b/mchf-eclipse/drivers/ui/oscillator/ui_si570.h
@@ -37,7 +37,11 @@ typedef struct OscillatorState
 
     uint8_t				base_reg;
 
+    bool                present; // is a working Si570 present?
 } OscillatorState;
+
+extern __IO OscillatorState os;
+
 
 
 typedef enum
@@ -66,5 +70,8 @@ uint8_t Si570_GeTI2CAddress();
 
 uchar   Si570_InitExternalTempSensor();
 uchar   Si570_ReadExternalTempSensor(int *temp);
+
+inline bool   Si570_IsPresent() { return os.present == true; }
+
 
 #endif

--- a/mchf-eclipse/drivers/ui/ui_menu.h
+++ b/mchf-eclipse/drivers/ui/ui_menu.h
@@ -37,6 +37,26 @@ void UiMenu_RenderFirstScreen();
 bool UiMenu_RenderNextScreen(); // returns true if screen was changed, i.e. not last screen
 bool UiMenu_RenderPrevScreen(); // returns true if screen was changed, i.e. not first screen
 
+
+enum MENU_INFO_ITEM
+{
+    INFO_EEPROM,
+    INFO_DISPLAY,
+    INFO_DISPLAY_CTRL,
+    INFO_SI570,
+    INFO_TP,
+    INFO_RFMOD,
+    INFO_VHFUHFMOD,
+    INFO_CPU,
+    INFO_FLASH,
+    INFO_RAM,
+    INFO_FW_VERSION,
+    INFO_BL_VERSION,
+    INFO_BUILD,
+};
+
+const char* UiMenu_GetSystemInfo(uint32_t* m_clr_ptr, int info_item);
+
 //
 #define	MENUSIZE	6				// number of menu items per page/screen
 //

--- a/mchf-eclipse/misc/serial_eeprom.c
+++ b/mchf-eclipse/misc/serial_eeprom.c
@@ -74,91 +74,91 @@ const SerialEEPROM_EEPROMTypeDescriptor SerialEEPROM_eepromTypeDescs[SERIAL_EEPR
                 .size = 128,
                 .supported = false,
                 .pagesize = 8,
-                .name = "24xx01/128B"
+                .name = "24xx01"
         },
         // 8
         {
                 .size = 256,
                 .supported = false,
                 .pagesize = 8,
-                .name = "24xx02/256B"
+                .name = "24xx02"
         },
         // 9
         {
                 .size = 2*256,
                 .supported = false,
                 .pagesize = 16,
-                .name = "24xx04/512B"
+                .name = "24xx04"
         },
         // 10
         {
                 .size = 1*1024,
                 .supported = false,
                 .pagesize = 16,
-                .name = "24xx08/1K"
+                .name = "24xx08"
         },
         // 11
         {
                 .size = 2*1024,
                 .supported = false,
                 .pagesize = 16,
-                .name = "24xx16/2K"
+                .name = "24xx16"
         },
         // 12
         {
                 .size = 4*1024,
                 .supported = false,
                 .pagesize = 32,
-                .name = "24xx32/4K"
+                .name = "24xx32"
         },
         // 13
         {
                 .size = 8*1024,
                 .supported = false,
                 .pagesize = 32,
-                .name = "24xx64/8K"
+                .name = "24xx64"
         },
         // 14
         {
                 .size = 16*1024,
                 .supported = false,
                 .pagesize = 64,
-                .name = "24xx128/16K"
+                .name = "24xx128"
         },
         // 15
         {
                 .size = 32*1024,
                 .supported = true,
                 .pagesize = 64,
-                .name = "24xx256/32K"
+                .name = "24xx256"
         },
         // 16
         {
                 .size = 64*1024,
                 .supported = true,
                 .pagesize = 128,
-                .name = "24xx512/64K"
+                .name = "24xx512"
         },
         // 17
         {
                 .size = 128*1024,
                 .supported = true,
                 .pagesize = 128,
-                .name = "24xx1025/64K"
+                .name = "24xx1025"
         },
         // 18
         {
                 .size = 128 * 1024,
                 .supported = true,
                 .pagesize = 128,
-                .name = "24xx1026/128K"
+                .name = "24xx1026"
         },
         // 19
         {
                 .size = 256*1024,
                 .supported = true,
                 .pagesize = 256,
-                .name = "24CM02/256K"
+                .name = "24CM02"
         }
 
 };


### PR DESCRIPTION
…ation

in single place. Splash screen and HW Info menu now mostly use same function
to generate info strings.

Added a presence detected flag (and query function) for the local oscillator.
Right now just used in the info code, i.e. mcHF still tries to talk to
a non-existing Si570 during  its operation. However, at least splash screen and HW Info menu
now report that the Si570 has not been detected.

Also added a calculation of I2C eeprom size info string (move away from hardcoded strings here).
