### PR TITLE
bass & treble adjustment for SSB TX

### DIFF
--- a/mchf-eclipse/drivers/ui/ui_configuration.c
+++ b/mchf-eclipse/drivers/ui/ui_configuration.c
@@ -154,8 +154,8 @@ const ConfigEntryDescriptor ConfigEntryInfo[] =
 	{ ConfigEntry_Int32_16, EEPROM_BASS_GAIN,&ts.bass_gain,2,-20,20},
     { ConfigEntry_Int32_16, EEPROM_TREBLE_GAIN,&ts.treble_gain,0,-20,20},
     { ConfigEntry_UInt8, EEPROM_TX_FILTER,&ts.tx_filter,0,0,TX_FILTER_WIDE_TREBLE},
-//	{ ConfigEntry_Int32_16, EEPROM_TX_BASS_GAIN,&ts.tx_bass_gain,4,-20,5},
-//  { ConfigEntry_Int32_16, EEPROM_TX_TREBLE_GAIN,&ts.tx_treble_gain,4,-20,5},
+	{ ConfigEntry_Int32_16, EEPROM_TX_BASS_GAIN,&ts.tx_bass_gain,4,-20,6},
+    { ConfigEntry_Int32_16, EEPROM_TX_TREBLE_GAIN,&ts.tx_treble_gain,4,-20,6},
 
 	UI_C_EEPROM_BAND_5W_PF( 0,80,m)
     UI_C_EEPROM_BAND_5W_PF(1,60,m)

--- a/mchf-eclipse/drivers/ui/ui_configuration.h
+++ b/mchf-eclipse/drivers/ui/ui_configuration.h
@@ -513,7 +513,9 @@ uint16_t    UiConfiguration_SaveEepromValues(void);
 #define EEPROM_TREBLE_GAIN				361		// treble gain highShelf filter
 #define	EEPROM_S_METER					362		// S-Meter configuration
 #define EEPROM_TX_FILTER				363		// TX_Filter configuration
-#define EEPROM_FIRST_UNUSED 			364  // change this if new value ids are introduced
+#define EEPROM_TX_BASS_GAIN				364		// TX bass gain lowShelf filter
+#define EEPROM_TX_TREBLE_GAIN			365		// TX treble gain highShelf filter
+#define EEPROM_FIRST_UNUSED 			366  // change this if new value ids are introduced
 
 #define MAX_VAR_ADDR (EEPROM_FIRST_UNUSED - 1)
 

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -4953,7 +4953,18 @@ static void UiDriverChangeEncoderTwoMode(bool just_display_no_change)
 
         if(just_display_no_change == false)
         {
-            ts.enc_two_mode++;
+    		//
+        	ts.enc_two_mode++;
+            // take care of TX case
+        	if(ts.txrx_mode == TRX_MODE_TX && ts.enc_two_mode < ENC_TWO_MODE_TX_BASS_GAIN) {
+        		ts.enc_two_mode = ENC_TWO_MODE_TX_BASS_GAIN;
+        	}
+        	// if in RX mode
+        	if(ts.txrx_mode == TRX_MODE_RX && (ts.enc_two_mode == ENC_TWO_MODE_TX_BASS_GAIN || ts.enc_two_mode == ENC_TWO_MODE_TX_TREBLE_GAIN)) {
+        		ts.enc_two_mode = ENC_TWO_NUM_MODES;
+        	}
+
+
             // only switch to notch frequency adjustment, if notch enabled!
             if(ts.enc_two_mode == ENC_TWO_MODE_NOTCH_F && is_dsp_mnotch() == false)
             {
@@ -4965,6 +4976,7 @@ static void UiDriverChangeEncoderTwoMode(bool just_display_no_change)
             {
                 ts.enc_two_mode++;
             }
+
             // flip round
             if(ts.enc_two_mode >= ENC_TWO_NUM_MODES)
             {
@@ -5000,6 +5012,14 @@ static void UiDriverChangeEncoderTwoMode(bool just_display_no_change)
         UiDriver_DisplayDSPMode(0);
         UiDriver_DisplayTone(1*inactive_mult);
         break;
+    case ENC_TWO_MODE_TX_BASS_GAIN:
+        UiDriver_DisplayDSPMode(0);
+        UiDriver_DisplayTone(1*inactive_mult);
+    	break;
+    case ENC_TWO_MODE_TX_TREBLE_GAIN:
+        UiDriver_DisplayDSPMode(0);
+        UiDriver_DisplayTone(1*inactive_mult);
+    	break;
     default:
         UiDriver_DisplayRfGain(0);
         UiDriver_DisplayNoiseBlanker(0);
@@ -5434,7 +5454,7 @@ static void UiDriver_DisplayTone(bool encoder_active)
 
     // UiLcdHy28_DrawFullRect(POS_AG_IND_X, POS_AG_IND_Y + NOTCH_DELTA_Y, 16 + 12 , 112, Black);
 
-    bool enable = (ts.enc_two_mode == ENC_TWO_MODE_BASS_GAIN);
+    bool enable = (ts.enc_two_mode == ENC_TWO_MODE_BASS_GAIN || ts.enc_two_mode == ENC_TWO_MODE_TX_BASS_GAIN);
     char temp[5];
     if(ts.txrx_mode == TRX_MODE_TX) // if in TX_mode, display TX bass gain instead of RX_bass gain!
     {


### PR DESCRIPTION
Bass & treble shelf filters for SSB TX implemented. 6 to -20dB adjustable.
During TX press M2 and then adjust bass & treble.
Adjusted values are saved in EEPROM (independent of the values for bass & treble gain in Rx)
Please test and report!
