### PR TITLE
(Hopefully) fixed a CW in split mode issue

### DIFF
--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -2448,13 +2448,13 @@ static void UiDriverProcessFunctionKeyClick(ulong id)
 
                     if(!ts.vfo_mem_flag)	 	// in normal VFO mode?
                     {
-                        label = " SPLIT";
+                        label = "SPLIT";
                         color = is_splitmode()?SPLIT_ACTIVE_COLOUR:SPLIT_INACTIVE_COLOUR;
                     }
                     else	 					// in memory mode
                     {
                         color = White;
-                        label = "  MEM ";
+                        label = "MEM";
                     }
                     UiDriverFButtonLabel(3,label,color);	// yes - indicate with color
                 }


### PR DESCRIPTION
Due to a race condition the wrong RX frequency (RX Freq showed TX Freq) was displayed after
a break. Don't exactly know if it fixes the particular issue, since
it was impossible to reproduce reliably (but I was able to reproduce
it once).
