### PR TITLE
This FreeDV change reduces decode time by more than 20 percent.

### DIFF
--- a/mchf-eclipse/drivers/freedv/quantise.c
+++ b/mchf-eclipse/drivers/freedv/quantise.c
@@ -1003,9 +1003,23 @@ void aks_to_M2(
 
   /* Determine power spectrum P(w) = E/(A(exp(jw))^2 ------------------------*/
 
+#ifndef ARM_MATH_CM4
   for(i=0; i<FFT_ENC/2; i++) {
     Pw[i].real = 1.0/(Aw[i].real*Aw[i].real + Aw[i].imag*Aw[i].imag + 1E-6);
   }
+#else
+  // this difference may seem strange, but the gcc for STM32F4 generates almost 5 times
+  // faster code with the two loops: 1120 ms -> 242 ms
+  // so please leave it as is or improve further
+  // since this code is called 4 times it results in almost 4ms gain (21ms -> 17ms per audio frame decode @ 1300 )
+  for(i=0; i<FFT_ENC/2; i++)
+  {
+      Pw[i].real = Aw[i].real * Aw[i].real + Aw[i].imag * Aw[i].imag  + 1E-6;
+  }
+  for(i=0; i<FFT_ENC/2; i++) {
+      Pw[i].real = 1.0/(Pw[i].real);
+  }
+#endif
 
   PROFILE_SAMPLE_AND_LOG(tpw, tfft, "      Pw");
 

--- a/mchf-eclipse/misc/profiling.c
+++ b/mchf-eclipse/misc/profiling.c
@@ -23,7 +23,7 @@
  */
 EventProfile_t eventProfile;
 
-#if 0
+#if 1
 // the code below is only used to ease profiling with eclipse
 // you just need hover over a variable to get the value
 void dummy() {
@@ -51,3 +51,19 @@ void dummy() {
 
 }
 #endif
+
+
+void profileEventsTracePrint()
+{
+#ifdef PROFILE_EVENTS
+
+            for (int i = 0;i < 10;i++)
+            {
+                ProfilingTimedEvent* ev_ptr = profileTimedEventGet(i);
+                if (ev_ptr->count != 0)
+                {
+                    trace_printf("%d: %d uS per run\n",i, (ev_ptr->duration/(ev_ptr->count*168)));
+                }
+            }
+#endif
+}

--- a/mchf-eclipse/misc/profiling.h
+++ b/mchf-eclipse/misc/profiling.h
@@ -75,6 +75,8 @@ inline void profileEvent(const ProfiledEventNames pe) {
  * remove the overhead later.
  */
 
+void profileEventsTracePrint();
+
 
 inline void profileTimedEventInit();
 inline void profileTimedEventStart(const ProfiledEventNames pe);

--- a/mchf-eclipse/misc/test_fdmdv.c
+++ b/mchf-eclipse/misc/test_fdmdv.c
@@ -293,17 +293,9 @@ int run(int cumulativeOutput, int numberOfRuns, int currentRun, int next_nin)
             int range=cumulativeOutput?FRAMES:1;
             int start=cumulativeOutput?0:f;
 
-#ifdef PROFILE_EVENTS
-            for (int i = 0;i < 10;i++)
-            {
-                ProfilingTimedEvent* ev_ptr = profileTimedEventGet(i);
-                if (ev_ptr->count != 0)
-                {
+
 #if CUMULATIVE
-                    trace_printf("%d: %d uS per run\n",i, (ev_ptr->duration/(ev_ptr->count*168)));
-#endif
-                }
-            }
+            profileEventsTracePrint();
 #endif
             octave_save_int(fout, "tx_bits_log_c", &tx_bits_log[start * FDMDV_BITS_PER_FRAME], 1, FDMDV_BITS_PER_FRAME*range);
             octave_save_complex(fout, "tx_symbols_log_c", &tx_symbols_log[(FDMDV_NC+1)*start], 1, (FDMDV_NC+1)*range, (FDMDV_NC+1)*FRAMES);


### PR DESCRIPTION
Average processing of 20ms frame is down to slightly less than 14ms
from almost 16ms.
