### PR TITLE
Made SNAP switchable feature, moved SNAP memory out of CCM

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.h
+++ b/mchf-eclipse/drivers/audio/audio_driver.h
@@ -568,6 +568,9 @@ extern __IO     SMeter              sm;
 // change this to 2048 (=1024 tap FFT), if problems with spectrum display with 7k5 SAM mode persist!
 #define FFT_IQ_BUFF_LEN2 2048
 //#define FFT_IQ_BUFF_LEN2 4096 // = 2048 tap FFT !!! this is very very accurate
+
+#ifdef USE_SNAP
+
 typedef struct SnapCarrier
 {
     // FFT state
@@ -593,6 +596,6 @@ typedef struct SnapCarrier
 } SnapCarrier;
 
 extern SnapCarrier sc;
-
+#endif
 
 #endif

--- a/mchf-eclipse/drivers/audio/audio_filter.c
+++ b/mchf-eclipse/drivers/audio/audio_filter.c
@@ -25,7 +25,7 @@
 // SSB Hilbert TX Filter
 #include "iq_tx_filter.h"
 //
-static __IO    FilterCoeffs        fc;
+static __IO    FilterCoeffs   __attribute__ ((section (".ccm")))     fc;
 
 enum
 {
@@ -914,16 +914,16 @@ uint8_t AudioFilter_NextApplicableFilterPath(const uint16_t query, const uint16_
 __IO    arm_fir_instance_f32    FIR_I;
 __IO    arm_fir_instance_f32    FIR_Q;
 
-static float32_t        FirState_I[FIR_RXAUDIO_BLOCK_SIZE+Q_NUM_TAPS];
-static float32_t        FirState_Q[FIR_RXAUDIO_BLOCK_SIZE+Q_NUM_TAPS];
+static float32_t    __attribute__ ((section (".ccm")))    FirState_I[FIR_RXAUDIO_BLOCK_SIZE+Q_NUM_TAPS];
+static float32_t    __attribute__ ((section (".ccm")))    FirState_Q[FIR_RXAUDIO_BLOCK_SIZE+Q_NUM_TAPS];
 
 //
 // TX Hilbert transform (90 degree) FIR filter state tables and instances
 //
 // FIXME: I think this is to short should calculated from max blocksize
 // (BUFLEN / 4 -> Each Interrupt == BUFLEN /2, each filter gets half of the samples, i.e. one audio channel) + max numTaps
-static float            FirState_I_TX[IQ_TX_NUM_TAPS_MAX+IQ_BUFSZ];
-static float            FirState_Q_TX[IQ_TX_NUM_TAPS_MAX+IQ_BUFSZ];
+static float   __attribute__ ((section (".ccm")))         FirState_I_TX[IQ_TX_NUM_TAPS_MAX+IQ_BUFSZ];
+static float   __attribute__ ((section (".ccm")))         FirState_Q_TX[IQ_TX_NUM_TAPS_MAX+IQ_BUFSZ];
 
 
 __IO    arm_fir_instance_f32    FIR_I_TX;

--- a/mchf-eclipse/drivers/audio/audio_filter.h
+++ b/mchf-eclipse/drivers/audio/audio_filter.h
@@ -119,7 +119,7 @@ enum
 typedef struct FilterDescriptor_s
 {
     const uint8_t id;
-    const char* name;
+    const char* const name;
     const uint16_t width;
 } FilterDescriptor;
 

--- a/mchf-eclipse/hardware/mchf_board.c
+++ b/mchf-eclipse/hardware/mchf_board.c
@@ -34,7 +34,7 @@
 
 
 // Transceiver state public structure
-__IO TransceiverState ts;
+__IO __attribute__ ((section (".ccm"))) TransceiverState ts;
 
 
 static void mchf_board_led_init(void)

--- a/mchf-eclipse/hardware/mchf_board.h
+++ b/mchf-eclipse/hardware/mchf_board.h
@@ -13,7 +13,9 @@
 ************************************************************************************/
 #ifndef __MCHF_BOARD_H
 #define __MCHF_BOARD_H
-#define USE_FREEDV
+
+// #define USE_FREEDV
+#define USE_SNAP
 
 // HW libs
 #include "stm32f4xx_rcc.h"
@@ -34,6 +36,8 @@
 #include "stm32f4xx_flash.h"
 #include "misc.h"
 #include "core_cm4.h"
+
+#include "freedv_api.h"
 
 #include "stm32f4xx.h"
 #include "mchf_types.h"
@@ -1211,9 +1215,13 @@ typedef struct {
     int16_t samples[320];
 }  FDV_Buffer;
 
+typedef struct {
+   COMP samples[320];
+}  FDV_Out_Buffer;
+
 extern struct freedv *f_FREEDV;
 extern FDV_Buffer FDV_TX_in_buff[FDV_BUFFER_IN_NUM];
-extern FDV_Buffer FDV_TX_out_buff[FDV_BUFFER_OUT_NUM];
+extern FDV_Out_Buffer FDV_TX_out_buff[FDV_BUFFER_OUT_NUM];
 
 //end DL2FW UGLY test for FREEDV - some globals :-(
 

--- a/mchf-eclipse/main.c
+++ b/mchf-eclipse/main.c
@@ -591,8 +591,8 @@ int main(void)
     // Freedv Test DL2FW
 
     f_FREEDV = freedv_open(FREEDV_MODE_1600);
-    // ts.dvmode = true;
-    // ts.digital_mode = 1;
+    ts.dvmode = true;
+    ts.digital_mode = 1;
     // end Freedv Test DL2FW
 #endif
 


### PR DESCRIPTION
Moved a lot of data structures into CCM, with FreeDV buffers it is full.
FreeDV and SNAP will not run at the same time on small memory machines (192k).
