### PR TITLE
snprintf does not seem to handle too long strings correctly. 

### DIFF
--- a/mchf-eclipse/drivers/ui/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/ui_menu.c
@@ -1310,7 +1310,7 @@ static const char* display_types[] = {
  */
 const char* UiMenu_GetSystemInfo(uint32_t* m_clr_ptr, int info_item)
 {
-    static char out[40];
+    static char out[48];
     const char* outs = NULL;
     *m_clr_ptr = White;
 
@@ -1398,7 +1398,7 @@ const char* UiMenu_GetSystemInfo(uint32_t* m_clr_ptr, int info_item)
             i2c_size = SerialEEPROM_eepromTypeDescs[ts.ser_eeprom_type].size;
             i2c_size_unit = "B";
         }
-        snprintf(out,32,"%x %s/%u%s%s",ts.ser_eeprom_type, SerialEEPROM_eepromTypeDescs[ts.ser_eeprom_type].name, i2c_size, i2c_size_unit, label);
+        snprintf(out,48,"%x %s/%u%s%s",ts.ser_eeprom_type, SerialEEPROM_eepromTypeDescs[ts.ser_eeprom_type].name, i2c_size, i2c_size_unit, label);
     }
     break;
     case INFO_BL_VERSION:
@@ -1426,7 +1426,7 @@ const char* UiMenu_GetSystemInfo(uint32_t* m_clr_ptr, int info_item)
     break;
     case INFO_BUILD:
     {
-        snprintf(out,32,"%s - %s",__DATE__,__TIME__);
+        outs  = __DATE__ " - " __TIME__;
     }
     break;
     default:

--- a/mchf-eclipse/hardware/mchf_board.h
+++ b/mchf-eclipse/hardware/mchf_board.h
@@ -1130,6 +1130,7 @@ typedef struct TransceiverState
 
 #define EEPROM_SER_NONE 0
 #define EEPROM_SER_WRONG_SIG 1
+#define EEPROM_SER_UNKNOWN 2
     uchar	ser_eeprom_type;			// serial eeprom type
 
 #define SER_EEPROM_IN_USE_I2C         0x00

--- a/mchf-eclipse/misc/serial_eeprom.c
+++ b/mchf-eclipse/misc/serial_eeprom.c
@@ -39,7 +39,7 @@ const SerialEEPROM_EEPROMTypeDescriptor SerialEEPROM_eepromTypeDescs[SERIAL_EEPR
                 .size = 0,
                 .supported = false,
                 .pagesize = 0,
-                .name = "Not used"
+                .name = "Unknown Type"
         },
         // 3
         {
@@ -339,7 +339,7 @@ uint16_t SerialEEPROM_24Cxx_WriteBulk(uint32_t Addr, uint8_t *buffer, uint16_t l
 
 uint8_t SerialEEPROM_24Cxx_Detect() {
 
-    uint8_t ser_eeprom_type = 0xFF;
+    uint8_t ser_eeprom_type = EEPROM_SER_UNKNOWN;
 
     // serial EEPROM init
     //  Write_24Cxx(0,0xFF,16);     //enable to reset EEPROM and force new copyvirt2ser
@@ -452,6 +452,11 @@ uint8_t SerialEEPROM_24Cxx_Detect() {
                 }
             }
         }
+    }
+    // just to be save. Never ever deliver a type id outside the array boundaries.
+    if (ser_eeprom_type >= SERIAL_EEPROM_DESC_NUM)
+    {
+        ser_eeprom_type = EEPROM_SER_UNKNOWN;
     }
     return ser_eeprom_type;
 }


### PR DESCRIPTION
Increased string length. Did not test, but it is my only hunch after briefly looking at the vsnprinft code.
Just try and  see if it does not crash the Sys Info Menu,  since with certain messages we did break the 32 character size limit.
