### PR TITLE
FreeDV now uses arm*fft routines to reduce memory footprint

### DIFF
--- a/mchf-eclipse/.cproject
+++ b/mchf-eclipse/.cproject
@@ -14,7 +14,7 @@
 				</extensions>
 			</storageModule>
 			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
-				<configuration artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe,org.eclipse.cdt.build.core.buildType=org.eclipse.cdt.build.core.buildType.debug" cleanCommand="${cross_rm} -rf" description="" errorParsers="org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.CWDLocator;org.eclipse.cdt.core.GCCErrorParser;org.eclipse.cdt.core.GASErrorParser;org.eclipse.cdt.core.GLDErrorParser" id="ilg.gnuarmeclipse.managedbuild.cross.config.elf.debug.433341838" name="Debug" parent="ilg.gnuarmeclipse.managedbuild.cross.config.elf.debug" postannouncebuildStep="" postbuildStep="" preannouncebuildStep="" prebuildStep="">
+				<configuration artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildType=org.eclipse.cdt.build.core.buildType.debug,org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe" cleanCommand="${cross_rm} -rf" description="" errorParsers="org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.CWDLocator;org.eclipse.cdt.core.GCCErrorParser;org.eclipse.cdt.core.GASErrorParser;org.eclipse.cdt.core.GLDErrorParser" id="ilg.gnuarmeclipse.managedbuild.cross.config.elf.debug.433341838" name="Debug" parent="ilg.gnuarmeclipse.managedbuild.cross.config.elf.debug" postannouncebuildStep="" postbuildStep="" preannouncebuildStep="" prebuildStep="">
 					<folderInfo id="ilg.gnuarmeclipse.managedbuild.cross.config.elf.debug.433341838." name="/" resourcePath="">
 						<toolChain errorParsers="" id="ilg.gnuarmeclipse.managedbuild.cross.toolchain.elf.debug.680557654" name="Cross ARM GCC" superClass="ilg.gnuarmeclipse.managedbuild.cross.toolchain.elf.debug">
 							<option id="ilg.gnuarmeclipse.managedbuild.cross.option.optimization.level.384915231" name="Optimization Level" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.optimization.level" value="ilg.gnuarmeclipse.managedbuild.cross.option.optimization.level.more" valueType="enumerated"/>
@@ -86,6 +86,7 @@
 									<listOptionValue builtIn="false" value="_GNU_SOURCE"/>
 									<listOptionValue builtIn="false" value="CORTEX_M4"/>
 									<listOptionValue builtIn="false" value="TRACE"/>
+									<listOptionValue builtIn="false" value="__FPU_PRESENT"/>
 								</option>
 								<inputType id="ilg.gnuarmeclipse.managedbuild.cross.tool.assembler.input.1134137507" superClass="ilg.gnuarmeclipse.managedbuild.cross.tool.assembler.input"/>
 							</tool>
@@ -97,6 +98,7 @@
 									<listOptionValue builtIn="false" value="USE_STDPERIPH_DRIVER"/>
 									<listOptionValue builtIn="false" value="_GNU_SOURCE"/>
 									<listOptionValue builtIn="false" value="CORTEX_M4"/>
+									<listOptionValue builtIn="false" value="__FPU_PRESENT"/>
 								</option>
 								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.c.compiler.include.paths.2147099817" name="Include paths (-I)" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.c.compiler.include.paths" useByScannerDiscovery="false" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/mchf-eclipse/cmsis}&quot;"/>
@@ -139,6 +141,7 @@
 									<listOptionValue builtIn="false" value="USE_STDPERIPH_DRIVER"/>
 									<listOptionValue builtIn="false" value="_GNU_SOURCE"/>
 									<listOptionValue builtIn="false" value="CORTEX_M4"/>
+									<listOptionValue builtIn="false" value="__FPU_PRESENT"/>
 								</option>
 								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.cpp.compiler.include.paths.1485167743" name="Include paths (-I)" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.cpp.compiler.include.paths" useByScannerDiscovery="false" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/mchf-eclipse/cmsis}&quot;"/>
@@ -374,7 +377,6 @@
 									<listOptionValue builtIn="false" value="ARM_MATH_CM4"/>
 									<listOptionValue builtIn="false" value="STM32F407VG"/>
 									<listOptionValue builtIn="false" value="STM32F4XX"/>
-									<listOptionValue builtIn="false" value="__FPU_USED"/>
 									<listOptionValue builtIn="false" value="__FPU_PRESENT"/>
 									<listOptionValue builtIn="false" value="USE_STDPERIPH_DRIVER"/>
 									<listOptionValue builtIn="false" value="_GNU_SOURCE"/>
