### PR TITLE
Added semihosting to Eclipse Debug Build

### DIFF
--- a/mchf-eclipse/.cproject
+++ b/mchf-eclipse/.cproject
@@ -75,6 +75,7 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/mchf-eclipse/usb/usbd/class/cdc/inc}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/mchf-eclipse/usb/usbd/class/audio/inc}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/mchf-eclipse/misc}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/mchf-eclipse/drivers}&quot;"/>
 								</option>
 								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.assembler.defs.1642012270" name="Defined symbols (-D)" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.assembler.defs" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="ARM_MATH_CM4"/>
@@ -83,6 +84,7 @@
 									<listOptionValue builtIn="false" value="USE_STDPERIPH_DRIVER"/>
 									<listOptionValue builtIn="false" value="_GNU_SOURCE"/>
 									<listOptionValue builtIn="false" value="CORTEX_M4"/>
+									<listOptionValue builtIn="false" value="TRACE"/>
 								</option>
 								<inputType id="ilg.gnuarmeclipse.managedbuild.cross.tool.assembler.input.1134137507" superClass="ilg.gnuarmeclipse.managedbuild.cross.tool.assembler.input"/>
 							</tool>
@@ -94,6 +96,8 @@
 									<listOptionValue builtIn="false" value="USE_STDPERIPH_DRIVER"/>
 									<listOptionValue builtIn="false" value="_GNU_SOURCE"/>
 									<listOptionValue builtIn="false" value="CORTEX_M4"/>
+									<listOptionValue builtIn="false" value="TRACE"/>
+									<listOptionValue builtIn="false" value="OS_USE_TRACE_SEMIHOSTING_DEBUG"/>
 								</option>
 								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.c.compiler.include.paths.2147099817" name="Include paths (-I)" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.c.compiler.include.paths" useByScannerDiscovery="false" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/mchf-eclipse/cmsis}&quot;"/>
@@ -123,6 +127,7 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/mchf-eclipse/usb/usbd/class/cdc/inc}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/mchf-eclipse/usb/usbd/class/audio/inc}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/mchf-eclipse/misc}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/mchf-eclipse/drivers}&quot;"/>
 								</option>
 								<inputType id="ilg.gnuarmeclipse.managedbuild.cross.tool.c.compiler.input.1542448985" superClass="ilg.gnuarmeclipse.managedbuild.cross.tool.c.compiler.input"/>
 							</tool>
@@ -134,6 +139,8 @@
 									<listOptionValue builtIn="false" value="USE_STDPERIPH_DRIVER"/>
 									<listOptionValue builtIn="false" value="_GNU_SOURCE"/>
 									<listOptionValue builtIn="false" value="CORTEX_M4"/>
+									<listOptionValue builtIn="false" value="TRACE"/>
+									<listOptionValue builtIn="false" value="OS_USE_TRACE_SEMIHOSTING_DEBUG"/>
 								</option>
 								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.cpp.compiler.include.paths.1485167743" name="Include paths (-I)" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.cpp.compiler.include.paths" useByScannerDiscovery="false" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/mchf-eclipse/cmsis}&quot;"/>
@@ -163,6 +170,7 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/mchf-eclipse/usb/usbd/class/cdc/inc}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/mchf-eclipse/usb/usbd/class/audio/inc}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/mchf-eclipse/misc}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/mchf-eclipse/drivers}&quot;"/>
 								</option>
 								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.cpp.compiler.nortti.770213086" name="Do not use RTTI (-fno-rtti)" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.cpp.compiler.nortti" useByScannerDiscovery="true" value="true" valueType="boolean"/>
 								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.cpp.compiler.noexceptions.533377747" name="Do not use exceptions (-fno-exceptions)" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.cpp.compiler.noexceptions" useByScannerDiscovery="true" value="true" valueType="boolean"/>
@@ -281,6 +289,7 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/mchf-eclipse/usb/usbd/class/cdc/inc}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/mchf-eclipse/usb/usbd/class/audio/inc}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/mchf-eclipse/misc}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/mchf-eclipse/drivers}&quot;"/>
 								</option>
 								<inputType id="ilg.gnuarmeclipse.managedbuild.cross.tool.c.compiler.input.34608003" superClass="ilg.gnuarmeclipse.managedbuild.cross.tool.c.compiler.input"/>
 							</tool>
@@ -373,6 +382,7 @@
 								</option>
 								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.assembler.include.paths.402370453" name="Include paths (-I)" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.assembler.include.paths" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/mchf-eclipse/misc}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/mchf-eclipse/drivers}&quot;"/>
 								</option>
 								<inputType id="ilg.gnuarmeclipse.managedbuild.cross.tool.assembler.input.1673248143" superClass="ilg.gnuarmeclipse.managedbuild.cross.tool.assembler.input"/>
 							</tool>
@@ -389,6 +399,7 @@
 								</option>
 								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.c.compiler.include.paths.1818911985" name="Include paths (-I)" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.c.compiler.include.paths" useByScannerDiscovery="false" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/mchf-eclipse/misc}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/mchf-eclipse/drivers}&quot;"/>
 								</option>
 								<inputType id="ilg.gnuarmeclipse.managedbuild.cross.tool.c.compiler.input.1071089195" superClass="ilg.gnuarmeclipse.managedbuild.cross.tool.c.compiler.input"/>
 							</tool>
@@ -396,6 +407,9 @@
 								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.cpp.compiler.defs.1964694686" name="Defined symbols (-D)" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.cpp.compiler.defs" useByScannerDiscovery="false" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="_GNU_SOURCE"/>
 									<listOptionValue builtIn="false" value="CORTEX_M4"/>
+								</option>
+								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.cpp.compiler.include.paths.2083680376" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.cpp.compiler.include.paths" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/mchf-eclipse/drivers}&quot;"/>
 								</option>
 								<inputType id="ilg.gnuarmeclipse.managedbuild.cross.tool.cpp.compiler.input.301192583" superClass="ilg.gnuarmeclipse.managedbuild.cross.tool.cpp.compiler.input"/>
 							</tool>

--- a/mchf-eclipse/.settings/language.settings.xml
+++ b/mchf-eclipse/.settings/language.settings.xml
@@ -5,7 +5,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="32411333825305283" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings Cross ARM" parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="968455824784626386" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings Cross ARM" parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>
@@ -16,7 +16,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="5285158236956421" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings Cross ARM" parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="948841535391084052" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings Cross ARM" parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>

--- a/mchf-eclipse/Makefile
+++ b/mchf-eclipse/Makefile
@@ -63,6 +63,8 @@ SUBDIRS :=  \
     drivers/audio/softdds  \
     drivers/cat  \
     drivers/cat/usb  \
+    drivers/diag \
+    drivers/diag/arm \
     drivers/keyboard  \
     drivers/keyboard/usb  \
     drivers/ui  \
@@ -172,6 +174,9 @@ SRC =  \
     drivers/cat/usb/usbd_cdc_vcp.c  \
     drivers/cat/usb/usbd_desc.c  \
     drivers/cat/usb/usbd_usr.c  \
+    \
+    drivers/diag/Trace.c  \
+    drivers/diag/trace_impl.c  \
     \
     drivers/freedv/codebook.c  \
     drivers/freedv/codebookd.c  \

