### PR TITLE
now all Zoom FFT steps 1 - 32x functional

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -2181,9 +2181,9 @@ static void audio_rx_processor(AudioSample_t * const src, AudioSample_t * const 
         {
             if(sd.state == 0)
             {
-            	sd.FFT_Samples[sd.samp_ptr] = (float32_t)adb.i_buffer[i*(int)powf(2,sd.magnify)];	// get floating point data for FFT for spectrum scope/waterfall display
+            	sd.FFT_Samples[sd.samp_ptr] = (float32_t)adb.q_buffer[i*(int)powf(2,sd.magnify)];	// get floating point data for FFT for spectrum scope/waterfall display
             	sd.samp_ptr++;
-            	sd.FFT_Samples[sd.samp_ptr] = (float32_t)adb.q_buffer[i*(int)powf(2,sd.magnify)];
+            	sd.FFT_Samples[sd.samp_ptr] = (float32_t)adb.i_buffer[i*(int)powf(2,sd.magnify)];
             	sd.samp_ptr++;
 
         // On obtaining enough samples for spectrum scope/waterfall, update state machine, reset pointer and wait until we process what we have

--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -2183,7 +2183,7 @@ static void audio_rx_processor(AudioSample_t * const src, AudioSample_t * const 
             {
             	sd.FFT_Samples[sd.samp_ptr] = (float32_t)adb.q_buffer[i << sd.magnify];	// get floating point data for FFT for spectrum scope/waterfall display
             	sd.samp_ptr++;
-            	sd.FFT_Samples[sd.samp_ptr] = (float32_t)adb.i_buffer[i << sd.magnify];
+            	sd.FFT_Samples[sd.samp_ptr] = (float32_t)adb.i_buffer[i << sd.magnify]; // (i << sd.magnify) is the same as (i * 2^sd.magnify)
             	sd.samp_ptr++;
 
         // On obtaining enough samples for spectrum scope/waterfall, update state machine, reset pointer and wait until we process what we have

--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -2080,7 +2080,7 @@ static void audio_rx_processor(AudioSample_t * const src, AudioSample_t * const 
 
         //
         // Collect I/Q samples // why are the I & Q buffers filled with I & Q, the FFT buffers are filled with Q & I?
-        if(sd.state == 0 && sd.magnify != 4)		// o magnify x 16
+        if(sd.state == 0 && sd.magnify == 0)		//
         {
             sd.FFT_Samples[sd.samp_ptr] = (float32_t)(src[i].r);	// get floating point data for FFT for spectrum scope/waterfall display
             sd.samp_ptr++;
@@ -2165,7 +2165,7 @@ static void audio_rx_processor(AudioSample_t * const src, AudioSample_t * const 
     // example: decimate by 8 --> 48kHz / 8 = 6kHz spectrum display
     // frequency resolution with
 
-	if(sd.magnify == 4)				// magnify x 16
+	if(sd.magnify != 0)				// magnify 2, 4, 8, 16, or 32
 	{
     // lowpass [with IIR_TX_WIDE_BASS]
    // arm_iir_lattice_f32(&IIR_TXFilter, adb.i_buffer, adb.x_buffer, blockSize);
@@ -2177,13 +2177,13 @@ static void audio_rx_processor(AudioSample_t * const src, AudioSample_t * const 
     // collect samples for spectrum display 256-point-FFT
 
     	// loop to put decimated samples from x and y buffer into sd.FFT_Samples
-        for(i = 0; i < blockSize/16; i++)
+        for(i = 0; i < blockSize/powf(2,sd.magnify); i++)
         {
             if(sd.state == 0)
             {
-            	sd.FFT_Samples[sd.samp_ptr] = (float32_t)adb.i_buffer[i*16];	// get floating point data for FFT for spectrum scope/waterfall display
+            	sd.FFT_Samples[sd.samp_ptr] = (float32_t)adb.i_buffer[i*(int)powf(2,sd.magnify)];	// get floating point data for FFT for spectrum scope/waterfall display
             	sd.samp_ptr++;
-            	sd.FFT_Samples[sd.samp_ptr] = (float32_t)adb.q_buffer[i*16];
+            	sd.FFT_Samples[sd.samp_ptr] = (float32_t)adb.q_buffer[i*(int)powf(2,sd.magnify)];
             	sd.samp_ptr++;
 
         // On obtaining enough samples for spectrum scope/waterfall, update state machine, reset pointer and wait until we process what we have

--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -2181,9 +2181,9 @@ static void audio_rx_processor(AudioSample_t * const src, AudioSample_t * const 
         {
             if(sd.state == 0)
             {
-            	sd.FFT_Samples[sd.samp_ptr] = (float32_t)adb.q_buffer[i*(int)powf(2,sd.magnify)];	// get floating point data for FFT for spectrum scope/waterfall display
+            	sd.FFT_Samples[sd.samp_ptr] = (float32_t)adb.q_buffer[i << sd.magnify];	// get floating point data for FFT for spectrum scope/waterfall display
             	sd.samp_ptr++;
-            	sd.FFT_Samples[sd.samp_ptr] = (float32_t)adb.i_buffer[i*(int)powf(2,sd.magnify)];
+            	sd.FFT_Samples[sd.samp_ptr] = (float32_t)adb.i_buffer[i << sd.magnify];
             	sd.samp_ptr++;
 
         // On obtaining enough samples for spectrum scope/waterfall, update state machine, reset pointer and wait until we process what we have

--- a/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
@@ -1127,7 +1127,7 @@ void UiSpectrumReDrawScopeDisplay()
         // compiler can heavily optimize this since we  all these values being power of 2 value
 //        if(sd.magnify != 0)	 	// is magnify mode on?
         if(0)	 	// FIXME
-        {
+        { // we don´t need all this any more, because the new Zoom FFT takes care of that, DD4WH, Aug 15th, 2016
             uint32_t end_range;
             switch(ts.iq_freq_mode)
             {
@@ -1505,6 +1505,8 @@ void UiSpectrumReDrawWaterfall()
             // position of center is always in the middle if
             // in magnify mode, so we fix that position here
 
+/*			// we don´t need the following anymore, because the new Zoom FFT already
+  	  	  	// takes care of that, DD4WH, Aug 15th, 2016
             for(i = 0; i < FFT_IQ_BUFF_LEN/2; i++)	 	// expand data to fill entire screen - get lower half
             {
                 ptr = (i/2) + magnify_offset;
@@ -1514,6 +1516,7 @@ void UiSpectrumReDrawWaterfall()
                 }
             }
             arm_copy_f32((float32_t *)sd.wfall_temp, (float32_t *)sd.FFT_Samples, FFT_IQ_BUFF_LEN/2);		// copy the rescaled/shifted data into the main buffer
+*/
         }
 
         // After the above manipulation, clip the result to make sure that it is within the range of the palette table

--- a/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
@@ -1125,7 +1125,8 @@ void UiSpectrumReDrawScopeDisplay()
         // gives us the index in the buffer.
         // we use this  knowledge to simplify the magnification code
         // compiler can heavily optimize this since we  all these values being power of 2 value
-        if(sd.magnify != 0)	 	// is magnify mode on?
+//        if(sd.magnify != 0)	 	// is magnify mode on?
+        if(0)	 	// FIXME
         {
             uint32_t end_range;
             switch(ts.iq_freq_mode)

--- a/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
@@ -915,7 +915,7 @@ void UiSpectrumReDrawScopeDisplay()
         //
         // Find peak and average to vertically adjust display
         //
-        if(sd.magnify)	 	// are we in magnify mode?  If so, find max/mean of only those portions of the spectrum magnified - which are NOT in the proper order, dammit!
+        if(sd.magnify != 0)	 	// are we in magnify mode?  If so, find max/mean of only those portions of the spectrum magnified - which are NOT in the proper order, dammit!
         {
             //
             if(!ts.iq_freq_mode)	 	// yes, are we NOT in translate mode?
@@ -1125,7 +1125,7 @@ void UiSpectrumReDrawScopeDisplay()
         // gives us the index in the buffer.
         // we use this  knowledge to simplify the magnification code
         // compiler can heavily optimize this since we  all these values being power of 2 value
-        if(sd.magnify)	 	// is magnify mode on?
+        if(sd.magnify != 0)	 	// is magnify mode on?
         {
             uint32_t end_range;
             switch(ts.iq_freq_mode)


### PR DESCRIPTION
only flaw is, that depending on adjacent stations and the desired Magnify level, alias products can appear (looking like signal, but without audio).
TODO: lowpass filters in I&Q before decimation in the ZoomFFT
