### PR TITLE
gain correction in biquad RX and TX filters

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -393,6 +393,7 @@ void audio_driver_set_rx_audio_filter(uint8_t dmod_mode)
      ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*/
     // biquad_1 :   Notch & peak filters & lowShelf (Bass) in the decimated path
     // biquad 2 :   Treble in the 48kHz path
+    // TX_biquad:   Bass & Treble in the 48kHz path
     // DSP Audio-EQ-cookbook for generating the coeffs of the filters on the fly
     // www.musicdsp.org/files/Audio-EQ-Cookbook.txt  [by Robert Bristow-Johnson]
     //

--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -413,12 +413,6 @@ void audio_driver_set_rx_audio_filter(uint8_t dmod_mode)
     //
     float32_t FSdec = 24000.0; // we need the sampling rate in the decimated path for calculation of the coefficients
 
-    /* if (FilterPathInfo[ts.filter_path].sample_rate_dec == RX_DECIMATION_RATE_24KHZ)
-    {
-        FSdec = 24000.0;
-    }
-    else*/
-
     if (FilterPathInfo[ts.filter_path].sample_rate_dec == RX_DECIMATION_RATE_12KHZ)
     {
         FSdec = 12000.0;
@@ -577,8 +571,8 @@ void audio_driver_set_rx_audio_filter(uint8_t dmod_mode)
     //    float32_t DCgain = (b0 + b1 + b2) / (1 - (a1 + a2));
     // does not work for some reason?
     // I take a divide by a constant instead !
-//    float32_t DCgain = 3; //
-    float32_t DCgain = 2; //
+    float32_t DCgain = 1; //
+//    float32_t DCgain = (b0 + b1 + b2) / (1 - (- a1 - a2)); // takes into account that a1 and a2 are already negated!
     b0 = b0 / DCgain;
     b1 = b1 / DCgain;
     b2 = b2 / DCgain;
@@ -624,8 +618,11 @@ void audio_driver_set_rx_audio_filter(uint8_t dmod_mode)
     a1 = a1/a0;
     a2 = a2/a0;
 
-//    DCgain = 3; //
-    DCgain = 2; //
+    DCgain = 1; //
+
+//    DCgain = 2; //
+//    DCgain = (b0 + b1 + b2) / (1 + (a1 + a2)); // takes into account that a1 and a2 are already negated!
+
     b0 = b0 / DCgain;
     b1 = b1 / DCgain;
     b2 = b2 / DCgain;
@@ -672,8 +669,9 @@ void audio_driver_set_rx_audio_filter(uint8_t dmod_mode)
     a1 = a1/a0;
     a2 = a2/a0;
 
-//    DCgain = 3; //
     DCgain = 2; //
+//    DCgain = (b0 + b1 + b2) / (1 - (- a1 - a2)); // takes into account that a1 and a2 are already negated!
+
     b0 = b0 / DCgain;
     b1 = b1 / DCgain;
     b2 = b2 / DCgain;
@@ -719,8 +717,8 @@ void audio_driver_set_rx_audio_filter(uint8_t dmod_mode)
     //    float32_t DCgain = (b0 + b1 + b2) / (1 - (a1 + a2));
     // does not work for some reason?
     // I take a divide by a constant instead !
-//    float32_t DCgain = 3; //
-    DCgain = 2; //
+    DCgain = 1; //
+//    DCgain = (b0 + b1 + b2) / (1 - (- a1 - a2)); // takes into account that a1 and a2 are already negated!
     b0 = b0 / DCgain;
     b1 = b1 / DCgain;
     b2 = b2 / DCgain;

--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -1009,9 +1009,12 @@ void Audio_TXFilter_Init(uint8_t dmod_mode)
 //            IIR_TXFilter.numStages = IIR_TX_WIDE_BASS.numStages;		// number of stages
 //            IIR_TXFilter.pkCoeffs = IIR_TX_WIDE_BASS.pkCoeffs;	// point to reflection coefficients
 //            IIR_TXFilter.pvCoeffs = IIR_TX_WIDE_BASS.pvCoeffs;	// point to ladder coefficients
-    	      IIR_TXFilter.numStages = IIR_TX_2k7.numStages;		// number of stages
-    		  IIR_TXFilter.pkCoeffs = IIR_TX_2k7.pkCoeffs;	// point to reflection coefficients
-  		      IIR_TXFilter.pvCoeffs = IIR_TX_2k7.pvCoeffs;	// point to ladder coefficients
+//			  IIR_TXFilter.numStages = IIR_TX_2k7.numStages;		// number of stages
+//    		  IIR_TXFilter.pkCoeffs = IIR_TX_2k7.pkCoeffs;	// point to reflection coefficients
+//		      IIR_TXFilter.pvCoeffs = IIR_TX_2k7.pvCoeffs;	// point to ladder coefficients
+    	      IIR_TXFilter.numStages = IIR_TX_2k7_FM.numStages;		// number of stages
+    		  IIR_TXFilter.pkCoeffs = IIR_TX_2k7_FM.pkCoeffs;	// point to reflection coefficients
+  		      IIR_TXFilter.pvCoeffs = IIR_TX_2k7_FM.pvCoeffs;	// point to ladder coefficients
     	}
    	}
     else	 	// This is FM - use a filter with "better" lows and highs more appropriate for FM

