### PR TITLE
Switched to use the arm_*fft routines for FreeDV using a abstract

### DIFF
--- a/mchf-eclipse/drivers/freedv/codec2.c
+++ b/mchf-eclipse/drivers/freedv/codec2.c
@@ -117,16 +117,16 @@ struct CODEC2 * codec2_create(int mode)
 	return NULL;
 
     c2->mode = mode;
-    for(i=0; i<M; i++)
+    for(i=0; i<M_PITCH; i++)
 	c2->Sn[i] = 1.0;
     c2->hpf_states[0] = c2->hpf_states[1] = 0.0;
-    for(i=0; i<2*N; i++)
+    for(i=0; i<2*N_SAMP; i++)
 	c2->Sn_[i] = 0;
-    c2->fft_fwd_cfg = kiss_fft_alloc(FFT_ENC, 0, NULL, NULL);
-    c2->fftr_fwd_cfg = kiss_fftr_alloc(FFT_ENC, 0, NULL, NULL);
+    c2->fft_fwd_cfg = codec2_fft_alloc(FFT_ENC, 0, NULL, NULL);
+    c2->fftr_fwd_cfg = codec2_fftr_alloc(FFT_ENC, 0, NULL, NULL);
     make_analysis_window(c2->fft_fwd_cfg, c2->w,c2->W);
     make_synthesis_window(c2->Pn);
-    c2->fft_inv_cfg = kiss_fft_alloc(FFT_DEC, 1, NULL, NULL);
+    c2->fft_inv_cfg = codec2_fft_alloc(FFT_DEC, 1, NULL, NULL);
     quantise_init();
     c2->prev_Wo_enc = 0.0;
     c2->bg_est = 0.0;
@@ -143,7 +143,7 @@ struct CODEC2 * codec2_create(int mode)
     }
     c2->prev_e_dec = 1;
 
-    c2->nlp = nlp_create(M);
+    c2->nlp = nlp_create(M_PITCH);
     if (c2->nlp == NULL) {
 	free (c2);
 	return NULL;
@@ -161,9 +161,9 @@ struct CODEC2 * codec2_create(int mode)
 
     c2->smoothing = 0;
 
-    c2->bpf_buf = (float*)malloc(sizeof(float)*(BPF_N+4*N));
+    c2->bpf_buf = (float*)malloc(sizeof(float)*(BPF_N+4*N_SAMP));
     assert(c2->bpf_buf != NULL);
-    for(i=0; i<BPF_N+4*N; i++)
+    for(i=0; i<BPF_N+4*N_SAMP; i++)
         c2->bpf_buf[i] = 0.0;
 
     c2->softdec = NULL;
@@ -186,9 +186,9 @@ void codec2_destroy(struct CODEC2 *c2)
     assert(c2 != NULL);
     free(c2->bpf_buf);
     nlp_destroy(c2->nlp);
-    KISS_FFT_FREE(c2->fft_fwd_cfg);
-    KISS_FFT_FREE(c2->fftr_fwd_cfg);
-    KISS_FFT_FREE(c2->fft_inv_cfg);
+    codec2_fft_free(c2->fft_fwd_cfg);
+    codec2_fftr_free(c2->fftr_fwd_cfg);
+    codec2_fft_free(c2->fft_inv_cfg);
     free(c2);
 }
 
@@ -377,7 +377,7 @@ void codec2_encode_3200(struct CODEC2 *c2, unsigned char * bits, short speech[])
 
     /* second 10ms analysis frame */
 
-    analyse_one_frame(c2, &model, &speech[N]);
+    analyse_one_frame(c2, &model, &speech[N_SAMP]);
     pack(bits, &nbit, model.voiced, 1);
     Wo_index = encode_Wo(model.Wo, WO_BITS);
     pack(bits, &nbit, Wo_index, WO_BITS);
@@ -463,7 +463,7 @@ void codec2_decode_3200(struct CODEC2 *c2, short speech[], const unsigned char *
 	aks_to_M2(c2->fftr_fwd_cfg, &ak[i][0], LPC_ORD, &model[i], e[i], &snr, 0, 0,
                   c2->lpc_pf, c2->bass_boost, c2->beta, c2->gamma, Aw);
 	apply_lpc_correction(&model[i]);
-	synthesise_one_frame(c2, &speech[N*i], &model[i], Aw);
+	synthesise_one_frame(c2, &speech[N_SAMP*i], &model[i], Aw);
     }
 
     /* update memories for next frame ----------------------------*/
@@ -523,7 +523,7 @@ void codec2_encode_2400(struct CODEC2 *c2, unsigned char * bits, short speech[])
 
     /* second 10ms analysis frame */
 
-    analyse_one_frame(c2, &model, &speech[N]);
+    analyse_one_frame(c2, &model, &speech[N_SAMP]);
     pack(bits, &nbit, model.voiced, 1);
 
     e = speech_to_uq_lsps(lsps, ak, c2->Sn, c2->w, LPC_ORD);
@@ -606,7 +606,7 @@ void codec2_decode_2400(struct CODEC2 *c2, short speech[], const unsigned char *
 	aks_to_M2(c2->fftr_fwd_cfg, &ak[i][0], LPC_ORD, &model[i], e[i], &snr, 0, 0,
                   c2->lpc_pf, c2->bass_boost, c2->beta, c2->gamma, Aw);
 	apply_lpc_correction(&model[i]);
-	synthesise_one_frame(c2, &speech[N*i], &model[i], Aw);
+	synthesise_one_frame(c2, &speech[N_SAMP*i], &model[i], Aw);
     }
 
     /* update memories for next frame ----------------------------*/
