### PR TITLE
Enabled Spectrum Display in FreeDV Mode.

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.h
+++ b/mchf-eclipse/drivers/audio/audio_driver.h
@@ -79,10 +79,6 @@ typedef struct
     float32_t                   i2_buffer[IQ_BUFSZ];
     float32_t                   q2_buffer[IQ_BUFSZ];
 
-    float32_t                   x_buffer[IQ_BUFSZ];
-    float32_t                   y_buffer[IQ_BUFSZ];
-
-
     //
     float32_t                   Osc_I_buffer[IQ_BUFSZ];
     float32_t                   Osc_Q_buffer[IQ_BUFSZ];
@@ -584,7 +580,6 @@ typedef struct SnapCarrier
     //
     float32_t   FFT_Samples[FFT_IQ_BUFF_LEN2];
 //    float32_t   FFT_Windat[FFT_IQ_BUFF_LEN2];
-    float32_t   FFT_MagData[FFT_IQ_BUFF_LEN2/2];
     // Current data ptr
     ulong   samp_ptr;
     int8_t FFT_number;


### PR DESCRIPTION
Be aware that using the Waterfall may cause trouble due to the extremly
high load. Scope seems to be fine.

Also removed 2 kByte statically allocated RAM in SnapCarrier data
structure. Be aware that it now is used
dynamically during SNAP. But in total this lowers the risk of not enough
memory since there is enough room on the stack (currently!).