--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -669,8 +669,9 @@ void audio_driver_set_rx_audio_filter(uint8_t dmod_mode)
     a1 = a1/a0;
     a2 = a2/a0;
 
-    DCgain = 2; //
+//    DCgain = 2; //
 //    DCgain = (b0 + b1 + b2) / (1 - (- a1 - a2)); // takes into account that a1 and a2 are already negated!
+    DCgain = 1; //
 
     b0 = b0 / DCgain;
     b1 = b1 / DCgain;

--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -2951,8 +2951,12 @@ static void audio_tx_processor(AudioSample_t * const src, AudioSample_t * const 
             {
                arm_iir_lattice_f32(&IIR_TXFilter, adb.a_buffer, adb.a_buffer, blockSize);
             }
-            // biquad filter for bass & treble
+
+            if(ts.tx_audio_source != TX_AUDIO_DIG && ts.tx_audio_source != TX_AUDIO_DIGIQ)
+            { //
+            // biquad filter for bass & treble --> NOT enabled when using USB Audio (eg. for Digimodes)
         	arm_biquad_cascade_df1_f32 (&IIR_TX_biquad, adb.a_buffer,adb.a_buffer, blockSize);
+            }
         }
 
         //

--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -989,13 +989,13 @@ void Audio_TXFilter_Init(uint8_t dmod_mode)
     //
     if(dmod_mode != DEMOD_FM)	 						// not FM - use bandpass filter that restricts low and, stops at 2.7 kHz
     {
-    	if(ts.tx_filter == TX_FILTER_WIDE_BASS)
+    	if(ts.tx_filter == TX_FILTER_BASS)
     	{
             IIR_TXFilter.numStages = IIR_TX_WIDE_BASS.numStages;		// number of stages
             IIR_TXFilter.pkCoeffs = IIR_TX_WIDE_BASS.pkCoeffs;	// point to reflection coefficients
             IIR_TXFilter.pvCoeffs = IIR_TX_WIDE_BASS.pvCoeffs;	// point to ladder coefficients
     	}
-    	else if (ts.tx_filter == TX_FILTER_WIDE_TREBLE)
+    	else if (ts.tx_filter == TX_FILTER_TENOR)
     	{
 //            IIR_TXFilter.numStages = IIR_TX_WIDE_BASS.numStages;		// number of stages
 //            IIR_TXFilter.pkCoeffs = IIR_TX_WIDE_BASS.pkCoeffs;	// point to reflection coefficients

--- a/mchf-eclipse/drivers/audio/audio_filter.c
+++ b/mchf-eclipse/drivers/audio/audio_filter.c
@@ -983,10 +983,10 @@ void AudioFilter_InitTxHilbertFIR(void)
     // phase adjustment is now done in audio_driver.c audio_tx_processor
 
     IQ_FilterDescriptor iq_tx_filter =
-            (ts.tx_filter == TX_FILTER_WIDE_BASS ||
+            (ts.tx_filter == TX_FILTER_BASS ||
             		//             ts.tx_filter == TX_FILTER_WIDE_TREBLE) ? iq_tx_wide:iq_tx_narrow;
             		// FIXME: dirty trial: always use the "wide" 201 tap Hilbert filter
-             ts.tx_filter == TX_FILTER_WIDE_TREBLE) ? iq_tx_wide:iq_tx_wide;
+             ts.tx_filter == TX_FILTER_SOPRANO) ? iq_tx_wide:iq_tx_wide;
 
 
     fc.tx_q_num_taps = iq_tx_filter.num_taps;

--- a/mchf-eclipse/drivers/ui/ui_configuration.c
+++ b/mchf-eclipse/drivers/ui/ui_configuration.c
@@ -153,7 +153,7 @@ const ConfigEntryDescriptor ConfigEntryInfo[] =
     { ConfigEntry_UInt8, EEPROM_S_METER,&ts.s_meter,0,0,2},
 	{ ConfigEntry_Int32_16, EEPROM_BASS_GAIN,&ts.bass_gain,2,-20,20},
     { ConfigEntry_Int32_16, EEPROM_TREBLE_GAIN,&ts.treble_gain,0,-20,20},
-    { ConfigEntry_UInt8, EEPROM_TX_FILTER,&ts.tx_filter,0,0,TX_FILTER_WIDE_TREBLE},
+    { ConfigEntry_UInt8, EEPROM_TX_FILTER,&ts.tx_filter,0,0,TX_FILTER_BASS},
 	{ ConfigEntry_Int32_16, EEPROM_TX_BASS_GAIN,&ts.tx_bass_gain,4,-20,6},
     { ConfigEntry_Int32_16, EEPROM_TX_TREBLE_GAIN,&ts.tx_treble_gain,4,-20,6},
 

--- a/mchf-eclipse/drivers/ui/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/ui_menu.c
@@ -3866,23 +3866,19 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
         tchange = UiDriverMenuItemChangeUInt8(var, mode, &ts.tx_filter,
 //                0,
                 1,
-                                              TX_FILTER_WIDE_TREBLE,
-                                              TX_FILTER_NARROW,
+                                              TX_FILTER_BASS,
+                                              TX_FILTER_SOPRANO,
                                               1
                                              );
         switch(ts.tx_filter) {
-        case TX_FILTER_NONE:
-            txt_ptr = "        OFF";
-            clr = Orange;
+        case TX_FILTER_SOPRANO:
+            txt_ptr = " SOPRANO";
             break;
-        case TX_FILTER_NARROW:
-            txt_ptr = "     NARROW";
+        case TX_FILTER_BASS:
+            txt_ptr = "    BASS";
             break;
-        case TX_FILTER_WIDE_BASS:
-            txt_ptr = "  WIDE BASS";
-            break;
-        case TX_FILTER_WIDE_TREBLE:
-            txt_ptr = "WIDE TREBLE";
+        case TX_FILTER_TENOR:
+            txt_ptr = "   TENOR";
             break;
         }
         if(tchange)

--- a/mchf-eclipse/hardware/mchf_board.h
+++ b/mchf-eclipse/hardware/mchf_board.h
@@ -1166,10 +1166,10 @@ typedef struct TransceiverState
     uchar 	display_dbm;			// display dbm or dbm/Hz or OFF
     uchar	s_meter;				// defines S-Meter style/configuration
 
-    #define TX_FILTER_NONE			0
-    #define TX_FILTER_NARROW		1
-    #define TX_FILTER_WIDE_BASS		2
-    #define TX_FILTER_WIDE_TREBLE	3
+//    #define TX_FILTER_NONE			0
+    #define TX_FILTER_SOPRANO		1
+    #define TX_FILTER_TENOR			2
+    #define TX_FILTER_BASS			3
     uchar	tx_filter;				// which TX filter has been chosen?
 
     uint8_t display_type;           // existence/identification of display type


### PR DESCRIPTION
- Corrected gain in RX biquad filter
- Corrected gain in TX biquad filter
- biquad TX filter (BASS & TREBLE) only active when NOT in USB Audio In Mode
- TX filters now all linear filters with new names:
  SOPRANO - 250-2950Hz
  TENOR - 150-2850Hz
  BASS - 50-2750Hz
