### PR TITLE
fix ZoomFFT

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -105,7 +105,7 @@ static float32_t		iir_aa_state[IIR_RXAUDIO_BLOCK_SIZE + IIR_RXAUDIO_NUM_STAGES];
 static arm_iir_lattice_instance_f32	IIR_AntiAlias;
 
 
-static float32_t Koeff[20];
+// static float32_t Koeff[20];
 // variables for RX manual notch, manual peak & bass shelf IIR biquad filter
 static arm_biquad_casd_df1_inst_f32 IIR_biquad_1 =
 {
@@ -1394,14 +1394,14 @@ void audio_driver_set_rx_audio_filter(uint8_t dmod_mode)
     DECIMATE_ZOOM_FFT_I.numTaps = FirRxDecimate.numTaps;
     DECIMATE_ZOOM_FFT_I.pCoeffs = FirRxDecimate.pCoeffs;
 
-    DECIMATE_ZOOM_FFT_I.M = 1 << sd.magnify;			// Decimation factor
+    DECIMATE_ZOOM_FFT_I.M = (1 << sd.magnify);			// Decimation factor
 
     DECIMATE_ZOOM_FFT_I.pState = (float32_t *)&decimZoomFFTIState[0];			// Filter state variables
 
     DECIMATE_ZOOM_FFT_Q.numTaps = FirRxDecimate.numTaps;
     DECIMATE_ZOOM_FFT_Q.pCoeffs = FirRxDecimate.pCoeffs;
 
-    DECIMATE_ZOOM_FFT_Q.M = 8;			// Decimation factor  (48 kHz / 8 = 6 kHz)
+    DECIMATE_ZOOM_FFT_Q.M = (1 << sd.magnify);			// Decimation factor
 
     DECIMATE_ZOOM_FFT_Q.pState = (float32_t *)&decimZoomFFTQState[0];			// Filter state variables
 

--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -3486,11 +3486,19 @@ static void audio_dv_tx_processor (AudioSample_t * const src, AudioSample_t * co
 
         if (!ts.tune)
         {
-            AudioDriver_tx_filter_audio(true,ts.tx_audio_source != TX_AUDIO_DIG, adb.a_buffer,adb.a_buffer, blockSize);
+//            AudioDriver_tx_filter_audio(true,ts.tx_audio_source != TX_AUDIO_DIG, adb.a_buffer,adb.a_buffer, blockSize);
         }
         // *****************************   DV Modulator goes here - ads.a_buffer must be at 8 ksps
 
         // Freedv Test DL2FW
+
+        // we have to add a decimation filter here BEFORE we decimate
+        // for decimation-by-6 the stopband frequency is 48/6*2 = 4kHz
+        // but our audio is at most 3kHz wide, so we should use 3k or 2k9
+
+        // this should be the correct filter:
+        // use it ALWAYS, also with TUNE tone!!!
+        AudioDriver_tx_filter_audio(true,false, adb.a_buffer,adb.a_buffer, blockSize);
 
         for (int k = 0; k < blockSize; k++)
         {
@@ -3537,6 +3545,9 @@ static void audio_dv_tx_processor (AudioSample_t * const src, AudioSample_t * co
                     modulus_MOD = 0;
                 }
             }
+
+            // Add interpolation filter here to suppress alias frequencies
+
         } else {
           profileEvent(FreeDVTXUnderrun);
           // memset(dst,0,blockSize*sizeof(*dst));

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -698,6 +698,7 @@ void UiDriver_HandleTouchScreen()
           		}
           	  }
             UiSpectrumInitSpectrumDisplay();		// init spectrum scope
+            audio_driver_set_rx_audio_filter(ts.dmod_mode);
         }
         if(check_tp_coordinates(52,60,26,32))			// wf/scope bar magnify up
         {
@@ -719,6 +720,7 @@ void UiDriver_HandleTouchScreen()
           		}
           	  }
             UiSpectrumInitSpectrumDisplay();		// init spectrum scope
+            audio_driver_set_rx_audio_filter(ts.dmod_mode);
         }
         if(check_tp_coordinates(43,60,00,04))			// TUNE button
         {

--- a/mchf-eclipse/drivers/ui/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/ui_menu.c
@@ -2520,6 +2520,7 @@ static void UiDriverUpdateMenuLines(uchar index, uchar mode, int pos)
             txt_ptr = " x1";
             break;
         }
+        audio_driver_set_rx_audio_filter(ts.dmod_mode);
         break;
     case MENU_SCOPE_AGC_ADJUST:	// Spectrum scope AGC adjust
         fchange = UiDriverMenuItemChangeUInt8(var, mode, &ts.scope_agc_rate,


### PR DESCRIPTION
Zoom FFT now working for all magnification values. All lowpass filters implemented and filter switching correctly when switching mag value.
TODO: implement different FIR decimation filter 4 taps, that´s still the old filter used for RX! Makes the spectrum look a bit akward in 2x and 4x modes . . . 
