### PR TITLE
Hilbert TX filters changed to 0/90 degrees

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_filter.c
+++ b/mchf-eclipse/drivers/audio/audio_filter.c
@@ -988,10 +988,10 @@ void AudioFilter_InitTxHilbertFIR(void)
     //
     if(ts.tx_filter == TX_FILTER_WIDE_BASS || ts.tx_filter == TX_FILTER_WIDE_TREBLE)
     {
-        fc.tx_q_num_taps = 201;
-        fc.tx_i_num_taps = 201;
+        fc.tx_q_num_taps = Q_TX_NUM_TAPS;
+        fc.tx_i_num_taps = Q_TX_NUM_TAPS;
 
-        for(i = 0; i < 201;i++) //Q_TX_NUM_TAPS; i++)
+        for(i = 0; i < Q_TX_NUM_TAPS;i++)
             {
                 fc.tx_filt_q[i] = q_tx_wide_coeffs[i];
                 fc.tx_filt_i[i] = i_tx_wide_coeffs[i];

--- a/mchf-eclipse/drivers/audio/filters/i_tx_filter.h
+++ b/mchf-eclipse/drivers/audio/filters/i_tx_filter.h
@@ -30,7 +30,7 @@
      * -6dB @ 363, 3000 Hz
      *
      * 20140926 by KA7OEI using Iowa Hills Hilbert Filter Designer
-
+*/
 
 const float i_tx_coeffs[I_NUM_TAPS] =
 {
@@ -124,14 +124,15 @@ const float i_tx_coeffs[I_NUM_TAPS] =
     -0.00154698180275285,
     -0.0013696339
 };
-*/
+
 // trial with 0 degrees!!!
 // phase added, 48000 sampling frequency
 // Fc=1.50kHz, BW=2.70kHz
 // Kaiser, Beta = 3.650, Raised Cosine 0.910
 // Iowa Hills Hilbert Filter Designer Version 3.0
 // DD4WH, 2016_07_24
-const float i_tx_coeffs[I_NUM_TAPS] =
+//const float i_tx_coeffs[I_NUM_TAPS] =
+		const float i_tx_wide_coeffs[I_NUM_TAPS] =
 {
 
 		-0.000675829974580901,
@@ -224,7 +225,7 @@ const float i_tx_coeffs[I_NUM_TAPS] =
 		-0.000775321733206627,
 		-0.000675829974580823
 };
-
+/*
 // trial with +45 degrees!!!
 // phase added, 48000 sampling frequency
 // Fc=1.50kHz, BW=2.70kHz
@@ -436,7 +437,7 @@ const float i_tx_wide_coeffs[201] =
 		-0.000206699262770281
 };
 
-
+*/
 /*
 //
 // 0 degrees

--- a/mchf-eclipse/drivers/audio/filters/q_tx_filter.h
+++ b/mchf-eclipse/drivers/audio/filters/q_tx_filter.h
@@ -33,7 +33,7 @@
 //
 // -90.00 degrees
 //
-
+*/
 const float q_tx_coeffs[Q_NUM_TAPS] =
 {
     0.000350654345247197,
@@ -126,7 +126,7 @@ const float q_tx_coeffs[Q_NUM_TAPS] =
     -0.000048495992345297,
     -0.0003506543
 };
-*/
+
 
 // -90 degrees - just for comparison!
 // phase added, 48000 sampling frequency
@@ -134,7 +134,8 @@ const float q_tx_coeffs[Q_NUM_TAPS] =
 // Kaiser, Beta = 3.650, Raised Cosine 0.910
 // Iowa Hills Hilbert Filter Designer Version 3.0
 // DD4WH, 2016_07_24
-const float q_tx_coeffs[Q_NUM_TAPS] =
+//const float q_tx_coeffs[Q_NUM_TAPS] =
+		const float q_tx_wide_coeffs[Q_NUM_TAPS] =
 {
 
 		-0.000665402252765227,
@@ -231,7 +232,7 @@ const float q_tx_coeffs[Q_NUM_TAPS] =
 };
 
 
-
+/*
 //-45 degrees
 // phase added, 48000 sampling frequency
 // Fc=1.50kHz, BW=2.70kHz
@@ -444,7 +445,7 @@ const float q_tx_wide_coeffs[201] =
 
 
 };
-
+*/
 /*
 //
 // -90 degrees


### PR DESCRIPTION
- Hilbert TX filters with +45/-45 degrees had exactly the same sideband suppression for low audio frequencies than 0/-90 degrees filter pair
- Hilberts with 201 taps instead of 89 taps for TX filtering had much more sideband suppression for low audio frequencies
- Hilbert TX filters with +45/-45 degrees produced many spurs when in TUNE mode, therefore not usable, we will stick to 0/-90 degrees
- Hilbert filters still in a preliminary state, will be expanded/fixed later
