### PR TITLE
Added mcu cycle accurate profiling support

### DIFF
--- a/mchf-eclipse/drivers/audio/codec/i2s.c
+++ b/mchf-eclipse/drivers/audio/codec/i2s.c
@@ -14,6 +14,7 @@
 
 // Common
 #include "mchf_board.h"
+#include "profiling.h"
 
 #include "codec.h"
 #include "audio_driver.h"
@@ -189,6 +190,12 @@ void I2S_Block_Stop(void)
 //*----------------------------------------------------------------------------
 void DMA1_Stream2_IRQHandler(void)
 {
+#ifdef PROFILE_EVENTS
+    // we stop during interrupt
+    // at the end we start again
+    profileCycleCount_stop();
+#endif
+
 #ifdef USE_24_BITS
     static int32_t *src, *dst, sz;
 #else
@@ -248,5 +255,10 @@ void DMA1_Stream2_IRQHandler(void)
 #ifdef EXEC_PROFILING
     // Profiling pin (low level)
     GPIOE->BSRRH = GPIO_Pin_10;
+#endif
+#ifdef PROFILE_EVENTS
+    // we stopped during interrupt
+    // now we start again
+    profileCycleCount_start();
 #endif
 }

--- a/mchf-eclipse/drivers/audio/freedv_mchf.c
+++ b/mchf-eclipse/drivers/audio/freedv_mchf.c
@@ -20,6 +20,7 @@
 #include "freedv_api.h"
 #include "codec2_fdmdv.h"
 // end Freedv Test DL2FW
+#include "profiling.h"
 
 struct freedv *f_FREEDV;
 
@@ -244,8 +245,11 @@ void FreeDV_mcHF_HandleFreeDV()
             // is being used. This means the mcHF is essentially no longer controllable
             // since UI is not being updated
             // while (fdv_iq_has_data() && fdv_audio_has_room())
+            // while (fdv_audio_has_room())
             if (fdv_iq_has_data() && fdv_audio_has_room())
             {
+                mchf_board_green_led(1);
+
                 leave_now = false;
                 fdv_current_buffer_idx %= FDV_BUFFER_AUDIO_NUM; // this makes sure we stay in our index range, i.e. the number of avail buffers
 
@@ -307,7 +311,10 @@ void FreeDV_mcHF_HandleFreeDV()
                     {
                         // if we arrive here the rx_buffer for comprx is full and will be consumed now.
                         inBufCtrl.offset = 0;
+                        profileTimedEventStart(ProfileFreeDV);
                         outBufCtrl.count = freedv_comprx(f_FREEDV, rx_buffer, iq_buffer); // run the decoding process
+                        // outBufCtrl.count = iq_nin;
+                        profileTimedEventStop(ProfileFreeDV);
                     }
 
                     // result tells us the number of returned audio samples
@@ -354,6 +361,7 @@ void FreeDV_mcHF_HandleFreeDV()
                 }
             }
         }
+        mchf_board_green_led(0);
     }
     // END Freedv Test DL2FW
 }

--- a/mchf-eclipse/hardware/mchf_board.h
+++ b/mchf-eclipse/hardware/mchf_board.h
@@ -14,7 +14,6 @@
 #ifndef __MCHF_BOARD_H
 #define __MCHF_BOARD_H
 
-
 // some special switches
 //#define 	DEBUG_BUILD
 

--- a/mchf-eclipse/main.c
+++ b/mchf-eclipse/main.c
@@ -34,7 +34,7 @@
 #include "ui_menu.h"
 #include "ui_si570.h"
 #include "codec.h"
-
+#include "profiling.h"
 // Keyboard Driver
 // #include "keyb_driver.h"
 
@@ -569,6 +569,8 @@ int main(void)
 
     ts.temp_nb = ts.nb_setting;
     ts.nb_setting = 0;
+
+    profileTimedEventInit();
 
     // Audio HW init
     audio_driver_init();

--- a/mchf-eclipse/misc/profiling.c
+++ b/mchf-eclipse/misc/profiling.c
@@ -22,3 +22,6 @@
  * Not a big deal with ST-Link and Eclipse or gdb.
  */
 EventProfile_t eventProfile;
+
+
+


### PR DESCRIPTION
The resolution is 1/168.000.000s

See misc/profiling.h for quick instructions.

Right now configured (in i2s.c) to exclude time spent in the audio interrupt.
Other interrupts are being counted but should not give too much error hopefully.
Maybe later we have exclude all interrupt cycles in order to prevent measuring
wrong values.