@@ -392,7 +394,6 @@
 									<listOptionValue builtIn="false" value="ARM_MATH_CM4"/>
 									<listOptionValue builtIn="false" value="STM32F407VG"/>
 									<listOptionValue builtIn="false" value="STM32F4XX"/>
-									<listOptionValue builtIn="false" value="__FPU_USED"/>
 									<listOptionValue builtIn="false" value="__FPU_PRESENT"/>
 									<listOptionValue builtIn="false" value="USE_STDPERIPH_DRIVER"/>
 									<listOptionValue builtIn="false" value="_GNU_SOURCE"/>
@@ -409,6 +410,7 @@
 								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.cpp.compiler.defs.1964694686" name="Defined symbols (-D)" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.cpp.compiler.defs" useByScannerDiscovery="false" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="_GNU_SOURCE"/>
 									<listOptionValue builtIn="false" value="CORTEX_M4"/>
+									<listOptionValue builtIn="false" value="__FPU_PRESENT"/>
 								</option>
 								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.cpp.compiler.include.paths.2083680376" name="Include paths (-I)" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.cpp.compiler.include.paths" useByScannerDiscovery="false" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/mchf-eclipse/drivers}&quot;"/>
@@ -536,6 +538,8 @@
 									<listOptionValue builtIn="false" value="_GNU_SOURCE"/>
 									<listOptionValue builtIn="false" value="CORTEX_M4"/>
 									<listOptionValue builtIn="false" value="TRACE"/>
+									<listOptionValue builtIn="false" value="__FPU_PRESENT"/>
+									<listOptionValue builtIn="false" value="OS_USE_TRACE_SEMIHOSTING_STDOUT"/>
 								</option>
 								<inputType id="ilg.gnuarmeclipse.managedbuild.cross.tool.assembler.input.1969972230" superClass="ilg.gnuarmeclipse.managedbuild.cross.tool.assembler.input"/>
 							</tool>
@@ -548,6 +552,7 @@
 									<listOptionValue builtIn="false" value="_GNU_SOURCE"/>
 									<listOptionValue builtIn="false" value="CORTEX_M4"/>
 									<listOptionValue builtIn="false" value="TRACE"/>
+									<listOptionValue builtIn="false" value="__FPU_PRESENT"/>
 									<listOptionValue builtIn="false" value="OS_USE_TRACE_SEMIHOSTING_STDOUT"/>
 								</option>
 								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.c.compiler.include.paths.367706623" name="Include paths (-I)" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.c.compiler.include.paths" useByScannerDiscovery="false" valueType="includePath">
@@ -592,7 +597,7 @@
 									<listOptionValue builtIn="false" value="_GNU_SOURCE"/>
 									<listOptionValue builtIn="false" value="CORTEX_M4"/>
 									<listOptionValue builtIn="false" value="TRACE"/>
-									<listOptionValue builtIn="false" value="OS_USE_TRACE_SEMIHOSTING_DEBUG"/>
+									<listOptionValue builtIn="false" value="__FPU_PRESENT"/>
 									<listOptionValue builtIn="false" value="OS_USE_TRACE_SEMIHOSTING_STDOUT"/>
 								</option>
 								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.cpp.compiler.include.paths.491749856" name="Include paths (-I)" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.cpp.compiler.include.paths" useByScannerDiscovery="false" valueType="includePath">
@@ -807,10 +812,10 @@
 		<scannerConfigBuildInfo instanceId="ilg.gnuarmeclipse.managedbuild.cross.config.elf.release.563472857;ilg.gnuarmeclipse.managedbuild.cross.config.elf.release.563472857.;ilg.gnuarmeclipse.managedbuild.cross.tool.cpp.compiler.833539941;ilg.gnuarmeclipse.managedbuild.cross.tool.cpp.compiler.input.301192583">
 			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
 		</scannerConfigBuildInfo>
-		<scannerConfigBuildInfo instanceId="ilg.gnuarmeclipse.managedbuild.cross.config.elf.debug.433341838;ilg.gnuarmeclipse.managedbuild.cross.config.elf.debug.433341838.;ilg.gnuarmeclipse.managedbuild.cross.tool.cpp.compiler.1301137147;ilg.gnuarmeclipse.managedbuild.cross.tool.cpp.compiler.input.537084149">
+		<scannerConfigBuildInfo instanceId="ilg.gnuarmeclipse.managedbuild.cross.config.elf.debug.433341838.1563975183;ilg.gnuarmeclipse.managedbuild.cross.config.elf.debug.433341838.1563975183.;ilg.gnuarmeclipse.managedbuild.cross.tool.c.compiler.946620455;ilg.gnuarmeclipse.managedbuild.cross.tool.c.compiler.input.1067257841">
 			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
 		</scannerConfigBuildInfo>
