### PR TITLE
Zoom FFT working in experimental stage - but menu has to be built

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -2166,23 +2166,22 @@ static void audio_rx_processor(AudioSample_t * const src, AudioSample_t * const 
     // frequency resolution with
 #if ZOOM_FFT == 1
     // lowpass [with IIR_TX_WIDE_BASS]
-    arm_iir_lattice_f32(&IIR_TXFilter, adb.i_buffer, adb.x_buffer, blockSize);
-    arm_iir_lattice_f32(&IIR_TXFilter, adb.q_buffer, adb.y_buffer, blockSize);
+   // arm_iir_lattice_f32(&IIR_TXFilter, adb.i_buffer, adb.x_buffer, blockSize);
+   // arm_iir_lattice_f32(&IIR_TXFilter, adb.q_buffer, adb.y_buffer, blockSize);
 
     // decimation
-    arm_fir_decimate_f32(&DECIMATE_ZOOM_FFT, adb.x_buffer, adb.x_buffer, blockSize);
-    arm_fir_decimate_f32(&DECIMATE_ZOOM_FFT, adb.y_buffer, adb.y_buffer, blockSize);
+//    arm_fir_decimate_f32(&DECIMATE_ZOOM_FFT, adb.x_buffer, adb.x_buffer, blockSize);
+//    arm_fir_decimate_f32(&DECIMATE_ZOOM_FFT, adb.y_buffer, adb.y_buffer, blockSize);
     // collect samples for spectrum display 256-point-FFT
 
     	// loop to put decimated samples from x and y buffer into sd.FFT_Samples
-        for(i = 0; i < blockSize/8; i++)
+        for(i = 0; i < blockSize/16; i++)
         {
             if(sd.state == 0)
             {
-
-            	sd.FFT_Samples[sd.samp_ptr] = (float32_t)adb.y_buffer[i];	// get floating point data for FFT for spectrum scope/waterfall display
+            	sd.FFT_Samples[sd.samp_ptr] = (float32_t)adb.i_buffer[i*16];	// get floating point data for FFT for spectrum scope/waterfall display
             	sd.samp_ptr++;
-            	sd.FFT_Samples[sd.samp_ptr] = (float32_t)adb.x_buffer[i];
+            	sd.FFT_Samples[sd.samp_ptr] = (float32_t)adb.q_buffer[i*16];
             	sd.samp_ptr++;
 
         // On obtaining enough samples for spectrum scope/waterfall, update state machine, reset pointer and wait until we process what we have


### PR DESCRIPTION
If you set ZOOM_FFT to  1 in mchf_board.h, you can try out a 16x Zoom mode ;-). It is slower than the spectrum you are used to, because it takes time to collect the samples if you want to have high resolution in frequency! --> general rule in DSP
Processor load should be close to zero, because contrary to my expectations, I did not have to implement lowpass filtering or proper decimation, just taking every 16th sample pair was sufficient, but experience will tell, whether this produces other problems ;-).
Will add a proper menu later, the plan is to implement the following Zoom steps: 2x, 4x, 8x, 16x, 32x.
Will not add an additional menu point, but put this under menu display --> Spectrum 2x Magn. I think the menu point should be renamed to "Spectrum Zoom".
