### PR TITLE
Allow noise blanker when in AM mode and with wide filters

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -1072,7 +1072,8 @@ static void audio_rx_noise_blanker(int16_t *src, int16_t size)
     static float	nb_agc = 0;
 
     if((ts.nb_setting > 0) &&  (ts.dsp_active & DSP_NB_ENABLE)
-        && (ts.dmod_mode != DEMOD_AM && ts.dmod_mode != DEMOD_FM)
+//            && (ts.dmod_mode != DEMOD_AM && ts.dmod_mode != DEMOD_FM)
+	        && (ts.dmod_mode != DEMOD_FM)
         && (FilterPathInfo[ts.filter_path].sample_rate_dec != RX_DECIMATION_RATE_24KHZ ))
         // bail out if noise blanker disabled, in AM/FM mode, or set to 10 kHz
     {

--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -1073,9 +1073,10 @@ static void audio_rx_noise_blanker(int16_t *src, int16_t size)
 
     if((ts.nb_setting > 0) &&  (ts.dsp_active & DSP_NB_ENABLE)
 //            && (ts.dmod_mode != DEMOD_AM && ts.dmod_mode != DEMOD_FM)
-	        && (ts.dmod_mode != DEMOD_FM)
-        && (FilterPathInfo[ts.filter_path].sample_rate_dec != RX_DECIMATION_RATE_24KHZ ))
-        // bail out if noise blanker disabled, in AM/FM mode, or set to 10 kHz
+	        && (ts.dmod_mode != DEMOD_FM))
+//        && (FilterPathInfo[ts.filter_path].sample_rate_dec != RX_DECIMATION_RATE_24KHZ ))
+
+			// bail out if noise blanker disabled, in AM/FM mode, or set to 10 kHz
     {
 
         nb_short_setting = (float)ts.nb_setting;		// convert and rescale NB1 setting for higher resolution in adjustment


### PR DESCRIPTION
Noise blanker can now be activated when using AM demod_mode or when using wide filters with decimation rate of 24kHz. I think we have the processing power to allow this, if it causes problems, we can easily switch this back off again.
