### PR TITLE
Added RAM size detection code to startup code. Fixed EEPROM detection regression

### DIFF
--- a/mchf-eclipse/cmsis_boot/startup/startup_stm32f4xx.c
+++ b/mchf-eclipse/cmsis_boot/startup/startup_stm32f4xx.c
@@ -268,10 +268,14 @@ void (* const g_pfnVectors[])(void) =
   * @param  None
   * @retval None
   */
+
+unsigned int mchf_board_get_ramsize();
+
 void Default_Reset_Handler(void)
 {
 //      __asm volatile ("MSR msp, %0\n" : : "r" ((void (*)(void))((unsigned long)pulStack + sizeof(pulStack))) );
     __asm volatile ("MSR msp, %0\n" : : "r" ((void (*)(void))((unsigned long)&__stack - 2*sizeof(void*))));
+
 
     /* Initialize data and bss */
     unsigned long *pulSrc, *pulDest;
@@ -315,7 +319,15 @@ void Default_Reset_Handler(void)
           "  STR R1, [R0]");
 #endif
 
+
+
     SystemInit();
+
+    // if we have more ram than 192k, we move the stackpointer 64k up
+    if (mchf_board_get_ramsize() >= 256) {
+        __asm volatile ("MSR msp, %0\n" : : "r" ((void (*)(void))((unsigned long)&__stack - 2*sizeof(void*) + 64*1024)));
+    }
+
 
     /* Call the application's entry point.*/
     main();

--- a/mchf-eclipse/hardware/mchf_board.h
+++ b/mchf-eclipse/hardware/mchf_board.h
@@ -1248,6 +1248,7 @@ inline bool mchf_dit_line_pressed() {
     return  !GPIO_ReadInputDataBit(PADDLE_DIT_PIO,PADDLE_DIT);
 }
 
+unsigned int mchf_board_get_ramsize();
 void mchf_board_detect_ramsize();
 
 // in main.c

--- a/mchf-eclipse/misc/serial_eeprom.c
+++ b/mchf-eclipse/misc/serial_eeprom.c
@@ -390,16 +390,23 @@ uint8_t SerialEEPROM_24Cxx_Detect() {
             }
             else
             {
-                // 16 bit addressing
+                // 16 bit addressing check
+                // the other banks are mapped to different I2C
+                // device addresses. We simply try to read from them
+                // and if it succeeds we know the device type
+                // We need to check unique addresses for each EEPROM type
+                // 0xA0 + 0xA8
                 if(SerialEEPROM_24Cxx_Read(0x10000,17) < 0x100)
                 {
                     ser_eeprom_type = 17;            // 24LC1025
                 }
+                // 0xA0 + 0x1000: 0xA2
                 if(SerialEEPROM_24Cxx_Read(0x10000,18) < 0x100)
                 {
                     ser_eeprom_type = 18;            // 24LC1026
                 }
-                if(SerialEEPROM_24Cxx_Read(0x10000,19) < 0x100)
+                // 0xA0 + 0x1000: 0xA2 + 0x2000: 0xA4 + 0x3000: 0xA6
+                if(SerialEEPROM_24Cxx_Read(0x20000,19) < 0x100)
                 {
                     ser_eeprom_type = 19;            // 24CM02
                 }


### PR DESCRIPTION
Added RAM size detection code to startup code. Now stackpointer
is moved according to RAM size available. This will increase available
heap space (usable for malloc/free). All statically allocated memory
data structures will still have to fit into the "standard" 192 kByte memory map.
This ensures software will start and run on all machines.
It also requires careful use of malloc/free, since on 192 kByte machines
64k less memory is available compared to 256k Machines.

Removed regression in EEPROM testing due to overlap of tested I2C addresses.
24xx1026 were detected as 24CM02 due to I2C Address 0xA2 being supported
by both types of EEPROMS.
