### PR TITLE
fix dBm display

### DIFF
--- a/mchf-eclipse/drivers/audio/filters/fir_rx_decimate_4.c
+++ b/mchf-eclipse/drivers/audio/filters/fir_rx_decimate_4.c
@@ -59,7 +59,7 @@ const arm_fir_decimate_instance_f32 FirZoomFFTDecimate[] =
 {
         // TODO: Change to "passthru" filter" -> This is just a dummy filter for 1x magnification (right now copy of 2x filter)
         //
-        {
+/*        {
                 .numTaps = 4,
                 .pCoeffs = (float*) (const float[])
                 {
@@ -69,7 +69,7 @@ const arm_fir_decimate_instance_f32 FirZoomFFTDecimate[] =
                     -0.3105557871709
                 }
         },
-
+*/
         {
                 .numTaps = 4,
                 .pCoeffs = (float*) (const float[])


### PR DESCRIPTION
dBm display now uses the correct bin bandwidth. This was necessary after the implementation of the Zoom FFT = spectrum magnify modes.
