### PR TITLE
audio_driver.c 	Replaced numerous uses of size/2

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.h
+++ b/mchf-eclipse/drivers/audio/audio_driver.h
@@ -72,10 +72,10 @@ typedef struct AudioDriverState
 
     float32_t 					b_buffer[(IQ_BUFSZ*2)+1];	// this is larger since we need interleaved data for magnitude calculation in AM demod and thus, twice as much space
 
-    float32_t					c_buffer[IQ_BUFSZ+1];
-    float32_t					d_buffer[IQ_BUFSZ+1]; // only used in one place ( translate )
-    float32_t					e_buffer[IQ_BUFSZ+1]; // only used in briefly used in two places rx_proc / tx_proc
-    float32_t					f_buffer[IQ_BUFSZ+1]; // only used in briefly used in two places rx_proc / tx_proc
+    float32_t					c_buffer[IQ_BUFSZ+1]; // only used in two places ( audio_rx_freq_conv and audio_demod_fm )
+    float32_t					d_buffer[IQ_BUFSZ+1]; // only used in two places ( audio_rx_freq_conv and audio_demod_fm )
+    float32_t					e_buffer[IQ_BUFSZ+1]; // only used in three places audio_rx_freq_conv / rx_proc / tx_proc
+    float32_t					f_buffer[IQ_BUFSZ+1]; // only used in three places audio_rx_freq_conv / rx_proc / tx_proc
     //
     float32_t					Osc_I_buffer[IQ_BUFSZ+1];
     float32_t					Osc_Q_buffer[IQ_BUFSZ+1];

--- a/mchf-eclipse/drivers/audio/codec/i2s.c
+++ b/mchf-eclipse/drivers/audio/codec/i2s.c
@@ -97,8 +97,8 @@ void I2S_Block_Init(void)
     DMA_InitStructure2.DMA_Mode = DMA_Mode_Circular;
     DMA_InitStructure2.DMA_Priority = DMA_Priority_High;
     DMA_InitStructure2.DMA_FIFOMode = DMA_FIFOMode_Enable;
-    DMA_InitStructure2.DMA_FIFOThreshold = DMA_FIFOThreshold_1QuarterFull;
-    DMA_InitStructure2.DMA_MemoryBurst = DMA_MemoryBurst_Single;
+    DMA_InitStructure2.DMA_FIFOThreshold = DMA_FIFOThreshold_HalfFull;
+    DMA_InitStructure2.DMA_MemoryBurst = DMA_MemoryBurst_INC4;
     DMA_InitStructure2.DMA_PeripheralBurst = DMA_PeripheralBurst_Single;
     DMA_Init(AUDIO_I2S_EXT_DMA_STREAM, &DMA_InitStructure2);
 


### PR DESCRIPTION
with the more intuitive blockSize variable (which is defined as size/2).
Also aligned all functions to take blockSize directly as
argument instead of calculating it from size if they
use only size/2 and never size.

This should not change any functionality for good or bad.
But given the number of changes, it may do so anyway. Did a careful review of the changes but you never know.