@@ -668,7 +668,7 @@ void codec2_encode_1600(struct CODEC2 *c2, unsigned char * bits, short speech[])
 
     /* frame 2: - voicing, scalar Wo & E -------------------------------*/
 
-    analyse_one_frame(c2, &model, &speech[N]);
+    analyse_one_frame(c2, &model, &speech[N_SAMP]);
     pack(bits, &nbit, model.voiced, 1);
 
     Wo_index = encode_Wo(model.Wo, WO_BITS);
@@ -681,12 +681,12 @@ void codec2_encode_1600(struct CODEC2 *c2, unsigned char * bits, short speech[])
 
     /* frame 3: - voicing ---------------------------------------------*/
 
-    analyse_one_frame(c2, &model, &speech[2*N]);
+    analyse_one_frame(c2, &model, &speech[2*N_SAMP]);
     pack(bits, &nbit, model.voiced, 1);
 
     /* frame 4: - voicing, scalar Wo & E, scalar LSPs ------------------*/
 
-    analyse_one_frame(c2, &model, &speech[3*N]);
+    analyse_one_frame(c2, &model, &speech[3*N_SAMP]);
     pack(bits, &nbit, model.voiced, 1);
 
     Wo_index = encode_Wo(model.Wo, WO_BITS);
@@ -790,7 +790,7 @@ void codec2_decode_1600(struct CODEC2 *c2, short speech[], const unsigned char *
 	aks_to_M2(c2->fftr_fwd_cfg, &ak[i][0], LPC_ORD, &model[i], e[i], &snr, 0, 0,
                   c2->lpc_pf, c2->bass_boost, c2->beta, c2->gamma, Aw);
 	apply_lpc_correction(&model[i]);
-	synthesise_one_frame(c2, &speech[N*i], &model[i], Aw);
+	synthesise_one_frame(c2, &speech[N_SAMP*i], &model[i], Aw);
     }
 
     /* update memories for next frame ----------------------------*/
@@ -851,7 +851,7 @@ void codec2_encode_1400(struct CODEC2 *c2, unsigned char * bits, short speech[])
 
     /* frame 2: - voicing, joint Wo & E -------------------------------*/
 
-    analyse_one_frame(c2, &model, &speech[N]);
+    analyse_one_frame(c2, &model, &speech[N_SAMP]);
     pack(bits, &nbit, model.voiced, 1);
 
     /* need to run this just to get LPC energy */
@@ -862,12 +862,12 @@ void codec2_encode_1400(struct CODEC2 *c2, unsigned char * bits, short speech[])
 
     /* frame 3: - voicing ---------------------------------------------*/
 
-    analyse_one_frame(c2, &model, &speech[2*N]);
+    analyse_one_frame(c2, &model, &speech[2*N_SAMP]);
     pack(bits, &nbit, model.voiced, 1);
 
     /* frame 4: - voicing, joint Wo & E, scalar LSPs ------------------*/
 
-    analyse_one_frame(c2, &model, &speech[3*N]);
+    analyse_one_frame(c2, &model, &speech[3*N_SAMP]);
     pack(bits, &nbit, model.voiced, 1);
 
     e = speech_to_uq_lsps(lsps, ak, c2->Sn, c2->w, LPC_ORD);
@@ -960,7 +960,7 @@ void codec2_decode_1400(struct CODEC2 *c2, short speech[], const unsigned char *
 	aks_to_M2(c2->fftr_fwd_cfg, &ak[i][0], LPC_ORD, &model[i], e[i], &snr, 0, 0,
                   c2->lpc_pf, c2->bass_boost, c2->beta, c2->gamma, Aw);
 	apply_lpc_correction(&model[i]);
-	synthesise_one_frame(c2, &speech[N*i], &model[i], Aw);
+	synthesise_one_frame(c2, &speech[N_SAMP*i], &model[i], Aw);
     }
 
     /* update memories for next frame ----------------------------*/
@@ -1025,17 +1025,17 @@ void codec2_encode_1300(struct CODEC2 *c2, unsigned char * bits, short speech[])
 
     /* frame 2: - voicing ---------------------------------------------*/
 
-    analyse_one_frame(c2, &model, &speech[N]);
+    analyse_one_frame(c2, &model, &speech[N_SAMP]);
     pack_natural_or_gray(bits, &nbit, model.voiced, 1, c2->gray);
 
     /* frame 3: - voicing ---------------------------------------------*/
 
-    analyse_one_frame(c2, &model, &speech[2*N]);
+    analyse_one_frame(c2, &model, &speech[2*N_SAMP]);
     pack_natural_or_gray(bits, &nbit, model.voiced, 1, c2->gray);
 
     /* frame 4: - voicing, scalar Wo & E, scalar LSPs ------------------*/
 
-    analyse_one_frame(c2, &model, &speech[3*N]);
+    analyse_one_frame(c2, &model, &speech[3*N_SAMP]);
     pack_natural_or_gray(bits, &nbit, model.voiced, 1, c2->gray);
 
     Wo_index = encode_Wo(model.Wo, WO_BITS);
@@ -1143,7 +1143,7 @@ void codec2_decode_1300(struct CODEC2 *c2, short speech[], const unsigned char *
 	aks_to_M2(c2->fftr_fwd_cfg, &ak[i][0], LPC_ORD, &model[i], e[i], &snr, 0, 0,
                   c2->lpc_pf, c2->bass_boost, c2->beta, c2->gamma, Aw);
 	apply_lpc_correction(&model[i]);
-	synthesise_one_frame(c2, &speech[N*i], &model[i], Aw);
+	synthesise_one_frame(c2, &speech[N_SAMP*i], &model[i], Aw);
     }
     /*
     for(i=0; i<4; i++) {
@@ -1220,7 +1220,7 @@ void codec2_encode_1200(struct CODEC2 *c2, unsigned char * bits, short speech[])
 
     /* frame 2: - voicing, joint Wo & E -------------------------------*/
 