-		<scannerConfigBuildInfo instanceId="ilg.gnuarmeclipse.managedbuild.cross.config.elf.debug.433341838.1563975183;ilg.gnuarmeclipse.managedbuild.cross.config.elf.debug.433341838.1563975183.;ilg.gnuarmeclipse.managedbuild.cross.tool.c.compiler.946620455;ilg.gnuarmeclipse.managedbuild.cross.tool.c.compiler.input.1067257841">
+		<scannerConfigBuildInfo instanceId="ilg.gnuarmeclipse.managedbuild.cross.config.elf.debug.433341838;ilg.gnuarmeclipse.managedbuild.cross.config.elf.debug.433341838.;ilg.gnuarmeclipse.managedbuild.cross.tool.cpp.compiler.1301137147;ilg.gnuarmeclipse.managedbuild.cross.tool.cpp.compiler.input.537084149">
 			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
 		</scannerConfigBuildInfo>
 		<scannerConfigBuildInfo instanceId="ilg.gnuarmeclipse.managedbuild.cross.config.elf.release.563472857;ilg.gnuarmeclipse.managedbuild.cross.config.elf.release.563472857.;ilg.gnuarmeclipse.managedbuild.cross.tool.c.compiler.606680054;ilg.gnuarmeclipse.managedbuild.cross.tool.c.compiler.input.1071089195">

--- a/mchf-eclipse/Makefile
+++ b/mchf-eclipse/Makefile
@@ -191,7 +191,7 @@ SRC =  \
     drivers/freedv/codebookvq.c \
     drivers/freedv/codebookvqanssi.c \
     drivers/freedv/codec2.c \
-    drivers/freedv/codec2_fft.c \    
+    drivers/freedv/codec2_fft.c \
     drivers/freedv/cohpsk.c \
     drivers/freedv/dump.c \
     drivers/freedv/fdmdv.c \

--- a/mchf-eclipse/Makefile
+++ b/mchf-eclipse/Makefile
@@ -191,6 +191,7 @@ SRC =  \
     drivers/freedv/codebookvq.c \
     drivers/freedv/codebookvqanssi.c \
     drivers/freedv/codec2.c \
+    drivers/freedv/codec2_fft.c \    
     drivers/freedv/cohpsk.c \
     drivers/freedv/dump.c \
     drivers/freedv/fdmdv.c \

--- a/mchf-eclipse/drivers/freedv/codec2.c
+++ b/mchf-eclipse/drivers/freedv/codec2.c
@@ -33,6 +33,7 @@
 #include <math.h>
 
 #include "defines.h"
+#include "codec2_fft.h"
 #include "sine.h"
 #include "nlp.h"
 #include "dump.h"
@@ -126,7 +127,7 @@ struct CODEC2 * codec2_create(int mode)
     c2->fftr_fwd_cfg = codec2_fftr_alloc(FFT_ENC, 0, NULL, NULL);
     make_analysis_window(c2->fft_fwd_cfg, c2->w,c2->W);
     make_synthesis_window(c2->Pn);
-    c2->fft_inv_cfg = codec2_fft_alloc(FFT_DEC, 1, NULL, NULL);
+    c2->fftr_inv_cfg = codec2_fftr_alloc(FFT_DEC, 1, NULL, NULL);
     quantise_init();
     c2->prev_Wo_enc = 0.0;
     c2->bg_est = 0.0;
@@ -188,7 +189,7 @@ void codec2_destroy(struct CODEC2 *c2)
     nlp_destroy(c2->nlp);
     codec2_fft_free(c2->fft_fwd_cfg);
     codec2_fftr_free(c2->fftr_fwd_cfg);
-    codec2_fft_free(c2->fft_inv_cfg);
+    codec2_fftr_free(c2->fftr_inv_cfg);
     free(c2);
 }
 
