### PR TITLE
Reached prototype stage with FreeDV@mcHF

### DIFF
--- a/mchf-eclipse/.cproject
+++ b/mchf-eclipse/.cproject
@@ -812,10 +812,10 @@
 		<scannerConfigBuildInfo instanceId="ilg.gnuarmeclipse.managedbuild.cross.config.elf.release.563472857;ilg.gnuarmeclipse.managedbuild.cross.config.elf.release.563472857.;ilg.gnuarmeclipse.managedbuild.cross.tool.cpp.compiler.833539941;ilg.gnuarmeclipse.managedbuild.cross.tool.cpp.compiler.input.301192583">
 			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
 		</scannerConfigBuildInfo>
-		<scannerConfigBuildInfo instanceId="ilg.gnuarmeclipse.managedbuild.cross.config.elf.debug.433341838.1563975183;ilg.gnuarmeclipse.managedbuild.cross.config.elf.debug.433341838.1563975183.;ilg.gnuarmeclipse.managedbuild.cross.tool.c.compiler.946620455;ilg.gnuarmeclipse.managedbuild.cross.tool.c.compiler.input.1067257841">
+		<scannerConfigBuildInfo instanceId="ilg.gnuarmeclipse.managedbuild.cross.config.elf.debug.433341838;ilg.gnuarmeclipse.managedbuild.cross.config.elf.debug.433341838.;ilg.gnuarmeclipse.managedbuild.cross.tool.cpp.compiler.1301137147;ilg.gnuarmeclipse.managedbuild.cross.tool.cpp.compiler.input.537084149">
 			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
 		</scannerConfigBuildInfo>
-		<scannerConfigBuildInfo instanceId="ilg.gnuarmeclipse.managedbuild.cross.config.elf.debug.433341838;ilg.gnuarmeclipse.managedbuild.cross.config.elf.debug.433341838.;ilg.gnuarmeclipse.managedbuild.cross.tool.cpp.compiler.1301137147;ilg.gnuarmeclipse.managedbuild.cross.tool.cpp.compiler.input.537084149">
+		<scannerConfigBuildInfo instanceId="ilg.gnuarmeclipse.managedbuild.cross.config.elf.debug.433341838.1563975183;ilg.gnuarmeclipse.managedbuild.cross.config.elf.debug.433341838.1563975183.;ilg.gnuarmeclipse.managedbuild.cross.tool.c.compiler.946620455;ilg.gnuarmeclipse.managedbuild.cross.tool.c.compiler.input.1067257841">
 			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
 		</scannerConfigBuildInfo>
 		<scannerConfigBuildInfo instanceId="ilg.gnuarmeclipse.managedbuild.cross.config.elf.release.563472857;ilg.gnuarmeclipse.managedbuild.cross.config.elf.release.563472857.;ilg.gnuarmeclipse.managedbuild.cross.tool.c.compiler.606680054;ilg.gnuarmeclipse.managedbuild.cross.tool.c.compiler.input.1071089195">

--- a/mchf-eclipse/drivers/audio/freedv_mchf.c
+++ b/mchf-eclipse/drivers/audio/freedv_mchf.c
@@ -241,14 +241,12 @@ void FreeDV_mcHF_HandleFreeDV()
             rx_was_here = true; // this is used to clear buffers when going into TX
 
             // while makes this highest prio
-            // since we are so slow, right now the loop then is never left if while
-            // is being used. This means the mcHF is essentially no longer controllable
-            // since UI is not being updated
-            // while (fdv_iq_has_data() && fdv_audio_has_room())
+            // if may give more responsiveness but can cause interrupted reception
+            while (fdv_iq_has_data() && fdv_audio_has_room())
             // while (fdv_audio_has_room())