-    analyse_one_frame(c2, &model, &speech[N]);
+    analyse_one_frame(c2, &model, &speech[N_SAMP]);
     pack(bits, &nbit, model.voiced, 1);
 
     /* need to run this just to get LPC energy */
@@ -1231,12 +1231,12 @@ void codec2_encode_1200(struct CODEC2 *c2, unsigned char * bits, short speech[])
 
     /* frame 3: - voicing ---------------------------------------------*/
 
-    analyse_one_frame(c2, &model, &speech[2*N]);
+    analyse_one_frame(c2, &model, &speech[2*N_SAMP]);
     pack(bits, &nbit, model.voiced, 1);
 
     /* frame 4: - voicing, joint Wo & E, scalar LSPs ------------------*/
 
-    analyse_one_frame(c2, &model, &speech[3*N]);
+    analyse_one_frame(c2, &model, &speech[3*N_SAMP]);
     pack(bits, &nbit, model.voiced, 1);
 
     e = speech_to_uq_lsps(lsps, ak, c2->Sn, c2->w, LPC_ORD);
@@ -1330,7 +1330,7 @@ void codec2_decode_1200(struct CODEC2 *c2, short speech[], const unsigned char *
 	aks_to_M2(c2->fftr_fwd_cfg, &ak[i][0], LPC_ORD, &model[i], e[i], &snr, 0, 0,
                   c2->lpc_pf, c2->bass_boost, c2->beta, c2->gamma, Aw);
 	apply_lpc_correction(&model[i]);
-	synthesise_one_frame(c2, &speech[N*i], &model[i], Aw);
+	synthesise_one_frame(c2, &speech[N_SAMP*i], &model[i], Aw);
     }
 
     /* update memories for next frame ----------------------------*/
@@ -1382,8 +1382,8 @@ void codec2_encode_700(struct CODEC2 *c2, unsigned char * bits, short speech[])
     int     indexes[LPC_ORD_LOW];
     int     Wo_index, e_index, i;
     unsigned int nbit = 0;
-    float   bpf_out[4*N];
-    short   bpf_speech[4*N];
+    float   bpf_out[4*N_SAMP];
+    short   bpf_speech[4*N_SAMP];
     int     spare = 0;
 
     assert(c2 != NULL);
@@ -1393,11 +1393,11 @@ void codec2_encode_700(struct CODEC2 *c2, unsigned char * bits, short speech[])
     /* band pass filter */
 
     for(i=0; i<BPF_N; i++)
-        c2->bpf_buf[i] = c2->bpf_buf[4*N+i];
-    for(i=0; i<4*N; i++)
+        c2->bpf_buf[i] = c2->bpf_buf[4*N_SAMP+i];
+    for(i=0; i<4*N_SAMP; i++)
         c2->bpf_buf[BPF_N+i] = speech[i];
-    inverse_filter(&c2->bpf_buf[BPF_N], bpf, 4*N, bpf_out, BPF_N-1);
-    for(i=0; i<4*N; i++)
+    inverse_filter(&c2->bpf_buf[BPF_N], bpf, 4*N_SAMP, bpf_out, BPF_N-1);
+    for(i=0; i<4*N_SAMP; i++)
         bpf_speech[i] = bpf_out[i];
 
     /* frame 1 --------------------------------------------------------*/
@@ -1406,15 +1406,15 @@ void codec2_encode_700(struct CODEC2 *c2, unsigned char * bits, short speech[])
 
     /* frame 2 --------------------------------------------------------*/
 
-    analyse_one_frame(c2, &model, &bpf_speech[N]);
+    analyse_one_frame(c2, &model, &bpf_speech[N_SAMP]);
 
     /* frame 3 --------------------------------------------------------*/
 
-    analyse_one_frame(c2, &model, &bpf_speech[2*N]);
+    analyse_one_frame(c2, &model, &bpf_speech[2*N_SAMP]);
 
     /* frame 4: - voicing, scalar Wo & E, scalar LSPs -----------------*/
 
-    analyse_one_frame(c2, &model, &bpf_speech[3*N]);
+    analyse_one_frame(c2, &model, &bpf_speech[3*N_SAMP]);
     pack(bits, &nbit, model.voiced, 1);
     Wo_index = encode_log_Wo(model.Wo, 5);
     pack_natural_or_gray(bits, &nbit, Wo_index, 5, c2->gray);
@@ -1528,7 +1528,7 @@ void codec2_decode_700(struct CODEC2 *c2, short speech[], const unsigned char * 
 	aks_to_M2(c2->fftr_fwd_cfg, &ak[i][0], LPC_ORD_LOW, &model[i], e[i], &snr, 0, 0,
                   c2->lpc_pf, c2->bass_boost, c2->beta, c2->gamma, Aw);
 	apply_lpc_correction(&model[i]);
-	synthesise_one_frame(c2, &speech[N*i], &model[i], Aw);
+	synthesise_one_frame(c2, &speech[N_SAMP*i], &model[i], Aw);
     }
 
     #ifdef DUMP
@@ -1594,8 +1594,8 @@ void codec2_encode_700b(struct CODEC2 *c2, unsigned char * bits, short speech[])
     int     indexes[3];
     int     Wo_index, e_index, i;
     unsigned int nbit = 0;