--- a/mchf-eclipse/cmsis/DEVICE.h
+++ b/mchf-eclipse/cmsis/DEVICE.h
@@ -1,0 +1,243 @@
+/**************************************************************************//**
+ * @file     <Device>.h
+ * @brief    CMSIS Cortex-M# Core Peripheral Access Layer Header File for
+ *           Device <Device>
+ * @version  V3.10
+ * @date     23. November 2012
+ *
+ * @note
+ *
+ ******************************************************************************/
+/* Copyright (c) 2012 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+
+#ifndef Device_H      /* ToDo: replace '<Device>' with your device name */
+#define Device_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* ToDo: replace '<Device>' with your device name; add your doxyGen comment   */
+/** @addtogroup <Device>_Definitions <Device> Definitions
+  This file defines all structures and symbols for <Device>:
+    - registers and bitfields
+    - peripheral base address
+    - peripheral ID
+    - Peripheral definitions
+  @{
+*/
+
+
+/******************************************************************************/
+/*                Processor and Core Peripherals                              */
+/******************************************************************************/
+/** @addtogroup <Device>_CMSIS Device CMSIS Definitions
+  Configuration of the Cortex-M# Processor and Core Peripherals
+  @{
+*/
+
+/*
+ * ==========================================================================
+ * ---------- Interrupt Number Definition -----------------------------------
+ * ==========================================================================
+ */
+
+typedef enum IRQn
+{
+/******  Cortex-M# Processor Exceptions Numbers ***************************************************/
+
+#if defined(__ARM_ARCH_6M__)
+
+/* ToDo: use this Cortex interrupt numbers if your device is a CORTEX-M0 device                   */
+  NonMaskableInt_IRQn           = -14,      /*!<  2 Non Maskable Interrupt                        */
+  HardFault_IRQn                = -13,      /*!<  3 Hard Fault Interrupt                          */
+  SVCall_IRQn                   = -5,       /*!< 11 SV Call Interrupt                             */
+  PendSV_IRQn                   = -2,       /*!< 14 Pend SV Interrupt                             */
+  SysTick_IRQn                  = -1,       /*!< 15 System Tick Interrupt                         */
+
+#elif defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7EM__)
+
+/* ToDo: use this Cortex interrupt numbers if your device is a CORTEX-M3 / Cortex-M4 device       */
+  NonMaskableInt_IRQn           = -14,      /*!<  2 Non Maskable Interrupt                        */
+  MemoryManagement_IRQn         = -12,      /*!<  4 Memory Management Interrupt                   */
+  BusFault_IRQn                 = -11,      /*!<  5 Bus Fault Interrupt                           */
+  UsageFault_IRQn               = -10,      /*!<  6 Usage Fault Interrupt                         */
+  SVCall_IRQn                   = -5,       /*!< 11 SV Call Interrupt                             */
+  DebugMonitor_IRQn             = -4,       /*!< 12 Debug Monitor Interrupt                       */
+  PendSV_IRQn                   = -2,       /*!< 14 Pend SV Interrupt                             */
+  SysTick_IRQn                  = -1,       /*!< 15 System Tick Interrupt                         */
+
+#endif
+
+/******  Device Specific Interrupt Numbers ********************************************************/
+/* ToDo: add here your device specific external interrupt numbers
+         according the interrupt handlers defined in startup_Device.s
+         eg.: Interrupt for Timer#1       TIM1_IRQHandler   ->   TIM1_IRQn                        */
+  DeviceInterrupt_IRQn        = 0,        /*!< Device Interrupt                                 */
+} IRQn_Type;
+
+
+/*
+ * ==========================================================================
+ * ----------- Processor and Core Peripheral Section ------------------------
+ * ==========================================================================
+ */
+
+/* Configuration of the Cortex-M# Processor and Core Peripherals */
+/* ToDo: set the defines according your Device                                                    */
+/* ToDo: define the correct core revision
+         __CM0_REV if your device is a CORTEX-M0 device
+         __CM3_REV if your device is a CORTEX-M3 device
+         __CM4_REV if your device is a CORTEX-M4 device                                           */
+//#define __CM#_REV                 0x0201    /*!< Core Revision r2p1                               */
+#if defined(__ARM_ARCH_6M__)
+#define __CM0_REV                 0x0201
+#elif defined(__ARM_ARCH_7M__)
+#define __CM3_REV                 0x0201
+#elif defined(__ARM_ARCH_7EM__)
+#define __CM4_REV                 0x0201
+#endif
+
+#define __NVIC_PRIO_BITS          2         /*!< Number of Bits used for Priority Levels          */
+#define __Vendor_SysTickConfig    0         /*!< Set to 1 if different SysTick Config is used     */
+#define __MPU_PRESENT             0         /*!< MPU present or not                               */
+/* ToDo: define __FPU_PRESENT if your devise is a CORTEX-M4                                       */
+#ifdef __CM4_REV
+#define __FPU_PRESENT             1        /*!< FPU present or not                                */
+#else
+#define __FPU_PRESENT             0        /*!< FPU present or not                                */
+#endif
+/*@}*/ /* end of group <Device>_CMSIS */
+
+
+/* ToDo: include the correct core_cm#.h file
+         core_cm0.h if your device is a CORTEX-M0 device
+         core_cm3.h if your device is a CORTEX-M3 device
+         core_cm4.h if your device is a CORTEX-M4 device                                          */
+
+//#include <core_cm#.h>                       /* Cortex-M# processor and core peripherals           */
+#if defined(__ARM_ARCH_6M__)
+#include <core_cm0.h>
+#elif defined(__ARM_ARCH_7M__)
+#include <core_cm3.h>
+#elif defined(__ARM_ARCH_7EM__)
+#include <core_cm4.h>
+#endif
+
+/* ToDo: include your system_<Device>.h file
+         replace '<Device>' with your device name                                                 */
+#include "system_DEVICE.h"                /* <Device> System  include file                      */
+
+
+/******************************************************************************/
+/*                Device Specific Peripheral registers structures             */
+/******************************************************************************/
+/** @addtogroup <Device>_Peripherals <Device> Peripherals
+  <Device> Device Specific Peripheral registers structures
+  @{
+*/
+
+#if defined ( __CC_ARM   )
+#pragma anon_unions
+#endif
+
+/* ToDo: add here your device specific peripheral access structure typedefs
+         following is an example for a timer                                  */
+
+/*------------- 16-bit Timer/Event Counter (TMR) -----------------------------*/
+/** @addtogroup <Device>_TMR <Device> 16-bit Timer/Event Counter (TMR)
+  @{
+*/
+typedef struct
+{
+  __IO uint32_t EN;                         /*!< Offset: 0x0000   Timer Enable Register           */
+  __IO uint32_t RUN;                        /*!< Offset: 0x0004   Timer RUN Register              */
+  __IO uint32_t CR;                         /*!< Offset: 0x0008   Timer Control Register          */
+  __IO uint32_t MOD;                        /*!< Offset: 0x000C   Timer Mode Register             */
+       uint32_t RESERVED0[1];
+  __IO uint32_t ST;                         /*!< Offset: 0x0014   Timer Status Register           */
+  __IO uint32_t IM;                         /*!< Offset: 0x0018   Interrupt Mask Register         */
+  __IO uint32_t UC;                         /*!< Offset: 0x001C   Timer Up Counter Register       */
+  __IO uint32_t RG0;                        /*!< Offset: 0x0020   Timer Register                  */
+       uint32_t RESERVED1[2];
+  __IO uint32_t CP;                         /*!< Offset: 0x002C   Capture register                */
+} DeviceAbbreviation_TMR_TypeDef;
+/*@}*/ /* end of group <Device>_TMR */
+
+
+#if defined ( __CC_ARM   )
+#pragma no_anon_unions
+#endif
+
+/*@}*/ /* end of group <Device>_Peripherals */
+
+
+/******************************************************************************/
+/*                         Peripheral memory map                              */
+/******************************************************************************/
+/* ToDo: add here your device peripherals base addresses
+         following is an example for timer                                    */
+/** @addtogroup <Device>_MemoryMap <Device> Memory Mapping
+  @{
+*/
+
+/* Peripheral and SRAM base address */
+#define DeviceAbbreviation_FLASH_BASE       (0x00000000UL)                              /*!< (FLASH     ) Base Address */
+#define DeviceAbbreviation_SRAM_BASE        (0x20000000UL)                              /*!< (SRAM      ) Base Address */
+#define DeviceAbbreviation_PERIPH_BASE      (0x40000000UL)                              /*!< (Peripheral) Base Address */
+
+/* Peripheral memory map */
+#define DeviceAbbreviationTIM0_BASE         (DeviceAbbreviation_PERIPH_BASE)          /*!< (Timer0    ) Base Address */
+#define DeviceAbbreviationTIM1_BASE         (DeviceAbbreviation_PERIPH_BASE + 0x0800) /*!< (Timer1    ) Base Address */
+#define DeviceAbbreviationTIM2_BASE         (DeviceAbbreviation_PERIPH_BASE + 0x1000) /*!< (Timer2    ) Base Address */
+/*@}*/ /* end of group <Device>_MemoryMap */
+
+
+/******************************************************************************/
+/*                         Peripheral declaration                             */
+/******************************************************************************/
+/* ToDo: add here your device peripherals pointer definitions
+         following is an example for timer                                    */
+
+/** @addtogroup <Device>_PeripheralDecl <Device> Peripheral Declaration
+  @{
+*/
+
+#define DeviceAbbreviation_TIM0        ((DeviceAbbreviation_TMR_TypeDef *) DeviceAbbreviationTIM0_BASE)
+#define DeviceAbbreviation_TIM1        ((DeviceAbbreviation_TMR_TypeDef *) DeviceAbbreviationTIM0_BASE)
+#define DeviceAbbreviation_TIM2        ((DeviceAbbreviation_TMR_TypeDef *) DeviceAbbreviationTIM0_BASE)
+/*@}*/ /* end of group <Device>_PeripheralDecl */
+
+/*@}*/ /* end of group <Device>_Definitions */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* <Device>_H */

