### PR TITLE
Introduced a data struct for audio samples

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.h
+++ b/mchf-eclipse/drivers/audio/audio_driver.h
@@ -62,23 +62,30 @@
 #define SCALING_FACTOR_IQ_AMPLITUDE_ADJUST 2731.0
 
 
+typedef struct
+{
+    // Stereo buffers
+    float32_t                   i_buffer[IQ_BUFSZ+1];
+    float32_t                   q_buffer[IQ_BUFSZ+1];
+    float32_t                   a_buffer[IQ_BUFSZ+1];
+
+    float32_t                   b_buffer[(IQ_BUFSZ*2)+1];   // this is larger since we need interleaved data for magnitude calculation in AM demod and thus, twice as much space
+
+    float32_t                   c_buffer[IQ_BUFSZ+1]; // only used in two places ( audio_rx_freq_conv and audio_demod_fm )
+    float32_t                   d_buffer[IQ_BUFSZ+1]; // only used in two places ( audio_rx_freq_conv and audio_demod_fm )
+    float32_t                   e_buffer[IQ_BUFSZ+1]; // only used in three places audio_rx_freq_conv / rx_proc / tx_proc
+    float32_t                   f_buffer[IQ_BUFSZ+1]; // only used in three places audio_rx_freq_conv / rx_proc / tx_proc
+    //
+    float32_t                   Osc_I_buffer[IQ_BUFSZ+1];
+    float32_t                   Osc_Q_buffer[IQ_BUFSZ+1];
+
+    float32_t                   agc_valbuf[BUFF_LEN];   // holder for "running" AGC value
+
+} AudioDriverBuffer;
+
 // Audio driver publics
 typedef struct AudioDriverState
 {
-    // Stereo buffers
-    float32_t					i_buffer[IQ_BUFSZ+1];
-    float32_t 					q_buffer[IQ_BUFSZ+1];
-    float32_t 					a_buffer[IQ_BUFSZ+1];
-
-    float32_t 					b_buffer[(IQ_BUFSZ*2)+1];	// this is larger since we need interleaved data for magnitude calculation in AM demod and thus, twice as much space
-
-    float32_t					c_buffer[IQ_BUFSZ+1]; // only used in two places ( audio_rx_freq_conv and audio_demod_fm )
-    float32_t					d_buffer[IQ_BUFSZ+1]; // only used in two places ( audio_rx_freq_conv and audio_demod_fm )
-    float32_t					e_buffer[IQ_BUFSZ+1]; // only used in three places audio_rx_freq_conv / rx_proc / tx_proc
-    float32_t					f_buffer[IQ_BUFSZ+1]; // only used in three places audio_rx_freq_conv / rx_proc / tx_proc
-    //
-    float32_t					Osc_I_buffer[IQ_BUFSZ+1];
-    float32_t					Osc_Q_buffer[IQ_BUFSZ+1];
     //
     // Lock audio filter flag
     //
@@ -90,7 +97,6 @@ typedef struct AudioDriverState
     float 					agc_val;			// "live" receiver AGC value
     float					agc_var;
     float					agc_calc;
-    float					agc_valbuf[BUFF_LEN];	// holder for "running" AGC value
     float					agc_holder;			// used to hold AGC value during transmit and tuning
     float					agc_decay;			// decay rate (speed) of AGC
     float					agc_rf_gain;		// manual RF gain (actual) - calculated from the value of "ts.rf_gain"


### PR DESCRIPTION
, this is in line with the BlockSize definition introduced in #493 , so we do not need "size" anymore except in the very low level I2S driver part.

Also moved most audio driver buffers out of the ads structure into the "AudioDriverBuffer" adb structure.
This allows us to drop the  volatile (aka __IO) on the buffers which not only
reduces the code size by 1k or so but also allows the compiler to generate
more efficient code in some places.

And, one more bonus: We can remove loads of casts (float32_t*) in our code.
This makes the code way more readable IMHO.

BTW, I did this only for buffer structures for which this is safe, since these are
read and written in the interrupt code only.