-    float   bpf_out[4*N];
-    short   bpf_speech[4*N];
+    float   bpf_out[4*N_SAMP];
+    short   bpf_speech[4*N_SAMP];
     int     spare = 0;
 
     assert(c2 != NULL);
@@ -1605,11 +1605,11 @@ void codec2_encode_700b(struct CODEC2 *c2, unsigned char * bits, short speech[])
     /* band pass filter */
 
     for(i=0; i<BPF_N; i++)
-        c2->bpf_buf[i] = c2->bpf_buf[4*N+i];
-    for(i=0; i<4*N; i++)
+        c2->bpf_buf[i] = c2->bpf_buf[4*N_SAMP+i];
+    for(i=0; i<4*N_SAMP; i++)
         c2->bpf_buf[BPF_N+i] = speech[i];
-    inverse_filter(&c2->bpf_buf[BPF_N], bpfb, 4*N, bpf_out, BPF_N-1);
-    for(i=0; i<4*N; i++)
+    inverse_filter(&c2->bpf_buf[BPF_N], bpfb, 4*N_SAMP, bpf_out, BPF_N-1);
+    for(i=0; i<4*N_SAMP; i++)
         bpf_speech[i] = bpf_out[i];
 
     /* frame 1 --------------------------------------------------------*/
@@ -1618,15 +1618,15 @@ void codec2_encode_700b(struct CODEC2 *c2, unsigned char * bits, short speech[])
 
     /* frame 2 --------------------------------------------------------*/
 
-    analyse_one_frame(c2, &model, &bpf_speech[N]);
+    analyse_one_frame(c2, &model, &bpf_speech[N_SAMP]);
 
     /* frame 3 --------------------------------------------------------*/
 
-    analyse_one_frame(c2, &model, &bpf_speech[2*N]);
+    analyse_one_frame(c2, &model, &bpf_speech[2*N_SAMP]);
 
     /* frame 4: - voicing, scalar Wo & E, VQ mel LSPs -----------------*/
 
-    analyse_one_frame(c2, &model, &bpf_speech[3*N]);
+    analyse_one_frame(c2, &model, &bpf_speech[3*N_SAMP]);
     pack(bits, &nbit, model.voiced, 1);
     Wo_index = encode_log_Wo(model.Wo, 5);
     pack_natural_or_gray(bits, &nbit, Wo_index, 5, c2->gray);
@@ -1732,7 +1732,7 @@ void codec2_decode_700b(struct CODEC2 *c2, short speech[], const unsigned char *
 	aks_to_M2(c2->fftr_fwd_cfg, &ak[i][0], LPC_ORD_LOW, &model[i], e[i], &snr, 0, 0,
                   c2->lpc_pf, c2->bass_boost, c2->beta, c2->gamma, Aw);
 	apply_lpc_correction(&model[i]);
-	synthesise_one_frame(c2, &speech[N*i], &model[i], Aw);
+	synthesise_one_frame(c2, &speech[N_SAMP*i], &model[i], Aw);
     }
 
     #ifdef DUMP