--- a/mchf-eclipse/cmsis/cmsis_device.h
+++ b/mchf-eclipse/cmsis/cmsis_device.h
@@ -1,0 +1,6 @@
+#ifndef _CMSIS_H_
+#define _CMSIS_H_
+
+#include "DEVICE.h"
+
+#endif // _CMSIS_H_

--- a/mchf-eclipse/cmsis/system_DEVICE.h
+++ b/mchf-eclipse/cmsis/system_DEVICE.h
@@ -1,0 +1,77 @@
+/**************************************************************************//**
+ * @file     system_<Device>.h
+ * @brief    CMSIS Cortex-M# Device Peripheral Access Layer Header File for
+ *           Device <Device>
+ * @version  V3.10
+ * @date     23. November 2012
+ *
+ * @note
+ *
+ ******************************************************************************/
+/* Copyright (c) 2012 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+
+#ifndef SYSTEM_Device_H   /* ToDo: replace '<Device>' with your device name */
+#define SYSTEM_Device_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+extern uint32_t SystemCoreClock;     /*!< System Clock Frequency (Core Clock)  */
+
+
+/**
+ * Initialize the system
+ *
+ * @param  none
+ * @return none
+ *
+ * @brief  Setup the microcontroller system.
+ *         Initialize the System and update the SystemCoreClock variable.
+ */
+extern void SystemInit (void);
+
+/**
+ * Update SystemCoreClock variable
+ *
+ * @param  none
+ * @return none
+ *
+ * @brief  Updates the SystemCoreClock with current core Clock
+ *         retrieved from cpu registers.
+ */
+extern void SystemCoreClockUpdate (void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SYSTEM_<Device>_H */

--- a/mchf-eclipse/drivers/diag/Trace.c
+++ b/mchf-eclipse/drivers/diag/Trace.c
@@ -1,0 +1,76 @@
+//
+// This file is part of the µOS++ III distribution.
+// Copyright (c) 2014 Liviu Ionescu.
+//
+
+// ----------------------------------------------------------------------------
+
+#if defined(TRACE)
+
+#include <stdio.h>
+#include <stdarg.h>
+#include "diag/Trace.h"
+#include "string.h"
+
+#ifndef OS_INTEGER_TRACE_PRINTF_TMP_ARRAY_SIZE
+#define OS_INTEGER_TRACE_PRINTF_TMP_ARRAY_SIZE (128)
+#endif
+
+// ----------------------------------------------------------------------------
+
+int
+trace_printf(const char* format, ...)
+{
+  int ret;
+  va_list ap;
+
+  va_start (ap, format);
+
+  // TODO: rewrite it to no longer use newlib, it is way too heavy
+
+  static char buf[OS_INTEGER_TRACE_PRINTF_TMP_ARRAY_SIZE];
+
+  // Print to the local buffer
+  ret = vsnprintf (buf, sizeof(buf), format, ap);
+  if (ret > 0)
+    {
+      // Transfer the buffer to the device
+      ret = trace_write (buf, (size_t)ret);
+    }
+
+  va_end (ap);
+  return ret;
+}
+
+int
+trace_puts(const char *s)
+{
+  trace_write(s, strlen(s));
+  return trace_write("\n", 1);
+}
+
+int
+trace_putchar(int c)
+{
+  trace_write((const char*)&c, 1);
+  return c;
+}
+
+void
+trace_dump_args(int argc, char* argv[])
+{
+  trace_printf("main(argc=%d, argv=[", argc);
+  for (int i = 0; i < argc; ++i)
+    {
+      if (i != 0)
+        {
+          trace_printf(", ");
+        }
+      trace_printf("\"%s\"", argv[i]);
+    }
+  trace_printf("]);\n");
+}
+
+// ----------------------------------------------------------------------------
+
+#endif // TRACE

--- a/mchf-eclipse/drivers/diag/Trace.h
+++ b/mchf-eclipse/drivers/diag/Trace.h
@@ -1,0 +1,146 @@
+//
+// This file is part of the µOS++ III distribution.
+// Copyright (c) 2014 Liviu Ionescu.
+//
+
+#ifndef DIAG_TRACE_H_
+#define DIAG_TRACE_H_
+
+// ----------------------------------------------------------------------------
+
+#include <unistd.h>
+
+// ----------------------------------------------------------------------------
+
+// The trace device is an independent output channel, intended for debug
+// purposes.
+//
+// The API is simple, and mimics the standard output calls:
+// - trace_printf()
+// - trace_puts()
+// - trace_putchar();
+//
+// The implementation is done in
+// - trace_write()
+//
+// Trace support is enabled by adding the TRACE definition.
+// By default the trace messages are forwarded to the ITM output,
+// but can be rerouted via any device or completely suppressed by
+// changing the definitions required in system/src/diag/trace_impl.c
+// (currently OS_USE_TRACE_ITM, OS_USE_TRACE_SEMIHOSTING_DEBUG/_STDOUT).
+//
+// When TRACE is not defined, all functions are inlined to empty bodies.
+// This has the advantage that the trace call do not need to be conditionally
+// compiled with #ifdef TRACE/#endif
+
+
+#if defined(TRACE)
+
+#if defined(__cplusplus)
+extern "C"
+{
+#endif
+
+  void
+  trace_initialize(void);
+
+  // Implementation dependent
+  ssize_t
+  trace_write(const char* buf, size_t nbyte);
+
+  // ----- Portable -----
+
+  int
+  trace_printf(const char* format, ...);
+
+  int
+  trace_puts(const char *s);
+
+  int
+  trace_putchar(int c);
+
+  void
+  trace_dump_args(int argc, char* argv[]);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#else // !defined(TRACE)
+
+#if defined(__cplusplus)
+extern "C"
+{
+#endif
+
+  inline void
+  trace_initialize(void);
+
+  // Implementation dependent
+  inline ssize_t
+  trace_write(const char* buf, size_t nbyte);
+
+  inline int
+  trace_printf(const char* format, ...);
+
+  inline int
+  trace_puts(const char *s);
+
+  inline int
+  trace_putchar(int c);
+
+  inline void
+  trace_dump_args(int argc, char* argv[]);
+
+#if defined(__cplusplus)
+}
+#endif
+
+inline void
+__attribute__((always_inline))
+trace_initialize(void)
+{
+}
+
+// Empty definitions when trace is not defined
+inline ssize_t
+__attribute__((always_inline))
+trace_write(const char* buf __attribute__((unused)),
+    size_t nbyte __attribute__((unused)))
+{
+  return 0;
+}
+
+inline int
+__attribute__((always_inline))
+trace_printf(const char* format __attribute__((unused)), ...)
+  {
+    return 0;
+  }
+
+inline int
+__attribute__((always_inline))
+trace_puts(const char *s __attribute__((unused)))
+{
+  return 0;
+}
+
+inline int
+__attribute__((always_inline))
+trace_putchar(int c)
+{
+  return c;
+}
+
+inline void
+__attribute__((always_inline))
+trace_dump_args(int argc __attribute__((unused)),
+    char* argv[] __attribute__((unused)))
+{
+}
+
+#endif // defined(TRACE)
+
+// ----------------------------------------------------------------------------
+
+#endif // DIAG_TRACE_H_

--- a/mchf-eclipse/drivers/diag/arm/semihosting.h
+++ b/mchf-eclipse/drivers/diag/arm/semihosting.h
@@ -1,0 +1,120 @@
+//
+// This file is part of the µOS++ III distribution.
+// Copyright (c) 2014 Liviu Ionescu.
+//
+
+#ifndef ARM_SEMIHOSTING_H_
+#define ARM_SEMIHOSTING_H_
+
+// ----------------------------------------------------------------------------
+
+// Semihosting operations.
+enum OperationNumber
+{
+  // Regular operations
+  SEMIHOSTING_EnterSVC = 0x17,
+  SEMIHOSTING_ReportException = 0x18,
+  SEMIHOSTING_SYS_CLOSE = 0x02,
+  SEMIHOSTING_SYS_CLOCK = 0x10,
+  SEMIHOSTING_SYS_ELAPSED = 0x30,
+  SEMIHOSTING_SYS_ERRNO = 0x13,
+  SEMIHOSTING_SYS_FLEN = 0x0C,
+  SEMIHOSTING_SYS_GET_CMDLINE = 0x15,
+  SEMIHOSTING_SYS_HEAPINFO = 0x16,
+  SEMIHOSTING_SYS_ISERROR = 0x08,
+  SEMIHOSTING_SYS_ISTTY = 0x09,
+  SEMIHOSTING_SYS_OPEN = 0x01,
+  SEMIHOSTING_SYS_READ = 0x06,
+  SEMIHOSTING_SYS_READC = 0x07,
+  SEMIHOSTING_SYS_REMOVE = 0x0E,
+  SEMIHOSTING_SYS_RENAME = 0x0F,
+  SEMIHOSTING_SYS_SEEK = 0x0A,
+  SEMIHOSTING_SYS_SYSTEM = 0x12,
+  SEMIHOSTING_SYS_TICKFREQ = 0x31,
+  SEMIHOSTING_SYS_TIME = 0x11,
+  SEMIHOSTING_SYS_TMPNAM = 0x0D,
+  SEMIHOSTING_SYS_WRITE = 0x05,
+  SEMIHOSTING_SYS_WRITEC = 0x03,
+  SEMIHOSTING_SYS_WRITE0 = 0x04,
+
+  // Codes returned by SEMIHOSTING_ReportException
+  ADP_Stopped_ApplicationExit = ((2 << 16) + 38),
+  ADP_Stopped_RunTimeError = ((2 << 16) + 35),
+
+};
+
+// ----------------------------------------------------------------------------
+
+// SWI numbers and reason codes for RDI (Angel) monitors.
+#define AngelSWI_ARM                    0x123456
+#ifdef __thumb__
+#define AngelSWI                        0xAB
+#else
+#define AngelSWI                        AngelSWI_ARM
+#endif
+// For thumb only architectures use the BKPT instruction instead of SWI.
+#if defined(__ARM_ARCH_7M__)     \
+    || defined(__ARM_ARCH_7EM__) \
+    || defined(__ARM_ARCH_6M__)
+#define AngelSWIInsn                    "bkpt"
+#define AngelSWIAsm                     bkpt
+#else
+#define AngelSWIInsn                    "swi"
+#define AngelSWIAsm                     swi
+#endif
+
+#if defined(OS_DEBUG_SEMIHOSTING_FAULTS)
+// Testing the local semihosting handler cannot use another BKPT, since this
+// configuration cannot trigger HaedFault exceptions while the debugger is
+// connected, so we use an illegal op code, that will trigger an
+// UsageFault exception.
+#define AngelSWITestFault       "setend be"
+#define AngelSWITestFaultOpCode (0xB658)
+#endif
+
+static inline int
+__attribute__ ((always_inline))
+call_host (int reason, void* arg)
+{
+  int value;
+  asm volatile (
+
+      " mov r0, %[rsn]  \n"
+      " mov r1, %[arg]  \n"
+#if defined(OS_DEBUG_SEMIHOSTING_FAULTS)
+      " " AngelSWITestFault " \n"
+#else
+      " " AngelSWIInsn " %[swi] \n"
+#endif
+      " mov %[val], r0"
+
+      : [val] "=r" (value) /* Outputs */
+      : [rsn] "r" (reason), [arg] "r" (arg), [swi] "i" (AngelSWI) /* Inputs */
+      : "r0", "r1", "r2", "r3", "ip", "lr", "memory", "cc"
+      // Clobbers r0 and r1, and lr if in supervisor mode
+  );
+
+  // Accordingly to page 13-77 of ARM DUI 0040D other registers
+  // can also be clobbered. Some memory positions may also be
+  // changed by a system call, so they should not be kept in
+  // registers. Note: we are assuming the manual is right and
+  // Angel is respecting the APCS.
+  return value;
+}
+
+// ----------------------------------------------------------------------------
+
+// Function used in _exit() to return the status code as Angel exception.
+static inline void
+__attribute__ ((always_inline,noreturn))
+report_exception (int reason)
+{
+  call_host (SEMIHOSTING_ReportException, (void*) reason);
+
+  for (;;)
+    ;
+}
+
+// ----------------------------------------------------------------------------
+
+#endif // ARM_SEMIHOSTING_H_

--- a/mchf-eclipse/drivers/diag/trace_impl.c
+++ b/mchf-eclipse/drivers/diag/trace_impl.c
@@ -1,0 +1,252 @@
+//
+// This file is part of the µOS++ III distribution.
+// Copyright (c) 2014 Liviu Ionescu.
+//
+
+// ----------------------------------------------------------------------------
+
+#if defined(TRACE)
+
+#include "cmsis_device.h"
+#include "diag/Trace.h"
+
+// ----------------------------------------------------------------------------
+
+// One of these definitions must be passed via the compiler command line
+// Note: small Cortex-M0/M0+ might implement a simplified debug interface.
+
+//#define OS_USE_TRACE_ITM
+//#define OS_USE_TRACE_SEMIHOSTING_DEBUG
+//#define OS_USE_TRACE_SEMIHOSTING_STDOUT
+
+#if !(defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7EM__))
+#if defined(OS_USE_TRACE_ITM)
+#undef OS_USE_TRACE_ITM
+#warning "ITM unavailable"
+#endif // defined(OS_USE_TRACE_ITM)
+#endif // !(defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7EM__))
+
+#if defined(OS_DEBUG_SEMIHOSTING_FAULTS)
+#if defined(OS_USE_TRACE_SEMIHOSTING_STDOUT) || defined(OS_USE_TRACE_SEMIHOSTING_DEBUG)
+#error "Cannot debug semihosting using semihosting trace; use OS_USE_TRACE_ITM"
+#endif
+#endif
+
+// ----------------------------------------------------------------------------
+
+// Forward definitions.
+
+#if defined(OS_USE_TRACE_ITM)
+static ssize_t
+_trace_write_itm (const char* buf, size_t nbyte);
+#endif
+
+#if defined(OS_USE_TRACE_SEMIHOSTING_STDOUT)
+static ssize_t
+_trace_write_semihosting_stdout(const char* buf, size_t nbyte);
+#endif
+
+#if defined(OS_USE_TRACE_SEMIHOSTING_DEBUG)
+static ssize_t
+_trace_write_semihosting_debug(const char* buf, size_t nbyte);
+#endif
+
+// ----------------------------------------------------------------------------
+
+void
+trace_initialize(void)
+{
+  // For regular ITM / semihosting, no inits required.
+}
+
+// ----------------------------------------------------------------------------
+
+// This function is called from _write() for fd==1 or fd==2 and from some
+// of the trace_* functions.
+
+ssize_t
+trace_write (const char* buf __attribute__((unused)),
+	     size_t nbyte __attribute__((unused)))
+{
+#if defined(OS_USE_TRACE_ITM)
+  return _trace_write_itm (buf, nbyte);
+#elif defined(OS_USE_TRACE_SEMIHOSTING_STDOUT)
+  return _trace_write_semihosting_stdout(buf, nbyte);
+#elif defined(OS_USE_TRACE_SEMIHOSTING_DEBUG)
+  return _trace_write_semihosting_debug(buf, nbyte);
+#endif
+
+  return -1;
+}
+
+// ----------------------------------------------------------------------------
+
+#if defined(OS_USE_TRACE_ITM)
+
+#if defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7EM__)
+
+// ITM is the ARM standard mechanism, running over SWD/SWO on Cortex-M3/M4
+// devices, and is the recommended setting, if available.
+//
+// The JLink probe and the GDB server fully support SWD/SWO
+// and the JLink Debugging plug-in enables it by default.
+// The current OpenOCD does not include support to parse the SWO stream,
+// so this configuration will not work on OpenOCD (will not crash, but
+// nothing will be displayed in the output console).
+
+#if !defined(OS_INTEGER_TRACE_ITM_STIMULUS_PORT)
+#define OS_INTEGER_TRACE_ITM_STIMULUS_PORT     (0)
+#endif
+
+static ssize_t
+_trace_write_itm (const char* buf, size_t nbyte)
+{
+  for (size_t i = 0; i < nbyte; i++)
+    {
+      // Check if ITM or the stimulus port are not enabled
+      if (((ITM->TCR & ITM_TCR_ITMENA_Msk) == 0)
+	  || ((ITM->TER & (1UL << OS_INTEGER_TRACE_ITM_STIMULUS_PORT)) == 0))
+	{
+	  return (ssize_t)i; // return the number of sent characters (may be 0)
+	}
+
+      // Wait until STIMx is ready...
+      while (ITM->PORT[OS_INTEGER_TRACE_ITM_STIMULUS_PORT].u32 == 0)
+	;
+      // then send data, one byte at a time
+      ITM->PORT[OS_INTEGER_TRACE_ITM_STIMULUS_PORT].u8 = (uint8_t) (*buf++);
+    }
+
+  return (ssize_t)nbyte; // all characters successfully sent
+}
+
+#endif // defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7EM__)
+
+#endif // OS_USE_TRACE_ITM
+
+// ----------------------------------------------------------------------------
+
+#if defined(OS_USE_TRACE_SEMIHOSTING_DEBUG) || defined(OS_USE_TRACE_SEMIHOSTING_STDOUT)
+
+#include "arm/semihosting.h"
+
+// Semihosting is the other output channel that can be used for the trace
+// messages. It comes in two flavours: STDOUT and DEBUG. The STDOUT channel
+// is the equivalent of the stdout in POSIX and in most cases it is forwarded
+// to the GDB server stdout stream. The debug channel is a separate
+// channel. STDOUT is buffered, so nothing is displayed until a \n;
+// DEBUG is not buffered, but can be slow.
+//
+// Choosing between semihosting stdout and debug depends on the capabilities
+// of your GDB server, and also on specific needs. It is recommended to test
+// DEBUG first, and if too slow, try STDOUT.
+//
+// The JLink GDB server fully support semihosting, and both configurations
+// are available; to activate it, use "monitor semihosting enable" or check
+// the corresponding button in the JLink Debugging plug-in.
+// In OpenOCD, support for semihosting can be enabled using
+// "monitor arm semihosting enable".
+//
+// Note: Applications built with semihosting output active normally cannot
+// be executed without the debugger connected and active, since they use
+// BKPT to communicate with the host. However, with a carefully written
+// HardFault_Handler, the semihosting BKPT calls can be processed, making
+// possible to run semihosting applications as standalone, without being
+// terminated with hardware faults.
+
+#endif // OS_USE_TRACE_SEMIHOSTING_DEBUG_*
+
+// ----------------------------------------------------------------------------
+
+#if defined(OS_USE_TRACE_SEMIHOSTING_STDOUT)
+
+static ssize_t
+_trace_write_semihosting_stdout (const char* buf, size_t nbyte)
+{
+  static int handle;
+  void* block[3];
+  int ret;
+
+  if (handle == 0)
+    {
+      // On the first call get the file handle from the host
+      block[0] = ":tt"; // special filename to be used for stdin/out/err
+      block[1] = (void*) 4; // mode "w"
+      // length of ":tt", except null terminator
+      block[2] = (void*) (sizeof(":tt") - 1);
+
+      ret = call_host (SEMIHOSTING_SYS_OPEN, (void*) block);
+      if (ret == -1)
+        return -1;
+
+      handle = ret;
+    }
+
+  block[0] = (void*) handle;
+  block[1] = (void*) buf;
+  block[2] = (void*) nbyte;
+  // send character array to host file/device
+  ret = call_host (SEMIHOSTING_SYS_WRITE, (void*) block);
+  // this call returns the number of bytes NOT written (0 if all ok)
+
+  // -1 is not a legal value, but SEGGER seems to return it
+  if (ret == -1)
+    return -1;
+
+  // The compliant way of returning errors
+  if (ret == (int) nbyte)
+    return -1;
+
+  // Return the number of bytes written
+  return (ssize_t) (nbyte) - (ssize_t) ret;
+}
+
+#endif // OS_USE_TRACE_SEMIHOSTING_STDOUT
+
+// ----------------------------------------------------------------------------
+
+#if defined(OS_USE_TRACE_SEMIHOSTING_DEBUG)
+
+#define OS_INTEGER_TRACE_TMP_ARRAY_SIZE  (16)
+
+static ssize_t
+_trace_write_semihosting_debug (const char* buf, size_t nbyte)
+{
+  // Since the single character debug channel is quite slow, try to
+  // optimise and send a null terminated string, if possible.
+  if (buf[nbyte] == '\0')
+    {
+      // send string
+      call_host (SEMIHOSTING_SYS_WRITE0, (void*) buf);
+    }
+  else
+    {
+      // If not, use a local buffer to speed things up
+      char tmp[OS_INTEGER_TRACE_TMP_ARRAY_SIZE];
+      size_t togo = nbyte;
+      while (togo > 0)
+        {
+          unsigned int n = ((togo < sizeof(tmp)) ? togo : sizeof(tmp));
+          unsigned int i = 0;
+          for (; i < n; ++i, ++buf)
+            {
+              tmp[i] = *buf;
+            }
+          tmp[i] = '\0';
+
+          call_host (SEMIHOSTING_SYS_WRITE0, (void*) tmp);
+
+          togo -= n;
+        }
+    }
+
+  // All bytes written
+  return (ssize_t) nbyte;
+}
+
+#endif // OS_USE_TRACE_SEMIHOSTING_DEBUG
+
+#endif // TRACE
+
+// ----------------------------------------------------------------------------
+

--- a/mchf-eclipse/drivers/freedv/freedv_api.c
+++ b/mchf-eclipse/drivers/freedv/freedv_api.c
@@ -740,7 +740,7 @@ int freedv_comprx(struct freedv *f, short speech_out[], COMP demod_in[]) {
 
     if (f->mode == FREEDV_MODE_1600) {
 
-#if 0
+#ifndef ARM_MATH_CM4
         // TODO: ~14,4us
         for(i=0; i<f->nin; i++)
             demod_in[i] = fcmult(1.0/FDMDV_SCALE, demod_in[i]);

--- a/mchf-eclipse/main.c
+++ b/mchf-eclipse/main.c
@@ -517,12 +517,15 @@ static void wd_reset(void)
 	}
 }
  */
+#include "diag/Trace.h"
 
 // Power on
 int main(void)
 {
 
 
+    trace_puts("Hello mcHF World!");
+    // trace_printf(" %u\n", 1u);
 
 
     *(__IO uint32_t*)(SRAM2_BASE) = 0x0;	// clearing delay prevent for bootloader

--- a/mchf-eclipse/support/MCHF.launch
+++ b/mchf-eclipse/support/MCHF.launch
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="ilg.gnuarmeclipse.debug.gdbjtag.openocd.launchConfigurationType">
+<stringAttribute key="bad_container_name" value="\mchf-eclipse\s"/>
+<stringAttribute key="ilg.gnuarmeclipse.debug.gdbjtag.PERIPHERALS" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#13;&#10;&lt;peripherals&gt;&#13;&#10;&lt;peripheral name=&quot;DMA1&quot;/&gt;&#13;&#10;&lt;peripheral name=&quot;SPI2&quot;/&gt;&#13;&#10;&lt;/peripherals&gt;&#13;&#10;"/>
+<booleanAttribute key="ilg.gnuarmeclipse.debug.gdbjtag.openocd.doContinue" value="true"/>
+<booleanAttribute key="ilg.gnuarmeclipse.debug.gdbjtag.openocd.doDebugInRam" value="false"/>
+<booleanAttribute key="ilg.gnuarmeclipse.debug.gdbjtag.openocd.doFirstReset" value="true"/>
+<booleanAttribute key="ilg.gnuarmeclipse.debug.gdbjtag.openocd.doGdbServerAllocateConsole" value="true"/>
+<booleanAttribute key="ilg.gnuarmeclipse.debug.gdbjtag.openocd.doGdbServerAllocateTelnetConsole" value="false"/>
+<booleanAttribute key="ilg.gnuarmeclipse.debug.gdbjtag.openocd.doSecondReset" value="true"/>
+<booleanAttribute key="ilg.gnuarmeclipse.debug.gdbjtag.openocd.doStartGdbServer" value="true"/>
+<booleanAttribute key="ilg.gnuarmeclipse.debug.gdbjtag.openocd.enableSemihosting" value="true"/>
+<stringAttribute key="ilg.gnuarmeclipse.debug.gdbjtag.openocd.firstResetType" value="init"/>
+<stringAttribute key="ilg.gnuarmeclipse.debug.gdbjtag.openocd.gdbClientOtherCommands" value="set mem inaccessible-by-default off"/>
+<stringAttribute key="ilg.gnuarmeclipse.debug.gdbjtag.openocd.gdbClientOtherOptions" value=""/>
+<stringAttribute key="ilg.gnuarmeclipse.debug.gdbjtag.openocd.gdbServerConnectionAddress" value=""/>
+<stringAttribute key="ilg.gnuarmeclipse.debug.gdbjtag.openocd.gdbServerExecutable" value="${openocd_path}/${openocd_executable}"/>
+<intAttribute key="ilg.gnuarmeclipse.debug.gdbjtag.openocd.gdbServerGdbPortNumber" value="3333"/>
+<stringAttribute key="ilg.gnuarmeclipse.debug.gdbjtag.openocd.gdbServerLog" value=""/>
+<stringAttribute key="ilg.gnuarmeclipse.debug.gdbjtag.openocd.gdbServerOther" value="-f support/MCHF.cfg"/>
+<intAttribute key="ilg.gnuarmeclipse.debug.gdbjtag.openocd.gdbServerTelnetPortNumber" value="4444"/>
+<stringAttribute key="ilg.gnuarmeclipse.debug.gdbjtag.openocd.otherInitCommands" value=""/>
+<stringAttribute key="ilg.gnuarmeclipse.debug.gdbjtag.openocd.otherRunCommands" value=""/>
+<stringAttribute key="ilg.gnuarmeclipse.debug.gdbjtag.openocd.secondResetType" value="halt"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.imageFileName" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.imageOffset" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.ipAddress" value="localhost"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.jtagDevice" value="GNU ARM OpenOCD"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadImage" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadSymbols" value="true"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.pcRegister" value=""/>
+<intAttribute key="org.eclipse.cdt.debug.gdbjtag.core.portNumber" value="3333"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setPcRegister" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setResume" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setStopAt" value="true"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.stopAt" value="main"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.symbolsFileName" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.symbolsOffset" value=""/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useFileForImage" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useFileForSymbols" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useProjBinaryForImage" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useProjBinaryForSymbols" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useRemoteTarget" value="true"/>
+<stringAttribute key="org.eclipse.cdt.debug.mi.core.commandFactory" value="Standard (Windows)"/>
+<stringAttribute key="org.eclipse.cdt.debug.mi.core.protocol" value="mi"/>
+<booleanAttribute key="org.eclipse.cdt.debug.mi.core.verboseMode" value="false"/>
+<stringAttribute key="org.eclipse.cdt.dsf.gdb.DEBUG_NAME" value="${cross_prefix}gdb${cross_suffix}"/>
+<booleanAttribute key="org.eclipse.cdt.dsf.gdb.UPDATE_THREADLIST_ON_SUSPEND" value="false"/>
+<intAttribute key="org.eclipse.cdt.launch.ATTR_BUILD_BEFORE_LAUNCH_ATTR" value="2"/>
+<stringAttribute key="org.eclipse.cdt.launch.COREFILE_PATH" value=""/>
+<stringAttribute key="org.eclipse.cdt.launch.DEBUGGER_REGISTER_GROUPS" value=""/>
+<stringAttribute key="org.eclipse.cdt.launch.PROGRAM_NAME" value="Debug\mchf-eclipse.elf"/>
+<stringAttribute key="org.eclipse.cdt.launch.PROJECT_ATTR" value="mchf-eclipse"/>
+<booleanAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_AUTO_ATTR" value="false"/>
+<stringAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_ID_ATTR" value=""/>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/mchf-eclipse"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="4"/>
+</listAttribute>
+<stringAttribute key="org.eclipse.dsf.launch.MEMORY_BLOCKS" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#13;&#10;&lt;memoryBlockExpressionList context=&quot;Context string&quot;/&gt;&#13;&#10;"/>
+<stringAttribute key="process_factory_id" value="org.eclipse.cdt.dsf.gdb.GdbProcessFactory"/>
+<stringAttribute key="saved_expressions&lt;seperator&gt;Unknown" value="0x2002000,0x20020000,0x200020000,0x20000000,0x2000000,0x200000000,0x2000000000,0x20000000000,0x20000,0x200000,0x20010000,0x20011000,0x20001000,0x20002000"/>
+</launchConfiguration>

--- a/mchf-eclipse/support/codec2-dev.patch
+++ b/mchf-eclipse/support/codec2-dev.patch
@@ -1,43 +1,222 @@
-Index: codec2-dev/src/fm.c
+Index: codec2-dev/src/fdmdv.c
 ===================================================================
---- codec2-dev/src/fm.c	(revision 2841)
-+++ codec2-dev/src/fm.c	(working copy)
-@@ -120,7 +120,10 @@
-   float  wd = 2*M_PI*fd/Fs;
-   COMP  *rx_bb = fm_states->rx_bb + FILT_MEM;
-   COMP   wc_rect, rx_bb_filt, rx_bb_diff;
--  float  rx_dem, acc;
-+  float  rx_dem;
-+  /*
-+  float acc;
-+  */
-   float *rx_dem_mem = fm_states->rx_dem_mem + FILT_MEM;
-   int    nsam = fm_states->nsam;
-   float  mag;
-@@ -170,8 +173,8 @@
-       rx_dem *= (1/wd);
-       //printf("%f %f\n", rx_bb_diff.real, rx_bb_diff.imag);
-       rx_dem_mem[i] = rx_dem;
-+      /*
-       acc = 0;
--      /*
-         for(k=0; k<FILT_MEM; k++) {
-           acc += rx_dem_mem[i-k] * bout[k];
-       }
-Index: codec2-dev/src/freedv_api.c
-===================================================================
---- codec2-dev/src/freedv_api.c	(revision 2841)
-+++ codec2-dev/src/freedv_api.c	(working copy)
-@@ -678,8 +678,11 @@
+--- codec2-dev/src/fdmdv.c	(revision 2846)
++++ codec2-dev/src/fdmdv.c	(working copy)
+@@ -50,11 +50,21 @@
+ #include "machdep.h"
  
- void freedv_comptx(struct freedv *f, COMP mod_out[], short speech_in[]) {
-     assert(f != NULL);
--    int    i, j;
-+    int    i;
-+#ifndef CORTEX_M4
-+    int    j;	
-     int    bits_per_codec_frame;
+ static int sync_uw[] = {1,-1,1,-1,1,-1};
+-
+ #ifdef __EMBEDDED__
+ #define printf gdb_stdio_printf
+ #endif
+ 
++#ifndef ARM_MATH_CM4
++  #define SINF(a) sinf(a)
++  #define COSF(a) cosf(a)
++#else
++  #define SINF(a) arm_sin_f32(a)
++  #define COSF(a) arm_cos_f32(a)
 +#endif
-     short  tx_real[f->n_nom_modem_samples];
++
++static const COMP  pi_on_4 = { .70710678118654752439, .70710678118654752439 }; // COSF(PI/4) , SINF(PI/4)
++
++
+ /*--------------------------------------------------------------------------* \
  
-     assert((f->mode == FREEDV_MODE_1600) || (f->mode == FREEDV_MODE_700) || 
+   FUNCTION....: fdmdv_create
+@@ -110,8 +120,8 @@
+            This helped PAPR for a few dB.  We don't need to adjust rx
+            phase as DQPSK takes care of that. */
+ 
+-	f->phase_tx[c].real = cosf(2.0*PI*c/(Nc+1));
+- 	f->phase_tx[c].imag = sinf(2.0*PI*c/(Nc+1));
++	f->phase_tx[c].real = COSF(2.0*PI*c/(Nc+1));
++ 	f->phase_tx[c].imag = SINF(2.0*PI*c/(Nc+1));
+ 
+ 	f->phase_rx[c].real = 1.0;
+  	f->phase_rx[c].imag = 0.0;
+@@ -124,12 +134,12 @@
+     f->prev_tx_symbols[Nc].real = 2.0;
+ 
+     fdmdv_set_fsep(f, FSEP);
+-    f->freq[Nc].real = cosf(2.0*PI*0.0/FS);
+-    f->freq[Nc].imag = sinf(2.0*PI*0.0/FS);
++    f->freq[Nc].real = COSF(2.0*PI*0.0/FS);
++    f->freq[Nc].imag = SINF(2.0*PI*0.0/FS);
+     f->freq_pol[Nc]  = 2.0*PI*0.0/FS;
+ 
+-    f->fbb_rect.real     = cosf(2.0*PI*FDMDV_FCENTRE/FS);
+-    f->fbb_rect.imag     = sinf(2.0*PI*FDMDV_FCENTRE/FS);
++    f->fbb_rect.real     = COSF(2.0*PI*FDMDV_FCENTRE/FS);
++    f->fbb_rect.imag     = SINF(2.0*PI*FDMDV_FCENTRE/FS);
+     f->fbb_pol           = 2.0*PI*FDMDV_FCENTRE/FS;
+     f->fbb_phase_tx.real = 1.0;
+     f->fbb_phase_tx.imag = 0.0;
+@@ -257,15 +267,15 @@
+ 
+     for(c=0; c<f->Nc/2; c++) {
+ 	carrier_freq = (-f->Nc/2 + c)*f->fsep;
+-	f->freq[c].real = cosf(2.0*PI*carrier_freq/FS);
+- 	f->freq[c].imag = sinf(2.0*PI*carrier_freq/FS);
++	f->freq[c].real = COSF(2.0*PI*carrier_freq/FS);
++ 	f->freq[c].imag = SINF(2.0*PI*carrier_freq/FS);
+  	f->freq_pol[c]  = 2.0*PI*carrier_freq/FS;
+     }
+ 
+     for(c=f->Nc/2; c<f->Nc; c++) {
+ 	carrier_freq = (-f->Nc/2 + c + 1)*f->fsep;
+-	f->freq[c].real = cosf(2.0*PI*carrier_freq/FS);
+- 	f->freq[c].imag = sinf(2.0*PI*carrier_freq/FS);
++	f->freq[c].real = COSF(2.0*PI*carrier_freq/FS);
++ 	f->freq[c].imag = SINF(2.0*PI*carrier_freq/FS);
+  	f->freq_pol[c]  = 2.0*PI*carrier_freq/FS;
+     }
+ }
+@@ -676,6 +686,12 @@
+ 	if (f >= 4)
+ 	    memcpy(&pilot_lut[M*(f-4)], pilot, M*sizeof(COMP));
+     }
++   
++    // create complex conjugate since we need this and only this later on 
++    for (f=0;f<4*M;f++)
++    {
++        pilot_lut[f] = cconj(pilot_lut[f]);
++    }
+ 
+ }
+ 
+@@ -806,10 +822,18 @@
+ 	f->pilot_baseband2[i] = f->pilot_baseband2[i+nin];
+     }
+ 
++#ifndef ARM_MATH_CM4
+     for(i=0,j=NPILOTBASEBAND-nin; i<nin; i++,j++) {
+-       	f->pilot_baseband1[j] = cmult(rx_fdm[i], cconj(pilot[i]));
+-	f->pilot_baseband2[j] = cmult(rx_fdm[i], cconj(prev_pilot[i]));
++       	f->pilot_baseband1[j] = cmult(rx_fdm[i], pilot[i]);
++	f->pilot_baseband2[j] = cmult(rx_fdm[i], prev_pilot[i]);
+     }
++#else
++    // TODO: Maybe a handwritten mult taking advantage of rx_fdm[0] being 
++    // used twice would be faster but this is for sure faster than 
++    // the implementation above in any case.
++    arm_cmplx_mult_cmplx_f32(&rx_fdm[0].real,&pilot[0].real,&f->pilot_baseband1[NPILOTBASEBAND-nin].real,nin);
++    arm_cmplx_mult_cmplx_f32(&rx_fdm[0].real,&prev_pilot[0].real,&f->pilot_baseband2[NPILOTBASEBAND-nin].real,nin);
++#endif
+ 
+     lpf_peak_pick(&foff1, &max1, f->pilot_baseband1, f->pilot_lpf1, f->fft_pilot_cfg, f->S1, nin, do_fft);
+     lpf_peak_pick(&foff2, &max2, f->pilot_baseband2, f->pilot_lpf2, f->fft_pilot_cfg, f->S2, nin, do_fft);
+@@ -840,8 +864,8 @@
+     float mag;
+     int   i;
+ 
+-    foff_rect.real = cosf(2.0*PI*foff/FS);
+-    foff_rect.imag = sinf(2.0*PI*foff/FS);
++    foff_rect.real = COSF(2.0*PI*foff/FS);
++    foff_rect.imag = SINF(2.0*PI*foff/FS);
+     for(i=0; i<nin; i++) {
+ 	*foff_phase_rect = cmult(*foff_phase_rect, foff_rect);
+ 	rx_fdm_fcorr[i] = cmult(rx_fdm[i], *foff_phase_rect);
+@@ -992,7 +1016,41 @@
+     return dec_rate*acc;
+ }
+ 
++/*---------------------------------------------------------------------------*\
+ 
++  FUNCTION....: fir_filter2()
++  AUTHOR......: David Rowe
++  DATE CREATED: July 2014
++
++  Helper fir filter function which runs 2x same filter on two sets of data.
++\*---------------------------------------------------------------------------*/
++
++static void fir_filter2(float acc[2], float mem[], float coeff[], const unsigned int dec_rate) {
++    acc[0] = 0.0;
++    acc[1] = 0.0;
++
++    float c,m1,m2,a1,a2;
++    float* inpCmplx = &mem[0];
++    float* coeffPtr = &coeff[0];
++
++    int m;
++
++    for(m=0; m<NFILTER; m+=dec_rate) {
++        c = *coeffPtr;
++        m1 = inpCmplx[0];
++        m2 = inpCmplx[1];
++        a1 = c * m1;
++        a2 = c * m2;
++        acc[0] += a1;
++        inpCmplx+= dec_rate*2;
++        acc[1] += a2;
++        coeffPtr+= dec_rate;
++    }
++
++    acc[0] *= dec_rate;
++    acc[1] *= dec_rate;
++}
++
+ /*---------------------------------------------------------------------------*\
+ 
+   FUNCTION....: down_convert_and_rx_filter()
+@@ -1049,8 +1107,8 @@
+ 
+         //PROFILE_SAMPLE(windback_start);
+         windback_phase           = -freq_pol[c]*NFILTER;
+-        windback_phase_rect.real = cosf(windback_phase);
+-        windback_phase_rect.imag = sinf(windback_phase);
++        windback_phase_rect.real = COSF(windback_phase);
++        windback_phase_rect.imag = SINF(windback_phase);
+         phase_rx[c]              = cmult(phase_rx[c],windback_phase_rect);
+         //PROFILE_SAMPLE_AND_LOG(downconvert_start, windback_start, "        windback");
+ 
+@@ -1082,8 +1140,9 @@
+            for(m=0; m<NFILTER; m++)
+                rx_filt[c][k] = cadd(rx_filt[c][k], fcmult(gt_alpha5_root[m], rx_baseband[st+i+m]));
+            #else
+-           rx_filt[c][k].real = fir_filter(&rx_baseband[st+i].real, (float*)gt_alpha5_root, dec_rate);
+-           rx_filt[c][k].imag = fir_filter(&rx_baseband[st+i].imag, (float*)gt_alpha5_root, dec_rate);
++            // rx_filt[c][k].real = fir_filter(&rx_baseband[st+i].real, (float*)gt_alpha5_root, dec_rate);
++            // rx_filt[c][k].imag = fir_filter(&rx_baseband[st+i].imag, (float*)gt_alpha5_root, dec_rate);
++	    fir_filter2(&rx_filt[c][k].real,&rx_baseband[st+i].real, (float*)gt_alpha5_root, dec_rate);
+            #endif
+         }
+         //PROFILE_SAMPLE_AND_LOG2(filter_start, "        filter");
+@@ -1155,8 +1214,8 @@
+        out single DFT at frequency 2*pi/P */
+ 
+     x.real = 0.0; x.imag = 0.0;
+-    freq.real = cosf(2*PI/P);
+-    freq.imag = sinf(2*PI/P);
++    freq.real = COSF(2*PI/P);
++    freq.imag = SINF(2*PI/P);
+     phase.real = 1.0;
+     phase.imag = 0.0;
+ 
+@@ -1213,13 +1272,10 @@
+                    COMP rx_symbols[], int old_qpsk_mapping)
+ {
+     int   c;
+-    COMP  pi_on_4;
+     COMP  d;
+     int   msb=0, lsb=0;
+     float ferr, norm;
+ 
+-    pi_on_4.real = cosf(PI/4.0);
+-    pi_on_4.imag = sinf(PI/4.0);
+ 
+     /* Extra 45 degree clockwise lets us use real and imag axis as
+        decision boundaries. "norm" makes sure the phase subtraction
+@@ -1296,11 +1352,8 @@
+     float s[NC+1];
+     COMP  refl_symbols[NC+1];
+     float n[NC+1];
+-    COMP  pi_on_4;
+     int   c;
+ 
+-    pi_on_4.real = cosf(PI/4.0);
+-    pi_on_4.imag = sinf(PI/4.0);
+ 
+     /* mag of each symbol is distance from origin, this gives us a
+        vector of mags, one for each carrier. */


### PR DESCRIPTION
Makefile needs to define TRACE and OS_USE_TRACE_SEMIHOSTING_DEBUG in order to run with semihosting. You have to connect with the ST-LINK USB debug interface to the mcHF in order to use semihosting.
You have to enable Semihosting in the Eclipse Debug Configuration, Startup Tab. How to do this in plain gdb / openocd needs to be figured out (should be easy). 

The example code is in main.c first lines of function main().

Please be aware that using the trace_puts and trace_printf may considerably
slow down the running mchf if used extensively.

Other changes in the second commit are non-functional cleanup in FreeDV
