### PR TITLE
 	TX filter now with three options, Hilbert 201 taps as standard filter

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -2927,7 +2927,9 @@ static void audio_tx_processor(int16_t *src, int16_t *dst, int16_t size)
             // and then a gradual roll-off toward the high end.  The net result is a very flat (to better than 1dB) response
             // over the 275-2500 Hz range.
             //
-            if(is_ssb_tx_filter_enabled())	// Do the audio filtering *IF* it is enabled
+            //            if(is_ssb_tx_filter_enabled())	// Do the audio filtering *IF* it is enabled
+            // FIXME: quick & dirty: TX IIR filter cannot be disabled anymore
+            if(1)	// Do the audio filtering *IF* it is enabled
             {
                 arm_iir_lattice_f32(&IIR_TXFilter, (float *)ads.a_buffer, (float *)ads.a_buffer, size/2);
             }

--- a/mchf-eclipse/drivers/audio/audio_filter.c
+++ b/mchf-eclipse/drivers/audio/audio_filter.c
@@ -984,7 +984,9 @@ void AudioFilter_InitTxHilbertFIR(void)
 
     IQ_FilterDescriptor iq_tx_filter =
             (ts.tx_filter == TX_FILTER_WIDE_BASS ||
-             ts.tx_filter == TX_FILTER_WIDE_TREBLE) ? iq_tx_wide:iq_tx_narrow;
+            		//             ts.tx_filter == TX_FILTER_WIDE_TREBLE) ? iq_tx_wide:iq_tx_narrow;
+            		// FIXME: dirty trial: always use the "wide" 201 tap Hilbert filter
+             ts.tx_filter == TX_FILTER_WIDE_TREBLE) ? iq_tx_wide:iq_tx_wide;
 
 
     fc.tx_q_num_taps = iq_tx_filter.num_taps;

--- a/mchf-eclipse/drivers/audio/filters/iq_tx_filter.c
+++ b/mchf-eclipse/drivers/audio/filters/iq_tx_filter.c
@@ -417,7 +417,7 @@ const IQ_FilterDescriptor iq_tx_narrow =
 };
 #endif
 
-#if 1
+#if 0
 // trial with +/-45 degrees!!!
 // phase added, 48000 sampling frequency
 // Fc=1.50kHz, BW=2.70kHz

--- a/mchf-eclipse/drivers/ui/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/ui_menu.c
@@ -3864,7 +3864,8 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
 */
     case CONFIG_SSB_TX_FILTER:	// Type of SSB TX audio filter
         tchange = UiDriverMenuItemChangeUInt8(var, mode, &ts.tx_filter,
-                                              0,
+//                0,
+                1,
                                               TX_FILTER_WIDE_TREBLE,
                                               TX_FILTER_NARROW,
                                               1


### PR DESCRIPTION
For TX filters WIDE the mirror suppression did not work at all, now it works with about -70dBc.
SSB TX Audio Filter changed:
NARROW: Hilbert 201 taps & IIR 260-2800Hz
WIDE BASS: Hilbert 201 taps & IIR 50-2750Hz
WIDE TREBLE: Hilbert 201 taps & 150-2850Hz
TX IIR Filter cannot be disabled anymore, because that lead to too many spurs