@@ -1859,9 +1859,9 @@ void synthesise_one_frame(struct CODEC2 *c2, short speech[], MODEL *model, COMP 
 
     PROFILE_SAMPLE_AND_LOG2(synth_start, "    synth");
 
-    ear_protection(c2->Sn_, N);
+    ear_protection(c2->Sn_, N_SAMP);
 
-    for(i=0; i<N; i++) {
+    for(i=0; i<N_SAMP; i++) {
 	if (c2->Sn_[i] > 32767.0)
 	    speech[i] = 32767;
 	else if (c2->Sn_[i] < -32767.0)
@@ -1894,10 +1894,10 @@ void analyse_one_frame(struct CODEC2 *c2, MODEL *model, short speech[])
 
     /* Read input speech */
 
-    for(i=0; i<M-N; i++)
-      c2->Sn[i] = c2->Sn[i+N];
-    for(i=0; i<N; i++)
-      c2->Sn[i+M-N] = speech[i];
+    for(i=0; i<M_PITCH-N_SAMP; i++)
+      c2->Sn[i] = c2->Sn[i+N_SAMP];
+    for(i=0; i<N_SAMP; i++)
+      c2->Sn[i+M_PITCH-N_SAMP] = speech[i];
 
     PROFILE_SAMPLE(dft_start);
     dft_speech(c2->fft_fwd_cfg, Sw, c2->Sn, c2->w);
@@ -1905,7 +1905,7 @@ void analyse_one_frame(struct CODEC2 *c2, MODEL *model, short speech[])
 
     /* Estimate pitch */
 
-    nlp(c2->nlp,c2->Sn,N,P_MIN,P_MAX,&pitch,Sw, c2->W, &c2->prev_Wo_enc);
+    nlp(c2->nlp,c2->Sn,N_SAMP,P_MIN,P_MAX,&pitch,Sw, c2->W, &c2->prev_Wo_enc);
     PROFILE_SAMPLE_AND_LOG(model_start, nlp_start, "    nlp");
 
     model->Wo = TWO_PI/pitch;

--- a/mchf-eclipse/drivers/freedv/codec2_fft.h
+++ b/mchf-eclipse/drivers/freedv/codec2_fft.h
@@ -1,0 +1,141 @@
+/*
+ * codec2_fft.h
+ *
+ *  Created on: 17.09.2016
+ *      Author: danilo
+ */
+
+#ifndef DRIVERS_FREEDV_CODEC2_FFT_H_
+#define DRIVERS_FREEDV_CODEC2_FFT_H_
+
+#include <assert.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <math.h>
+
+#ifdef ARM_MATH_CM4
+  #include "stm32f4xx.h"
+  #include "core_cm4.h"
+  #include "arm_math.h"
+  #include "arm_const_structs.h"
+#endif
+
+#include "defines.h"
+#include "kiss_fft.h"
+#include "kiss_fftr.h"
+#include "comp.h"
+
+#ifndef ARM_MATH_CM4
+    #define USE_KISS_FFT
+#endif
+
+
+#ifdef USE_KISS_FFT
+    typedef kiss_fftr_cfg codec2_fftr_cfg;
+    typedef kiss_fft_cfg codec2_fft_cfg;
+#else
+  typedef struct {
+      arm_rfft_fast_instance_f32* instance;
+      int inverse;
+  } codec2_fftr_struct;
+
+  typedef codec2_fftr_struct* codec2_fftr_cfg;
+
+  typedef struct {
+        const arm_cfft_instance_f32* instance;
+        int inverse;
+    } codec2_fft_struct;
+  typedef codec2_fft_struct* codec2_fft_cfg;
+#endif
+
+inline codec2_fftr_cfg codec2_fftr_alloc(int nfft, int inverse_fft, void* mem, size_t* lenmem)
+{
+    codec2_fftr_cfg retval;
+#ifdef USE_KISS_FFT
+    retval = kiss_fftr_alloc(nfft, inverse_fft, mem, lenmem);
+#else
+    retval = malloc(sizeof(codec2_fftr_struct));
+    retval->inverse  = inverse_fft;
+    retval->instance = malloc(sizeof(arm_rfft_fast_instance_f32));
+    arm_rfft_fast_init_f32(retval->instance,nfft);
+#endif
+    return retval;
+}
+typedef kiss_fft_scalar codec2_fft_scalar;
+typedef COMP    codec2_fft_cpx;
+
+inline void codec2_fftr(codec2_fftr_cfg cfg, codec2_fft_scalar* in, codec2_fft_cpx* out)
+{
+
+#ifdef USE_KISS_FFT
+      kiss_fftr(cfg, in, (kiss_fft_cpx*)out);
+#else
+    arm_rfft_fast_f32(cfg->instance,in,(float*)out,cfg->inverse);
+    out->imag = 0; // remove out[FFT_ENC/2]->real stored in out[0].imag
+#endif
+}
+
+inline void codec2_fftr_free(codec2_fftr_cfg cfg)
+{
+#ifdef USE_KISS_FFT
+    KISS_FFT_FREE(cfg);
+#else
+    free(cfg->instance);
+    free(cfg);
+#endif
+}
+
+
+inline codec2_fft_cfg codec2_fft_alloc(int nfft, int inverse_fft, void* mem, size_t* lenmem)
+{
+    codec2_fft_cfg retval;
+#ifdef USE_KISS_FFT
+    retval = kiss_fft_alloc(nfft, inverse_fft, mem, lenmem);
+#else
+    retval = malloc(sizeof(codec2_fft_struct));
+    retval->inverse  = inverse_fft;
+    switch(nfft)
+    {
+    case 256:
+        retval->instance = &arm_cfft_sR_f32_len256;
+        break;
+    case 512:
+        retval->instance = &arm_cfft_sR_f32_len512;
+        break;
+    case 1024:
+        retval->instance = &arm_cfft_sR_f32_len1024;
+        break;
+    default:
+        abort();
+    }
+#endif
+    return retval;
+}
+
+inline void codec2_fft(codec2_fft_cfg cfg, codec2_fft_cpx* in, codec2_fft_cpx* out)
+{
+
+#ifdef USE_KISS_FFT
+      kiss_fft(cfg, (kiss_fft_cpx*)in, (kiss_fft_cpx*)out);
+#else
+    arm_cfft_f32(cfg->instance,(float*)in,cfg->inverse,0);
+    // TODO: this is not nice, but for now required to keep changes minimal
+    // however, since main goal is to reduce the memory usage
+    // we should convert to an in place interface
+    // on PC like platforms the overhead of using the "inplace" kiss_fft calls
+    // is neglectable compared to the gain in memory usage on STM32 platforms
+    memcpy(out,in,cfg->instance->fftLen*2*sizeof(float));
+#endif
+}
+
+inline void codec2_fft_free(codec2_fft_cfg cfg)
+{
+#ifdef USE_KISS_FFT
+    KISS_FFT_FREE(cfg);
+#else
+    free(cfg);
+#endif
+}
+
+#endif /* DRIVERS_FREEDV_CODEC2_FFT_H_ */

--- a/mchf-eclipse/drivers/freedv/codec2_internal.h
+++ b/mchf-eclipse/drivers/freedv/codec2_internal.h
@@ -29,21 +29,23 @@
 #ifndef __CODEC2_INTERNAL__
 #define __CODEC2_INTERNAL__
 
+#include "codec2_fft.h"
+
 struct CODEC2 {
     int           mode;
-    kiss_fft_cfg  fft_fwd_cfg;             /* forward FFT config                        */
-    kiss_fftr_cfg fftr_fwd_cfg;            /* forward real FFT config                   */
-    float         w[M];	                   /* time domain hamming window                */
+    codec2_fft_cfg  fft_fwd_cfg;             /* forward FFT config                        */
+    codec2_fftr_cfg fftr_fwd_cfg;            /* forward real FFT config                   */
+    float         w[M_PITCH];	                   /* time domain hamming window                */
     COMP          W[FFT_ENC];	           /* DFT of w[]                                */
-    float         Pn[2*N];	           /* trapezoidal synthesis window              */
+    float         Pn[2*N_SAMP];	           /* trapezoidal synthesis window              */
     float        *bpf_buf;                 /* buffer for band pass filter               */
-    float         Sn[M];                   /* input speech                              */
+    float         Sn[M_PITCH];                   /* input speech                              */
     float         hpf_states[2];           /* high pass filter states                   */
     void         *nlp;                     /* pitch predictor states                    */
     int           gray;                    /* non-zero for gray encoding                */
 
-    kiss_fft_cfg  fft_inv_cfg;             /* inverse FFT config                        */
-    float         Sn_[2*N];	           /* synthesised output speech                 */
+    codec2_fft_cfg  fft_inv_cfg;             /* inverse FFT config                        */
+    float         Sn_[2*N_SAMP];	           /* synthesised output speech                 */
     float         ex_phase;                /* excitation model phase track              */
     float         bg_est;                  /* background noise estimate for post filter */
     float         prev_Wo_enc;             /* previous frame's pitch estimate           */

--- a/mchf-eclipse/drivers/freedv/defines.h
+++ b/mchf-eclipse/drivers/freedv/defines.h
@@ -36,9 +36,11 @@
 
 /* General defines */
 
-#define N          80		/* number of samples per frame          */
+#define N_SAMP          80		/* number of samples per frame          */
 #define MAX_AMP    80		/* maximum number of harmonics          */
+#ifndef PI
 #define PI         3.141592654	/* mathematical constant                */
+#endif
 #define TWO_PI     6.283185307	/* mathematical constant                */
 #define FS         8000		/* sample rate in Hz                    */
 #define MAX_STR    256          /* maximum string size                  */
@@ -53,7 +55,7 @@
 
 /* Pitch estimation defines */
 
-#define M        320		/* pitch analysis frame size            */
+#define M_PITCH        320		/* pitch analysis frame size            */
 #define P_MIN    20		/* minimum pitch                        */
 #define P_MAX    160		/* maximum pitch                        */
 

--- a/mchf-eclipse/drivers/freedv/fdmdv_internal.h
+++ b/mchf-eclipse/drivers/freedv/fdmdv_internal.h
@@ -31,7 +31,7 @@
 
 #include "comp.h"
 #include "codec2_fdmdv.h"
-#include "kiss_fft.h"
+#include "codec2_fft.h"
 
 /*---------------------------------------------------------------------------*\
 
@@ -48,21 +48,21 @@
 #define NC                      20  /* max number of data carriers (plus one pilot in the centre)           */
 #define NB                       2  /* Bits/symbol for QPSK modulation                                      */
 #define RB              (NC*RS*NB)  /* bit rate                                                             */
-#define M                  (FS/RS)  /* oversampling factor                                                  */
+#define M_FAC                  (FS/RS)  /* oversampling factor                                                  */
 #define NSYM                     6  /* number of symbols to filter over                                     */
-#define NFILTER            (NSYM*M) /* size of tx/rx filters at sample rate M                               */
+#define NFILTER            (NSYM*M_FAC) /* size of tx/rx filters at sample rate M                               */
 
 #define FSEP                    75  /* Default separation between carriers (Hz)                             */
 
 #define NT                       5  /* number of symbols we estimate timing over                            */
 #define P                        4  /* oversample factor used for initial rx symbol filtering output        */
-#define Q                     (M/4) /* oversample factor used for initial rx symbol filtering input         */
+#define Q                     (M_FAC/4) /* oversample factor used for initial rx symbol filtering input         */
 #define NRXDEC                  31  /* number of taps in the rx decimation filter                           */
 
-#define NPILOT_LUT                 (4*M)    /* number of pilot look up table samples                 */
+#define NPILOT_LUT                 (4*M_FAC)    /* number of pilot look up table samples                 */
 #define NPILOTCOEFF                   30    /* number of FIR filter coeffs in LP filter              */
-#define NPILOTBASEBAND (NPILOTCOEFF+M+M/P)  /* number of pilot baseband samples reqd for pilot LPF   */
-#define NPILOTLPF                  (4*M)    /* number of samples we DFT pilot over, pilot est window */
+#define NPILOTBASEBAND (NPILOTCOEFF+M_FAC+M_FAC/P)  /* number of pilot baseband samples reqd for pilot LPF   */
+#define NPILOTLPF                  (4*M_FAC)    /* number of samples we DFT pilot over, pilot est window */
 #define MPILOTFFT                    256
 
 #define NSYNC_MEM                6
@@ -130,8 +130,8 @@ struct FDMDV {
 
     /* Demodulator */
 
-    COMP  rxdec_lpf_mem[NRXDEC-1+M];
-    COMP  rx_fdm_mem[NFILTER+M];
+    COMP  rxdec_lpf_mem[NRXDEC-1+M_FAC];
+    COMP  rx_fdm_mem[NFILTER+M_FAC];
     COMP  phase_rx[NC+1];
     COMP  rx_filter_mem_timing[NC+1][NT*P];
     float rx_timing;
@@ -162,8 +162,8 @@ struct FDMDV {
 \*---------------------------------------------------------------------------*/
 
 void bits_to_dqpsk_symbols(COMP tx_symbols[], int Nc, COMP prev_tx_symbols[], int tx_bits[], int *pilot_bit, int old_qpsk_mapping);
-void tx_filter(COMP tx_baseband[NC+1][M], int Nc, COMP tx_symbols[], COMP tx_filter_memory[NC+1][NSYM]);
-void fdm_upconvert(COMP tx_fdm[], int Nc, COMP tx_baseband[NC+1][M], COMP phase_tx[], COMP freq_tx[],
+void tx_filter(COMP tx_baseband[NC+1][M_FAC], int Nc, COMP tx_symbols[], COMP tx_filter_memory[NC+1][NSYM]);
+void fdm_upconvert(COMP tx_fdm[], int Nc, COMP tx_baseband[NC+1][M_FAC], COMP phase_tx[], COMP freq_tx[],
                    COMP *fbb_phase, COMP fbb_rect);
 void tx_filter_and_upconvert(COMP tx_fdm[], int Nc, COMP tx_symbols[],
                              COMP tx_filter_memory[NC+1][NSYM],
@@ -172,9 +172,9 @@ void generate_pilot_fdm(COMP *pilot_fdm, int *bit, float *symbol, float *filter_
 void generate_pilot_lut(COMP pilot_lut[], COMP *pilot_freq);
 float rx_est_freq_offset(struct FDMDV *f, COMP rx_fdm[], int nin, int do_fft);
 void lpf_peak_pick(float *foff, float *max, COMP pilot_baseband[], COMP pilot_lpf[], kiss_fft_cfg fft_pilot_cfg, COMP S[], int nin, int do_fft);
-void fdm_downconvert(COMP rx_baseband[NC+1][M+M/P], int Nc, COMP rx_fdm[], COMP phase_rx[], COMP freq[], int nin);
+void fdm_downconvert(COMP rx_baseband[NC+1][M_FAC+M_FAC/P], int Nc, COMP rx_fdm[], COMP phase_rx[], COMP freq[], int nin);
 void rxdec_filter(COMP rx_fdm_filter[], COMP rx_fdm[], COMP rxdec_lpf_mem[], int nin);
-void rx_filter(COMP rx_filt[NC+1][P+1], int Nc, COMP rx_baseband[NC+1][M+M/P], COMP rx_filter_memory[NC+1][NFILTER], int nin);
+void rx_filter(COMP rx_filt[NC+1][P+1], int Nc, COMP rx_baseband[NC+1][M_FAC+M_FAC/P], COMP rx_filter_memory[NC+1][NFILTER], int nin);
 void down_convert_and_rx_filter(COMP rx_filt[NC+1][P+1], int Nc, COMP rx_fdm[],
                                 COMP rx_fdm_mem[], COMP phase_rx[], COMP freq[],
                                 float freq_pol[], int nin, int dec_rate);

--- a/mchf-eclipse/drivers/freedv/phase.c
+++ b/mchf-eclipse/drivers/freedv/phase.c
@@ -72,16 +72,16 @@
 
    As we don't transmit the pulse position for this model, we need to
    synthesise it.  Now the excitation pulses occur at a rate of Wo.
-   This means the phase of the first harmonic advances by N samples
-   over a synthesis frame of N samples.  For example if Wo is pi/20
-   (200 Hz), then over a 10ms frame (N=80 samples), the phase of the
+   This means the phase of the first harmonic advances by N_SAMP samples
+   over a synthesis frame of N_SAMP samples.  For example if Wo is pi/20
+   (200 Hz), then over a 10ms frame (N_SAMP=80 samples), the phase of the
    first harmonic would advance (pi/20)*80 = 4*pi or two complete
    cycles.
 
    We generate the excitation phase of the fundamental (first
    harmonic):
 
-     arg[E[1]] = Wo*N;
+     arg[E[1]] = Wo*N_SAMP;
 
    We then relate the phase of the m-th excitation harmonic to the
    phase of the fundamental as:
@@ -129,7 +129,7 @@
 \*---------------------------------------------------------------------------*/
 
 void phase_synth_zero_order(
-    kiss_fft_cfg fft_fwd_cfg,
+    codec2_fft_cfg fft_fwd_cfg,
     MODEL *model,
     float *ex_phase,            /* excitation phase of fundamental */
     COMP   A[]
@@ -158,10 +158,10 @@ void phase_synth_zero_order(
        I found that using just this frame's Wo improved quality for UV
        sounds compared to interpolating two frames Wo like this:
 
-       ex_phase[0] += (*prev_Wo+model->Wo)*N/2;
+       ex_phase[0] += (*prev_Wo+model->Wo)*N_SAMP/2;
     */
 
-    ex_phase[0] += (model->Wo)*N;
+    ex_phase[0] += (model->Wo)*N_SAMP;
     ex_phase[0] -= TWO_PI*floorf(ex_phase[0]/TWO_PI + 0.5);
 
     for(m=1; m<=model->L; m++) {

--- a/mchf-eclipse/drivers/freedv/phase.h
+++ b/mchf-eclipse/drivers/freedv/phase.h
@@ -28,10 +28,10 @@
 #ifndef __PHASE__
 #define __PHASE__
 
-#include "kiss_fft.h"
+#include "codec2_fft.h"
 #include "comp.h"
 
-void phase_synth_zero_order(kiss_fft_cfg fft_dec_cfg,
+void phase_synth_zero_order(codec2_fft_cfg fft_dec_cfg,
 			    MODEL *model,
                             float *ex_phase,
                             COMP   A[]);

--- a/mchf-eclipse/drivers/freedv/quantise.c
+++ b/mchf-eclipse/drivers/freedv/quantise.c
@@ -36,7 +36,7 @@
 #include "quantise.h"
 #include "lpc.h"
 #include "lsp.h"
-#include "kiss_fft.h"
+#include "codec2_fft.h"
 #undef PROFILE
 #include "machdep.h"
 
@@ -846,7 +846,7 @@ void force_min_lsp_dist(float lsp[], int order)
 
 \*---------------------------------------------------------------------------*/
 
-void lpc_post_filter(kiss_fftr_cfg fftr_fwd_cfg, float Pw[], float ak[],
+void lpc_post_filter(codec2_fftr_cfg fftr_fwd_cfg, float Pw[], float ak[],
                      int order, int dump, float beta, float gamma, int bass_boost, float E)
 {
     int   i;
@@ -873,7 +873,7 @@ void lpc_post_filter(kiss_fftr_cfg fftr_fwd_cfg, float Pw[], float ak[],
 	x[i] = ak[i] * coeff;
         coeff *= gamma;
     }
-    kiss_fftr(fftr_fwd_cfg, (kiss_fft_scalar *)x, (kiss_fft_cpx *)Ww);
+    codec2_fftr(fftr_fwd_cfg, x, Ww);
 
     PROFILE_SAMPLE_AND_LOG(tfft2, taw, "        fft2");
 
@@ -956,7 +956,7 @@ void lpc_post_filter(kiss_fftr_cfg fftr_fwd_cfg, float Pw[], float ak[],
 \*---------------------------------------------------------------------------*/
 
 void aks_to_M2(
-  kiss_fftr_cfg  fftr_fwd_cfg,
+  codec2_fftr_cfg  fftr_fwd_cfg,
   float         ak[],	     /* LPC's */
   int           order,
   MODEL        *model,	     /* sinusoidal model parameters for this frame */
@@ -993,7 +993,7 @@ void aks_to_M2(
 
       for(i=0; i<=order; i++)
           a[i] = ak[i];
-      kiss_fftr(fftr_fwd_cfg, (kiss_fft_scalar *)a, (kiss_fft_cpx *)Aw);
+      codec2_fftr(fftr_fwd_cfg, a, Aw);
   }
   PROFILE_SAMPLE_AND_LOG(tfft, tstart, "      fft");
 
@@ -1274,12 +1274,12 @@ float speech_to_uq_lsps(float lsp[],
 )
 {
     int   i, roots;
-    float Wn[M];
+    float Wn[M_PITCH];
     float R[order+1];
     float e, E;
 
     e = 0.0;
-    for(i=0; i<M; i++) {
+    for(i=0; i<M_PITCH; i++) {
 	Wn[i] = Sn[i]*w[i];
 	e += Wn[i]*Wn[i];
     }
@@ -1292,7 +1292,7 @@ float speech_to_uq_lsps(float lsp[],
 	return 0.0;
     }
 
-    autocorrelate(Wn, R, M, order);
+    autocorrelate(Wn, R, M_PITCH, order);
     levinson_durbin(R, ak, order);
 
     E = 0.0;
@@ -1932,7 +1932,7 @@ float decode_energy(int index, int bits)
 
 \*---------------------------------------------------------------------------*/
 
-float decode_amplitudes(kiss_fft_cfg  fft_fwd_cfg,
+float decode_amplitudes(codec2_fft_cfg  fft_fwd_cfg,
 			MODEL *model,
 			float  ak[],
 		        int    lsp_indexes[],

--- a/mchf-eclipse/drivers/freedv/quantise.h
+++ b/mchf-eclipse/drivers/freedv/quantise.h
@@ -26,8 +26,7 @@
 #ifndef __QUANTISE__
 #define __QUANTISE__
 
-#include "kiss_fft.h"
-#include "kiss_fftr.h"
+#include "codec2_fft.h"
 #include "comp.h"
 
 #define WO_BITS     7
@@ -57,7 +56,7 @@
 void quantise_init();
 float lpc_model_amplitudes(float Sn[], float w[], MODEL *model, int order,
 			   int lsp,float ak[]);
-void aks_to_M2(kiss_fftr_cfg fftr_fwd_cfg, float ak[], int order, MODEL *model,
+void aks_to_M2(codec2_fftr_cfg fftr_fwd_cfg, float ak[], int order, MODEL *model,
 	       float E, float *snr, int dump, int sim_pf,
                int pf, int bass_boost, float beta, float gamma, COMP Aw[]);
 

--- a/mchf-eclipse/drivers/freedv/sine.h
+++ b/mchf-eclipse/drivers/freedv/sine.h
@@ -30,16 +30,16 @@
 
 #include "defines.h"
 #include "comp.h"
-#include "kiss_fft.h"
+#include "codec2_fft.h"
 
-void make_analysis_window(kiss_fft_cfg fft_fwd_cfg, float w[], COMP W[]);
+void make_analysis_window(codec2_fft_cfg fft_fwd_cfg, float w[], COMP W[]);
 float hpf(float x, float states[]);
-void dft_speech(kiss_fft_cfg fft_fwd_cfg, COMP Sw[], float Sn[], float w[]);
+void dft_speech(codec2_fft_cfg fft_fwd_cfg, COMP Sw[], float Sn[], float w[]);
 void two_stage_pitch_refinement(MODEL *model, COMP Sw[]);
 void estimate_amplitudes(MODEL *model, COMP Sw[], COMP W[], int est_phase);
 float est_voicing_mbe(MODEL *model, COMP Sw[], COMP W[], COMP Sw_[],COMP Ew[]);
 void make_synthesis_window(float Pn[]);
-void synthesise(kiss_fft_cfg fft_inv_cfg, float Sn_[], MODEL *model, float Pn[], int shift);
+void synthesise(codec2_fft_cfg fft_inv_cfg, float Sn_[], MODEL *model, float Pn[], int shift);
 
 #define CODEC2_RAND_MAX 32767
 int codec2_rand(void);


### PR DESCRIPTION
interface which encapsulates kiss_fft and arm_fft.
The main benefit of this switch is reduced memory use, since the arm fft keeps some data in flash where kiss_fft needs malloced RAM. Further improvements (less stack) can be achieved if we change the FreeDV code to run inplace FFT, but this is for later.
It also runs a little faster (now ~11.5ms / about 0.7ms faster per 20ms/6%).   