@@ -1855,7 +1856,7 @@ void synthesise_one_frame(struct CODEC2 *c2, short speech[], MODEL *model, COMP 
 
     PROFILE_SAMPLE_AND_LOG(synth_start, pf_start, "    postfilter");
 
-    synthesise(c2->fft_inv_cfg, c2->Sn_, model, c2->Pn, 1);
+    synthesise(c2->fftr_inv_cfg, c2->Sn_, model, c2->Pn, 1);
 
     PROFILE_SAMPLE_AND_LOG2(synth_start, "    synth");
 

--- a/mchf-eclipse/drivers/freedv/codec2_fft.c
+++ b/mchf-eclipse/drivers/freedv/codec2_fft.c
@@ -1,0 +1,151 @@
+/*
+ * codec2_fft.c
+ *
+ *  Created on: 24.09.2016
+ *      Author: danilo
+ */
+
+#include "codec2_fft.h"
+#ifdef USE_KISS_FFT
+#include "_kiss_fft_guts.h"
+#endif
+
+#define FFT_INIT_CACHE_SIZE 4
+const arm_cfft_instance_f32* fft_init_cache[FFT_INIT_CACHE_SIZE];
+
+static const arm_cfft_instance_f32* arm_fft_instance2ram(const arm_cfft_instance_f32* in)
+{
+
+    arm_cfft_instance_f32* out = malloc(sizeof(arm_cfft_instance_f32));
+
+    if (out) {
+        memcpy(out,in,sizeof(arm_cfft_instance_f32));
+        out->pBitRevTable = malloc(out->bitRevLength * sizeof(uint16_t));
+        out->pTwiddle = malloc(out->fftLen * sizeof(float32_t));
+        memcpy((void*)out->pBitRevTable,in->pBitRevTable,out->bitRevLength * sizeof(uint16_t));
+        memcpy((void*)out->pTwiddle,in->pTwiddle,out->fftLen * sizeof(float32_t));
+    }
+    return out;
+}
+
+
+static const arm_cfft_instance_f32* arm_fft_cache_get(const arm_cfft_instance_f32* romfft)
+{
+    const arm_cfft_instance_f32* retval = NULL;
+    static int used = 0;
+    for (int i = 0; fft_init_cache[i] != NULL && i < used; i++)
+    {
+        if (romfft->fftLen == fft_init_cache[i]->fftLen)
+        {
+            retval = fft_init_cache[i];
+            break;
+        }
+    }
+    if (retval == NULL && used < FFT_INIT_CACHE_SIZE)
+    {
+         retval = arm_fft_instance2ram(romfft);
+         fft_init_cache[used++] = retval;
+    }
+    if (retval == NULL)
+    {
+        retval = romfft;
+    }
+    return retval;
+}
+
+
+void codec2_fft_free(codec2_fft_cfg cfg)
+{
+#ifdef USE_KISS_FFT
+    KISS_FFT_FREE(cfg);
+#else
+    free(cfg);
+#endif
+}
+
+codec2_fft_cfg codec2_fft_alloc(int nfft, int inverse_fft, void* mem, size_t* lenmem)
+{
+    codec2_fft_cfg retval;
+#ifdef USE_KISS_FFT
+    retval = kiss_fft_alloc(nfft, inverse_fft, mem, lenmem);
+#else
+    retval = malloc(sizeof(codec2_fft_struct));
+    retval->inverse  = inverse_fft;
+    switch(nfft)
+    {
+    case 128:
+        retval->instance = &arm_cfft_sR_f32_len128;
+        break;
+    case 256:
+        retval->instance = &arm_cfft_sR_f32_len256;
+        break;
+    case 512:
+        retval->instance = &arm_cfft_sR_f32_len512;
+        break;
+//    case 1024:
+//        retval->instance = &arm_cfft_sR_f32_len1024;
+//        break;
+    default:
+        abort();
+    }
+    // retval->instance = arm_fft_cache_get(retval->instance);
+#endif
+    return retval;
+}
+
+codec2_fftr_cfg codec2_fftr_alloc(int nfft, int inverse_fft, void* mem, size_t* lenmem)
+{
+    codec2_fftr_cfg retval;
+#ifdef USE_KISS_FFT
+    retval = kiss_fftr_alloc(nfft, inverse_fft, mem, lenmem);
+#else
+    retval = malloc(sizeof(codec2_fftr_struct));
+    retval->inverse  = inverse_fft;
+    retval->instance = malloc(sizeof(arm_rfft_fast_instance_f32));
+    arm_rfft_fast_init_f32(retval->instance,nfft);
+    // memcpy(&retval->instance->Sint,arm_fft_cache_get(&retval->instance->Sint),sizeof(arm_cfft_instance_f32));
+#endif
+    return retval;
+}
+void codec2_fftr_free(codec2_fftr_cfg cfg)
+{
+#ifdef USE_KISS_FFT
+    KISS_FFT_FREE(cfg);
+#else
+    free(cfg->instance);
+    free(cfg);
+#endif
+}
+
+// there is a little overhead for inplace kiss_fft but this is
+// on the powerful platforms like the Raspberry or even x86 PC based ones
+// not noticeable
+// the reduced usage of RAM and increased performance on STM32 platforms
+// should be worth it.
+void codec2_fft_inplace(codec2_fft_cfg cfg, codec2_fft_cpx* inout)
+{
+
+#ifdef USE_KISS_FFT
+    kiss_fft_cpx in[512];
+    // decide whether to use the local stack based buffer for in
+    // or to allow kiss_fft to allocate RAM
+    // second part is just to play safe since first method
+    // is much faster and uses less RAM
+    if (cfg->nfft <= 512)
+    {
+        memcpy(in,inout,cfg->nfft*sizeof(kiss_fft_cpx));
+        kiss_fft(cfg, in, (kiss_fft_cpx*)inout);
+    }
+    else
+    {
+        kiss_fft(cfg, (kiss_fft_cpx*)inout, (kiss_fft_cpx*)inout);
+    }
+#else
+    arm_cfft_f32(cfg->instance,(float*)inout,cfg->inverse,1);
+    if (cfg->inverse)
+    {
+        arm_scale_f32(inout,cfg->instance->fftLen,inout,cfg->instance->fftLen*2);
+    }
+
+#endif
+}

--- a/mchf-eclipse/drivers/freedv/codec2_fft.h
+++ b/mchf-eclipse/drivers/freedv/codec2_fft.h
@@ -22,19 +22,24 @@
 #endif
 
 #include "defines.h"
-#include "kiss_fft.h"
-#include "kiss_fftr.h"
 #include "comp.h"
 
 #ifndef ARM_MATH_CM4
     #define USE_KISS_FFT
 #endif
+// #define USE_KISS_FFT
 
+
+typedef COMP    codec2_fft_cpx;
+#include "kiss_fftr.h"
 
 #ifdef USE_KISS_FFT
+    #include "kiss_fft.h"
     typedef kiss_fftr_cfg codec2_fftr_cfg;
     typedef kiss_fft_cfg codec2_fft_cfg;
+    typedef kiss_fft_scalar codec2_fft_scalar;
 #else
+  typedef float32_t codec2_fft_scalar;
   typedef struct {
       arm_rfft_fast_instance_f32* instance;
       int inverse;
@@ -49,23 +54,9 @@
   typedef codec2_fft_struct* codec2_fft_cfg;
 #endif
 
-inline codec2_fftr_cfg codec2_fftr_alloc(int nfft, int inverse_fft, void* mem, size_t* lenmem)
-{
-    codec2_fftr_cfg retval;
-#ifdef USE_KISS_FFT
-    retval = kiss_fftr_alloc(nfft, inverse_fft, mem, lenmem);
-#else
-    retval = malloc(sizeof(codec2_fftr_struct));
-    retval->inverse  = inverse_fft;
-    retval->instance = malloc(sizeof(arm_rfft_fast_instance_f32));
-    arm_rfft_fast_init_f32(retval->instance,nfft);
-#endif
-    return retval;
-}
-typedef kiss_fft_scalar codec2_fft_scalar;
-typedef COMP    codec2_fft_cpx;
 
-inline void codec2_fftr(codec2_fftr_cfg cfg, codec2_fft_scalar* in, codec2_fft_cpx* out)
+
+static inline void codec2_fftr(codec2_fftr_cfg cfg, codec2_fft_scalar* in, codec2_fft_cpx* out)
 {
 
 #ifdef USE_KISS_FFT
@@ -76,66 +67,45 @@ inline void codec2_fftr(codec2_fftr_cfg cfg, codec2_fft_scalar* in, codec2_fft_c
 #endif
 }
 
-inline void codec2_fftr_free(codec2_fftr_cfg cfg)
+static inline void codec2_fftri(codec2_fftr_cfg cfg, codec2_fft_cpx* in, codec2_fft_scalar* out)
 {
 #ifdef USE_KISS_FFT
-    KISS_FFT_FREE(cfg);
+      kiss_fftri(cfg, (kiss_fft_cpx*)in, out);
 #else
-    free(cfg->instance);
-    free(cfg);
+    arm_rfft_fast_f32(cfg->instance,(float*)in,out,cfg->inverse);
+    // arm_scale_f32(out,cfg->instance->fftLenRFFT,out,cfg->instance->fftLenRFFT);
 #endif
+
 }
 
+codec2_fft_cfg codec2_fft_alloc(int nfft, int inverse_fft, void* mem, size_t* lenmem);
+codec2_fftr_cfg codec2_fftr_alloc(int nfft, int inverse_fft, void* mem, size_t* lenmem);
+void codec2_fft_free(codec2_fft_cfg cfg);
+void codec2_fftr_free(codec2_fftr_cfg cfg);
 
-inline codec2_fft_cfg codec2_fft_alloc(int nfft, int inverse_fft, void* mem, size_t* lenmem)
-{
-    codec2_fft_cfg retval;
-#ifdef USE_KISS_FFT
-    retval = kiss_fft_alloc(nfft, inverse_fft, mem, lenmem);
-#else
-    retval = malloc(sizeof(codec2_fft_struct));
-    retval->inverse  = inverse_fft;
-    switch(nfft)
-    {
-    case 256:
-        retval->instance = &arm_cfft_sR_f32_len256;
-        break;
-    case 512:
-        retval->instance = &arm_cfft_sR_f32_len512;
-        break;
-    case 1024:
-        retval->instance = &arm_cfft_sR_f32_len1024;
-        break;
-    default:
-        abort();
-    }
-#endif
-    return retval;
-}
 
-inline void codec2_fft(codec2_fft_cfg cfg, codec2_fft_cpx* in, codec2_fft_cpx* out)
+static inline void codec2_fft(codec2_fft_cfg cfg, codec2_fft_cpx* in, codec2_fft_cpx* out)
 {
 
 #ifdef USE_KISS_FFT
       kiss_fft(cfg, (kiss_fft_cpx*)in, (kiss_fft_cpx*)out);
 #else
-    arm_cfft_f32(cfg->instance,(float*)in,cfg->inverse,0);
+    memcpy(out,in,cfg->instance->fftLen*2*sizeof(float));
+    arm_cfft_f32(cfg->instance,(float*)out,cfg->inverse,0);
     // TODO: this is not nice, but for now required to keep changes minimal
     // however, since main goal is to reduce the memory usage
     // we should convert to an in place interface
     // on PC like platforms the overhead of using the "inplace" kiss_fft calls
     // is neglectable compared to the gain in memory usage on STM32 platforms
-    memcpy(out,in,cfg->instance->fftLen*2*sizeof(float));
+    if (cfg->inverse)
+    {
+        arm_scale_f32((float*)out,cfg->instance->fftLen,(float*)out,cfg->instance->fftLen*2);
+    }
 #endif
 }
 
-inline void codec2_fft_free(codec2_fft_cfg cfg)
-{
-#ifdef USE_KISS_FFT
-    KISS_FFT_FREE(cfg);
-#else
-    free(cfg);
-#endif
-}
+void codec2_fft_inplace(codec2_fft_cfg cfg, codec2_fft_cpx* inout);
 
-#endif /* DRIVERS_FREEDV_CODEC2_FFT_H_ */
+
+#endif
+/* DRIVERS_FREEDV_CODEC2_FFT_H_ */

--- a/mchf-eclipse/drivers/freedv/codec2_internal.h
+++ b/mchf-eclipse/drivers/freedv/codec2_internal.h
@@ -44,7 +44,7 @@ struct CODEC2 {
     void         *nlp;                     /* pitch predictor states                    */
     int           gray;                    /* non-zero for gray encoding                */
 
-    codec2_fft_cfg  fft_inv_cfg;             /* inverse FFT config                        */
+    codec2_fftr_cfg  fftr_inv_cfg;             /* inverse FFT config                        */
     float         Sn_[2*N_SAMP];	           /* synthesised output speech                 */
     float         ex_phase;                /* excitation model phase track              */
     float         bg_est;                  /* background noise estimate for post filter */

--- a/mchf-eclipse/drivers/freedv/dump.h
+++ b/mchf-eclipse/drivers/freedv/dump.h
@@ -28,8 +28,7 @@
 
 #include "defines.h"
 #include "comp.h"
-#include "kiss_fft.h"
-#include "kiss_fftr.h"
+#include "codec2_fft.h"
 #include "codec2_internal.h"
 
 void dump_on(char filename_prefix[]);

--- a/mchf-eclipse/drivers/freedv/fdmdv.c
+++ b/mchf-eclipse/drivers/freedv/fdmdv.c
@@ -51,7 +51,7 @@
 #include "rxdec_coeff.h"
 #include "test_bits.h"
 #include "pilot_coeff.h"
-#include "kiss_fft.h"
+#include "codec2_fft.h"
 #include "hanning.h"
 #include "os.h"
 #include "machdep.h"
@@ -159,7 +159,7 @@ struct FDMDV * fdmdv_create(int Nc)
 
     /* freq Offset estimation states */
 
-    f->fft_pilot_cfg = kiss_fft_alloc (MPILOTFFT, 0, NULL, NULL);
+    f->fft_pilot_cfg = codec2_fft_alloc (MPILOTFFT, 0, NULL, NULL);
     assert(f->fft_pilot_cfg != NULL);
 
     for(i=0; i<NPILOTBASEBAND; i++) {
@@ -218,7 +218,7 @@ struct FDMDV * fdmdv_create(int Nc)
 void fdmdv_destroy(struct FDMDV *fdmdv)
 {
     assert(fdmdv != NULL);
-    KISS_FFT_FREE(fdmdv->fft_pilot_cfg);
+    codec2_fft_free(fdmdv->fft_pilot_cfg);
     free(fdmdv->rx_test_bits_mem);
     free(fdmdv);
 }
@@ -713,12 +713,11 @@ void generate_pilot_lut(COMP pilot_lut[], COMP *pilot_freq)
 \*---------------------------------------------------------------------------*/
 
 void lpf_peak_pick(float *foff, float *max, COMP pilot_baseband[],
-		   COMP pilot_lpf[], kiss_fft_cfg fft_pilot_cfg, COMP S[], int nin,
+		   COMP pilot_lpf[], codec2_fft_cfg fft_pilot_cfg, COMP S[], int nin,
                    int do_fft)
 {
     int   i,j,k;
     int   mpilot;
-    COMP  s[MPILOTFFT];
     float mag, imax;
     int   ix;
     float r;
@@ -770,16 +769,14 @@ void lpf_peak_pick(float *foff, float *max, COMP pilot_baseband[],
     if (do_fft) {
 
         /* decimate to improve DFT resolution, window and DFT */
-
         mpilot = FS/(2*200);  /* calc decimation rate given new sample rate is twice LPF freq */
-        for(i=0; i<MPILOTFFT; i++) {
-            s[i].real = 0.0; s[i].imag = 0.0;
-        }
         for(i=0,j=0; i<NPILOTLPF; i+=mpilot,j++) {
-            s[j] = fcmult(hanning[i], pilot_lpf[i]);
+            S[j] = fcmult(hanning[i], pilot_lpf[i]);
         }
 
-        kiss_fft(fft_pilot_cfg, (kiss_fft_cpx *)s, (kiss_fft_cpx *)S);
+        // FIXME: arm_cfft does not seem to do the job here
+        // where as kiss_fft does. Needs investigation
+        codec2_fft_inplace(fft_pilot_cfg, S);
 
         /* peak pick and convert to Hz */
 

--- a/mchf-eclipse/drivers/freedv/fdmdv_internal.h
+++ b/mchf-eclipse/drivers/freedv/fdmdv_internal.h
@@ -107,7 +107,7 @@ struct FDMDV {
 
     /* freq offset estimation states */
 
-    kiss_fft_cfg fft_pilot_cfg;
+    codec2_fft_cfg fft_pilot_cfg;
     COMP pilot_baseband1[NPILOTBASEBAND];
     COMP pilot_baseband2[NPILOTBASEBAND];
     COMP pilot_lpf1[NPILOTLPF];
@@ -171,7 +171,7 @@ void tx_filter_and_upconvert(COMP tx_fdm[], int Nc, COMP tx_symbols[],
 void generate_pilot_fdm(COMP *pilot_fdm, int *bit, float *symbol, float *filter_mem, COMP *phase, COMP *freq);
 void generate_pilot_lut(COMP pilot_lut[], COMP *pilot_freq);
 float rx_est_freq_offset(struct FDMDV *f, COMP rx_fdm[], int nin, int do_fft);
-void lpf_peak_pick(float *foff, float *max, COMP pilot_baseband[], COMP pilot_lpf[], kiss_fft_cfg fft_pilot_cfg, COMP S[], int nin, int do_fft);
+void lpf_peak_pick(float *foff, float *max, COMP pilot_baseband[], COMP pilot_lpf[], codec2_fft_cfg fft_pilot_cfg, COMP S[], int nin, int do_fft);
 void fdm_downconvert(COMP rx_baseband[NC+1][M_FAC+M_FAC/P], int Nc, COMP rx_fdm[], COMP phase_rx[], COMP freq[], int nin);
 void rxdec_filter(COMP rx_fdm_filter[], COMP rx_fdm[], COMP rxdec_lpf_mem[], int nin);
 void rx_filter(COMP rx_filt[NC+1][P+1], int Nc, COMP rx_baseband[NC+1][M_FAC+M_FAC/P], COMP rx_filter_memory[NC+1][NFILTER], int nin);

--- a/mchf-eclipse/drivers/freedv/interp.c
+++ b/mchf-eclipse/drivers/freedv/interp.c
@@ -148,7 +148,7 @@ float sample_log_amp(MODEL *model, float w)
 \*---------------------------------------------------------------------------*/
 
 void interpolate_lsp(
-  kiss_fft_cfg  fft_fwd_cfg,
+  codec2_fft_cfg  fft_fwd_cfg,
   MODEL *interp,    /* interpolated model params                     */
   MODEL *prev,      /* previous frames model params                  */
   MODEL *next,      /* next frames model params                      */

--- a/mchf-eclipse/drivers/freedv/sine.h
+++ b/mchf-eclipse/drivers/freedv/sine.h
@@ -39,7 +39,7 @@ void two_stage_pitch_refinement(MODEL *model, COMP Sw[]);
 void estimate_amplitudes(MODEL *model, COMP Sw[], COMP W[], int est_phase);
 float est_voicing_mbe(MODEL *model, COMP Sw[], COMP W[], COMP Sw_[],COMP Ew[]);
 void make_synthesis_window(float Pn[]);
-void synthesise(codec2_fft_cfg fft_inv_cfg, float Sn_[], MODEL *model, float Pn[], int shift);
+void synthesise(codec2_fftr_cfg fftr_inv_cfg, float Sn_[], MODEL *model, float Pn[], int shift);
 
 #define CODEC2_RAND_MAX 32767
 int codec2_rand(void);

--- a/mchf-eclipse/firmware.coproj
+++ b/mchf-eclipse/firmware.coproj
@@ -176,6 +176,8 @@
     <File name="drivers/ui/lcd/ui_lcd_hy28_fonts.c" path="drivers/ui/lcd/ui_lcd_hy28_fonts.c" type="1"/>
     <File name="misc/TestCPlusPlusBuild.cpp" path="misc/TestCPlusPlusBuild.cpp" type="1"/>
     <File name="drivers/freedv/codec2.h" path="drivers/freedv/codec2.h" type="1"/>
+    <File name="drivers/freedv/codec2_fft.h" path="drivers/freedv/codec2_fft.h" type="1"/>
+    <File name="drivers/freedv/codec2_fft.c" path="drivers/freedv/codec2_fft.c" type="1"/>    
     <File name="cmsis_lib/source/stm32f4xx_usart.c" path="cmsis_lib/source/stm32f4xx_usart.c" type="1"/>
     <File name="drivers/freedv/varicode.c" path="drivers/freedv/varicode.c" type="1"/>
     <File name="drivers/freedv/rxdec_coeff.h" path="drivers/freedv/rxdec_coeff.h" type="1"/>

--- a/mchf-eclipse/misc/profiling.c
+++ b/mchf-eclipse/misc/profiling.c
@@ -55,7 +55,7 @@ void dummy() {
 
 void profileEventsTracePrint()
 {
-#ifdef PROFILE_EVENTS
+#ifdef XPROFILE_EVENTS
 
             for (int i = 0;i < 10;i++)
             {

--- a/mchf-eclipse/support/MCHF.launch
+++ b/mchf-eclipse/support/MCHF.launch
@@ -32,7 +32,7 @@
 <intAttribute key="org.eclipse.cdt.debug.gdbjtag.core.portNumber" value="3333"/>
 <booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setPcRegister" value="false"/>
 <booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setResume" value="false"/>
-<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setStopAt" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setStopAt" value="false"/>
 <stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.stopAt" value="main"/>
 <stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.symbolsFileName" value=""/>
 <stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.symbolsOffset" value=""/>
@@ -61,5 +61,5 @@
 </listAttribute>
 <stringAttribute key="org.eclipse.dsf.launch.MEMORY_BLOCKS" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#13;&#10;&lt;memoryBlockExpressionList context=&quot;Context string&quot;/&gt;&#13;&#10;"/>
 <stringAttribute key="process_factory_id" value="org.eclipse.cdt.dsf.gdb.GdbProcessFactory"/>
-<stringAttribute key="saved_expressions&lt;seperator&gt;Unknown" value="0x2002000,0x20020000,0x200020000,0x20000000,0x2000000,0x200000000,0x2000000000,0x20000000000,0x20000,0x200000,0x20010000,0x20011000,0x20001000,0x20002000"/>
+<stringAttribute key="saved_expressions&lt;seperator&gt;Unknown" value="0x2000000,0x200000000,0x2000000000,0x20000000000,0x20000,0x200000,0x20010000,0x20011000,0x20001000,0x20002000,0x2001A000,0x2001D000,0x2002D000,0x2003D000,0x20030000"/>
 </launchConfiguration>


### PR DESCRIPTION
Moved to use of codec2_fft wrapper and added one more use of real fft.
Removed a few more of local stack arrays. Switched to use arm_*fft for
FreeDV. This gives a little gain in speed but huge reduction in memory
usage.