-            if (fdv_iq_has_data() && fdv_audio_has_room())
+            // if (fdv_iq_has_data() && fdv_audio_has_room())
             {
-                mchf_board_green_led(1);
+                mchf_board_green_led(0);
 
                 leave_now = false;
                 fdv_current_buffer_idx %= FDV_BUFFER_AUDIO_NUM; // this makes sure we stay in our index range, i.e. the number of avail buffers
@@ -311,9 +309,9 @@ void FreeDV_mcHF_HandleFreeDV()
                     {
                         // if we arrive here the rx_buffer for comprx is full and will be consumed now.
                         inBufCtrl.offset = 0;
-                        profileTimedEventStart(7);
+                        // profileTimedEventStart(7);
                         outBufCtrl.count = freedv_comprx(f_FREEDV, rx_buffer, iq_buffer); // run the decoding process
-                        profileTimedEventStop(7);
+                        // profileTimedEventStop(7);
                         // outBufCtrl.count = iq_nin;
                     }
 
@@ -361,7 +359,7 @@ void FreeDV_mcHF_HandleFreeDV()
                 }
             }
         }
-        mchf_board_green_led(0);
+        mchf_board_green_led(1);
     }
     // END Freedv Test DL2FW
 }
@@ -393,14 +391,14 @@ void  FreeDV_mcHF_init()
     f_FREEDV = freedv_open(FREEDV_MODE_1600);
 
 
-    sprintf(my_cb_state.tx_str, "cq cq cq hello this is the mchf mchf mchf\n");
+    sprintf(my_cb_state.tx_str, "CQ CQ CQ mcHF SDR with integrated FreeDV codec calling!");
     my_cb_state.ptx_str = my_cb_state.tx_str;
     freedv_set_callback_txt(f_FREEDV, NULL, &my_get_next_tx_char, &my_cb_state);
     // freedv_set_squelch_en(f_FREEDV,0);
     // freedv_set_snr_squelch_thresh(f_FREEDV,-100.0);
 
-    ts.dvmode = true;
-    ts.digital_mode = 1;
+    // ts.dvmode = true;
+    // ts.digital_mode = 1;
 }
 // end Freedv Test DL2FW
 

