### PR TITLE
All voice tx modes now use the same input processing filter(s).

### DIFF
--- a/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
@@ -22,7 +22,7 @@
 #include "waterfall_colours.h"
 // ------------------------------------------------
 // Spectrum display public
-__IO    SpectrumDisplay  __attribute__ ((section (".ccm")))       sd;
+SpectrumDisplay  __attribute__ ((section (".ccm")))       sd;
 // this data structure is now located in the Core Connected Memory of the STM32F4
 // this is highly hardware specific code. This data structure nicely fills the 64k with roughly 60k.
 // If this data structure is being changed,  be aware of the 64k limit. See linker script arm-gcc-link.ld

--- a/mchf-eclipse/drivers/ui/lcd/ui_spectrum.h
+++ b/mchf-eclipse/drivers/ui/lcd/ui_spectrum.h
@@ -182,6 +182,6 @@ typedef struct SpectrumDisplay
 } SpectrumDisplay;
 
 // Spectrum display
-extern __IO   SpectrumDisplay      sd;
+extern SpectrumDisplay      sd;
 
 #endif

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -352,9 +352,6 @@ __IO LoTcxo						lo;
 __IO ulong 						unmute_delay = 0;
 
 // ------------------------------------------------
-// Spectrum display
-extern __IO	SpectrumDisplay		sd;
-
 
 uchar drv_state = 0;
 


### PR DESCRIPTION
Slightly restructured tx processing in order to simplify,
no functional changes.

Used more "const" and local copies of volatile variables to see the effect.
Codewise we lost a few hundreds byte, effect on performance
is not so easy to measure, but for sure not slower.

Removed volatile modifier from spectrum display data, since it is not necessary IMHO
here.
