### PR TITLE
Instrumented the fmdmdv code / freedv_demod for cycle timing. Reduced comp time by 10%

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -3750,7 +3750,6 @@ void I2S_RX_CallBack(int16_t *src, int16_t *dst, int16_t size, uint16_t ht)
     static bool to_tx = 0;	// used as a flag to clear the TX buffer
     static ulong tcount = 0;
 
-    profileEvent(ProfileAudioInterrupt);
 
     if(ts.show_tp_coordinates)
     {

--- a/mchf-eclipse/drivers/audio/freedv_mchf.c
+++ b/mchf-eclipse/drivers/audio/freedv_mchf.c
@@ -311,10 +311,8 @@ void FreeDV_mcHF_HandleFreeDV()
                     {
                         // if we arrive here the rx_buffer for comprx is full and will be consumed now.
                         inBufCtrl.offset = 0;
-                        profileTimedEventStart(ProfileFreeDV);
                         outBufCtrl.count = freedv_comprx(f_FREEDV, rx_buffer, iq_buffer); // run the decoding process
                         // outBufCtrl.count = iq_nin;
-                        profileTimedEventStop(ProfileFreeDV);
                     }
 
                     // result tells us the number of returned audio samples

--- a/mchf-eclipse/drivers/freedv/fdmdv_internal.h
+++ b/mchf-eclipse/drivers/freedv/fdmdv_internal.h
@@ -39,7 +39,9 @@
 
 \*---------------------------------------------------------------------------*/
 
-#define PI             3.141592654
+#ifndef PI
+    #define PI             3.141592654
+#endif
 #define FS                    8000  /* sample rate in Hz                                                    */
 #define T                 (1.0/FS)  /* sample period in seconds                                             */
 #define RS                      50  /* symbol rate in Hz                                                    */

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -1499,7 +1499,6 @@ static bool RadioManagement_HandleLoTemperatureDrift()
         // lo.skip++;
         // if(lo.skip >= LO_COMP_SKP)
         {
-            profileEvent(EnterLO);
             // lo.skip = 0;
             // Get current temperature
             if(Si570_ReadExternalTempSensor(&temp) == 0)
@@ -1594,7 +1593,6 @@ static void RadioManagement_HandlePttOnOff()
 {
     static uint32_t ptt_break_timer = ptt_break_time;
     // Not when tuning
-    profileEvent(EnterPTT);
 
     if(ts.tune == false)
     {
@@ -6181,7 +6179,6 @@ static void UiDriver_HandleVoltage()
     // pwmt.skip++;
     // if(pwmt.skip >= POWER_SAMPLES_SKP)
     {
-        profileEvent(EnterVoltage);
         // pwmt.skip = 0;
 
         // Collect samples
@@ -7133,7 +7130,6 @@ bool UiDriver_TimerExpireAndRewind(SysClockTimers sct,uint32_t now, uint32_t div
 void ui_driver_thread()
 {
 
-    profileEvent(EnterDriverThread);
     uint32_t now = ts.sysclock;
 
 #ifdef USE_FREEDV
@@ -7193,7 +7189,6 @@ void ui_driver_thread()
             if(!ts.boot_halt_flag)
             {
                 if (UiDriver_TimerExpireAndRewind(SCTimer_SMETER,now,4)){
-                    profileEvent(EnterSMeter);
                     UiDriverHandleSmeter();
                 }
             }

--- a/mchf-eclipse/misc/profiling.c
+++ b/mchf-eclipse/misc/profiling.c
@@ -22,6 +22,16 @@
  * Not a big deal with ST-Link and Eclipse or gdb.
  */
 EventProfile_t eventProfile;
+void dummy() {
+    eventProfile.event[2].duration;
+    eventProfile.event[2].count;
+    eventProfile.event[3].duration;
+    eventProfile.event[3].count;
+    eventProfile.event[4].duration;
+    eventProfile.event[4].count;
+    eventProfile.event[8].duration;
+    eventProfile.event[8].count;
 
 
+}
 


### PR DESCRIPTION
Identified hotspot and changed the fir_filter implementation into
a more ARM DSP friendly style. This reduced  computation time in this
function by 50% (or roughly 2ms / 10% per FreeDV frame computation which happens roughly every 20ms).