--- a/mchf-eclipse/drivers/freedv/codec2.c
+++ b/mchf-eclipse/drivers/freedv/codec2.c
@@ -1887,8 +1887,6 @@ void synthesise_one_frame(struct CODEC2 *c2, short speech[], MODEL *model, COMP 
 void analyse_one_frame(struct CODEC2 *c2, MODEL *model, short speech[])
 {
     COMP    Sw[FFT_ENC];
-    COMP    Sw_[FFT_ENC];
-    COMP    Ew[FFT_ENC];
     float   pitch;
     int     i;
     PROFILE_VAR(dft_start, nlp_start, model_start, two_stage, estamps);
@@ -1918,7 +1916,7 @@ void analyse_one_frame(struct CODEC2 *c2, MODEL *model, short speech[])
     PROFILE_SAMPLE_AND_LOG(two_stage, model_start, "    two_stage");
     estimate_amplitudes(model, Sw, c2->W, 0);
     PROFILE_SAMPLE_AND_LOG(estamps, two_stage, "    est_amps");
-    est_voicing_mbe(model, Sw, c2->W, Sw_, Ew);
+    est_voicing_mbe(model, Sw, c2->W);
     c2->prev_Wo_enc = model->Wo;
     PROFILE_SAMPLE_AND_LOG2(estamps, "    est_voicing");
     #ifdef DUMP

--- a/mchf-eclipse/drivers/freedv/nlp.c
+++ b/mchf-eclipse/drivers/freedv/nlp.c
@@ -28,7 +28,7 @@
 #include "defines.h"
 #include "nlp.h"
 #include "dump.h"
-#include "kiss_fft.h"
+#include "codec2_fft.h"
 #undef PROFILE
 #include "machdep.h"
 
@@ -120,7 +120,7 @@ typedef struct {
     float         sq[PMAX_M];	     /* squared speech samples       */
     float         mem_x,mem_y;       /* memory for notch filter      */
     float         mem_fir[NLP_NTAP]; /* decimation FIR filter memory */
-    kiss_fft_cfg  fft_cfg;           /* kiss FFT config              */
+    codec2_fft_cfg  fft_cfg;           /* kiss FFT config              */
 } NLP;
 
 float test_candidate_mbe(COMP Sw[], COMP W[], float f0);
@@ -162,7 +162,7 @@ int    m			/* analysis window size */
     for(i=0; i<NLP_NTAP; i++)
 	nlp->mem_fir[i] = 0.0;
 
-    nlp->fft_cfg = kiss_fft_alloc (PE_FFT_SIZE, 0, NULL, NULL);
+    nlp->fft_cfg = codec2_fft_alloc (PE_FFT_SIZE, 0, NULL, NULL);
     assert(nlp->fft_cfg != NULL);
 
     return (void*)nlp;
@@ -182,7 +182,7 @@ void nlp_destroy(void *nlp_state)
     assert(nlp_state != NULL);
     nlp = (NLP*)nlp_state;
 
-    KISS_FFT_FREE(nlp->fft_cfg);
+    codec2_fft_free(nlp->fft_cfg);
     free(nlp_state);
 }
 
@@ -230,8 +230,7 @@ float nlp(
 {
     NLP   *nlp;
     float  notch;		    /* current notch filter output    */
-    COMP   fw[PE_FFT_SIZE];	    /* DFT of squared signal (input)  */
-    COMP   Fw[PE_FFT_SIZE];	    /* DFT of squared signal (output) */
+    COMP   Fw[PE_FFT_SIZE];	    /* DFT of squared signal (input/output) */
     float  gmax;
     int    gmax_bin;
     int    m, i,j;
@@ -282,18 +281,20 @@ float nlp(
     /* Decimate and DFT */
 
     for(i=0; i<PE_FFT_SIZE; i++) {
-	fw[i].real = 0.0;
-	fw[i].imag = 0.0;
+	Fw[i].real = 0.0;
+	Fw[i].imag = 0.0;
     }
     for(i=0; i<m/DEC; i++) {
-	fw[i].real = nlp->sq[i*DEC]*nlp->w[i];
+	Fw[i].real = nlp->sq[i*DEC]*nlp->w[i];
     }
     PROFILE_SAMPLE_AND_LOG(window, filter, "      window");
     #ifdef DUMP
     dump_dec(Fw);
     #endif
 
-    kiss_fft(nlp->fft_cfg, (kiss_fft_cpx *)fw, (kiss_fft_cpx *)Fw);
+    // FIXME: check if this can be converted to a real fft
+    // since all imag inputs are 0
+    codec2_fft_inplace(nlp->fft_cfg, Fw);
     PROFILE_SAMPLE_AND_LOG(fft, window, "      fft");
 
     for(i=0; i<PE_FFT_SIZE; i++)

--- a/mchf-eclipse/drivers/freedv/quantise.c
+++ b/mchf-eclipse/drivers/freedv/quantise.c
@@ -1047,6 +1047,16 @@ void aks_to_M2(
   for(m=1; m<=model->L; m++) {
       am = (int)((m - 0.5)*model->Wo/r + 0.5);
       bm = (int)((m + 0.5)*model->Wo/r + 0.5);
+
+      // FIXME: With arm_rfft_fast_f32 we have to use this
+      // otherwise sometimes a to high bm is calculated
+      // which causes trouble later in the calculation
+      // chain
+      // it seems for some reason model->Wo is calculated somewhat too high
+      if (bm>FFT_ENC/2)
+      {
+          bm = FFT_ENC/2;
+      }
       Em = 0.0;
 
       for(i=am; i<bm; i++)
@@ -1070,7 +1080,6 @@ void aks_to_M2(
           if (Am < model->A[m])
               Am *= 1.4;
       }
-
       model->A[m] = Am;
   }
   *snr = 10.0*log10f(signal/noise);

--- a/mchf-eclipse/drivers/freedv/sine.h
+++ b/mchf-eclipse/drivers/freedv/sine.h
@@ -37,7 +37,7 @@ float hpf(float x, float states[]);
 void dft_speech(codec2_fft_cfg fft_fwd_cfg, COMP Sw[], float Sn[], float w[]);
 void two_stage_pitch_refinement(MODEL *model, COMP Sw[]);
 void estimate_amplitudes(MODEL *model, COMP Sw[], COMP W[], int est_phase);
-float est_voicing_mbe(MODEL *model, COMP Sw[], COMP W[], COMP Sw_[],COMP Ew[]);
+float est_voicing_mbe(MODEL *model, COMP Sw[], COMP W[]);
 void make_synthesis_window(float Pn[]);
 void synthesise(codec2_fftr_cfg fftr_inv_cfg, float Sn_[], MODEL *model, float Pn[], int shift);
 

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -774,20 +774,22 @@ void UiDriver_HandleTouchScreen()
         }
         if(check_tp_coordinates(0,7,10,13))			// toggle digital modes
         {
-            incr_wrap_uint8(&ts.digital_mode,0,7);
-            UiDriver_DisplayDigitalMode();
+            incr_wrap_uint8(&ts.digital_mode,0,1);
+            // We limit the reachable modes to the ones truly available
+            // which is FreeDV1 for now
 
-         //DL2FW freeDV test
+            //DL2FW freeDV test
 
             if (ts.digital_mode == 1)
-              {
-        	ts.dvmode = 1;
-              }
+            {
+                ts.dvmode = 1;
+            }
             else
-              {
-        	ts.dvmode = 0;
-              }
+            {
+                ts.dvmode = 0;
+            }
          //DL2FW freeDV test end
+            UiDriver_DisplayDigitalMode();
 
         }
 
@@ -5273,8 +5275,8 @@ typedef enum
 // for operational data per mode [r/w], use a different table with order of modes
 const DigitalModeDescriptor digimodes[DigitalModeNum] =
 {
-    { "DIGITAL", false	},
-    { "FREEDV1", false },
+    { "DIGITAL", true },
+    { "FreeDV", true },
     { "FREEDV2", false },
     { "BPSK 31", false },
     { "RTTY", false },
@@ -5285,12 +5287,15 @@ const DigitalModeDescriptor digimodes[DigitalModeNum] =
 
 static void UiDriver_DisplayDigitalMode()
 {
-    ushort color = digimodes[ts.digital_mode].enabled?White:Grey2;
+
+    ushort bgclr = ts.dvmode?Orange:Blue;
+    ushort color = digimodes[ts.digital_mode].enabled?(ts.dvmode?Black:White):Grey2;
+
     const char* txt = digimodes[ts.digital_mode].label;
 
     // Draw line for box
-    UiLcdHy28_DrawStraightLine(POS_DIGMODE_IND_X,(POS_DIGMODE_IND_Y - 1),LEFTBOX_WIDTH,LCD_DIR_HORIZONTAL,Blue);
-    UiLcdHy28_PrintTextCentered((POS_DIGMODE_IND_X),(POS_DIGMODE_IND_Y),LEFTBOX_WIDTH,txt,color,Blue,0);
+    UiLcdHy28_DrawStraightLine(POS_DIGMODE_IND_X,(POS_DIGMODE_IND_Y - 1),LEFTBOX_WIDTH,LCD_DIR_HORIZONTAL,bgclr);
+    UiLcdHy28_PrintTextCentered((POS_DIGMODE_IND_X),(POS_DIGMODE_IND_Y),LEFTBOX_WIDTH,txt,color,bgclr,0);
 }
 //*----------------------------------------------------------------------------
 //* Function Name       : UiDriverChangePowerLevel

--- a/mchf-eclipse/hardware/mchf_board.h
+++ b/mchf-eclipse/hardware/mchf_board.h
@@ -17,8 +17,8 @@
 // some special switches
 //#define 	DEBUG_BUILD
 
-// #define USE_FREEDV //uncomment to use freedv instead of SNAP function
-// #define DEBUG_FREEDV
+//#define USE_FREEDV //uncomment to use freedv instead of SNAP function
+//#define DEBUG_FREEDV
 // hardware specific switches
 //#define HY28BHISPEED			true		// uncomment for using new HY28B in SPI with bus speed 50MHz instead of 25MHz
 

--- a/mchf-eclipse/hardware/mchf_board.h
+++ b/mchf-eclipse/hardware/mchf_board.h
@@ -17,14 +17,12 @@
 // some special switches
 //#define 	DEBUG_BUILD
 
-//#define USE_FREEDV //uncomment to use freedv instead of SNAP function
-//#define DEBUG_FREEDV
+// #define USE_FREEDV //uncomment to use freedv instead of SNAP function
+// #define DEBUG_FREEDV
 // hardware specific switches
 //#define HY28BHISPEED			true		// uncomment for using new HY28B in SPI with bus speed 50MHz instead of 25MHz
 
-// TODO: FIX THIS, FREEDV and SNAP do not go together due to lack of memory in 192K machines,
-// it will work in 256K machines.
-//#define USE_FREEDV_AND_SNAP // experimental!!!
+#define USE_FREEDV_AND_SNAP // experimental!!!
 
 #ifndef USE_FREEDV
   #define USE_SNAP

--- a/mchf-eclipse/support/tfdmdv_out.txt
+++ b/mchf-eclipse/support/tfdmdv_out.txt
@@ -13,11 +13,11 @@ Info : Unable to match requested speed 2000 kHz, using 1800 kHz
 Info : clock speed 1800 kHz
 Info : STLINK v2 JTAG v24 API v2 SWIM v0 VID 0x0483 PID 0x3748
 Info : using stlink api v2
-Info : Target voltage: 2.874942
+Info : Target voltage: 2.932218
 Info : stm32f4x.cpu: hardware has 6 breakpoints, 4 watchpoints
 Info : accepting 'gdb' connection on tcp/3333
-Info : device id = 0x10036419
-Info : flash size = 2048kbytes
+Info : device id = 0x10016413
+Info : flash size = 1024kbytes
 undefined debug reason 7 - target needs reset
 stm32f4x.cpu: target state: halted
 target halted due to debug-request, current mode: Thread 
@@ -35,7 +35,7 @@ adapter speed: 4000 kHz
 stm32f4x.cpu: target state: halted
 target halted due to breakpoint, current mode: Thread 
 xPSR: 0x61000000 pc: 0x20000046 msp: 0x2001c000, semihosting
-Warn : keep_alive() was not invoked in the 1000ms timelimit. GDB alive packet not sent! (1244). Workaround: increase "set remotetimeout" in GDB
+Warn : keep_alive() was not invoked in the 1000ms timelimit. GDB alive packet not sent! (5646). Workaround: increase "set remotetimeout" in GDB
 stm32f4x.cpu: target state: halted
 target halted due to debug-request, current mode: Thread 
 xPSR: 0x01000000 pc: 0x080052d8 msp: 0x2001c000, semihosting
@@ -98,6 +98,7 @@ xPSR: 0x01000000 pc: 0x080052d8 msp: 0x2001c000, semihosting
 (51) dwt_3_comp (/32)
 (52) dwt_3_mask (/4)
 (53) dwt_3_function (/32)
+Info : halted: PC: 0x0803517a
 Hello mcHF World!
 # Created by tfdmdv.c
 # hex: false

--- a/mchf-eclipse/syscalls/syscalls.c
+++ b/mchf-eclipse/syscalls/syscalls.c
@@ -16,10 +16,10 @@
 #undef errno
 extern int errno;
 extern int  _end;
+static unsigned char *heap = NULL;
 
 caddr_t _sbrk ( int incr )
 {
-    static unsigned char *heap = NULL;
     unsigned char *prev_heap;
 
     if (heap == NULL)


### PR DESCRIPTION
FreeDV is now included by default in the builds together with all
existing functions (even SNAP!)

Be aware that using FreeDV is still considered to be very experimental.
FreeDV is activated using touch on the "DIGITAL" box. An orange "FreeDV"
box indicates FreeDV reception. Unless you truly receive a FreeDV signal
nothing can be heard. For tuning purpose use LSB or USB analog to find
FreeDV signal.

Removed unnessary arrays of complex data (in total 8k stack space during TX).

This may make debugging a little more difficult. In that case we can
put a second function with the old interface est_voicing_mbe_debug
so that it can be used on demand. For normal operation this is just
a waste. With that change the mcHF can now run TX successfully even with
kiss_fft.

Switch nlp to use codec2_fft_inplace wrapped, again removing some
memory allocations if arm_fft is being used.

Identified an issue in aks_to_M2 if arm_fft is being used.
model->Wo seems have different values so that sometimes the upper
array index limit derived from the Wo value is too high. Put a boundary
enforcement in place. Needs investigation.
