### PR TITLE
Fixed issue #569 FM problems (sort of)

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.h
+++ b/mchf-eclipse/drivers/audio/audio_driver.h
@@ -29,6 +29,11 @@
 // IRQ and 530uS idle time
 // (48kHz sampling - USB)
 //
+#define IQ_SAMPLE_RATE (48000)
+#define IQ_SAMPLE_RATE_F ((float32_t)IQ_SAMPLE_RATE)
+
+
+
 // -----------------------------
 // FFT buffer, this is double the size of the length of the FFT used for spectrum display and waterfall spectrum
 #define FFT_IQ_BUFF_LEN		512
@@ -381,7 +386,7 @@ typedef struct SMeter
 //
 #define	FM_ALC_GAIN_CORRECTION	0.95
 //
-// For subaudible and burst:  FM Tone word calculation:  freq / (sample rate/2^24) => freq / (48000/16777216) => freq * 349.52533333
+// For subaudible and burst:  FM Tone word calculation:  freq / (sample rate/2^24) => freq / (IQ_SAMPLE_RATE/16777216) => freq * 349.52533333
 //
 #define FM_TONE_AMPLITUDE_SCALING	0.00045	// Scaling factor for subaudible tone modulation - not pre-emphasized -to produce approx +/- 300 Hz deviation in 2.5kHz mode
 #define FM_TONE_DDS_ACC_SHIFT	14			// number of left-shift bits to obtain lookup word
@@ -390,14 +395,14 @@ typedef struct SMeter
 //
 #define FM_SUBAUDIBLE_TONE_OFF	0
 //
-#define	FM_SUBAUDIBLE_TONE_WORD_CALC_FACTOR	(16777216/48000)	// scaling factor for calculating "tone word" for subaudible tone generator
+#define	FM_SUBAUDIBLE_TONE_WORD_CALC_FACTOR	(16777216/IQ_SAMPLE_RATE)	// scaling factor for calculating "tone word" for subaudible tone generator
 //
 #define	FM_TONE_BURST_OFF	0
 #define	FM_TONE_BURST_1750_MODE	1
 #define	FM_TONE_BURST_2135_MODE	2
 #define	FM_TONE_BURST_MAX	2
 //
-#define	FM_BURST_TONE_WORD_CALC_FACTOR	(16777216/48000)	// scaling factor for calculating "tone word" for the tone burst generator
+#define	FM_BURST_TONE_WORD_CALC_FACTOR	(16777216/IQ_SAMPLE_RATE)	// scaling factor for calculating "tone word" for the tone burst generator
 //
 #define FM_TONE_BURST_1750	(1750 * FM_BURST_TONE_WORD_CALC_FACTOR)
 #define FM_TONE_BURST_2135	(2135 * FM_BURST_TONE_WORD_CALC_FACTOR)
@@ -429,7 +434,7 @@ enum	{
 #define	FM_GOERTZEL_LOW		0.95		// ratio of "low" detect frequency with respect to center
 //
 #define	BEEP_SCALING	20				// audio scaling of keyboard beep
-#define	BEEP_TONE_WORD_FACTOR			(65536/48000)	// scaling factor for beep frequency calculation
+#define	BEEP_TONE_WORD_FACTOR			(65536/IQ_SAMPLE_RATE)	// scaling factor for beep frequency calculation
 //
 #define	MIN_BEEP_FREQUENCY	200			// minimum beep frequency in Hz
 #define	MAX_BEEP_FREQUENCY	3000		// maximum beep frequency in Hz

--- a/mchf-eclipse/drivers/audio/audio_management.c
+++ b/mchf-eclipse/drivers/audio/audio_management.c
@@ -290,7 +290,7 @@ void AudioManagement_CalcSubaudibleDetFreq(void)
     //
     // Terms for "above" detection frequency
     //
-    ads.fm_goertzel_high_a = (0.5 + (ads.fm_subaudible_tone_det_freq * FM_GOERTZEL_HIGH) * FM_SUBAUDIBLE_GOERTZEL_WINDOW * (size/2)/48000);
+    ads.fm_goertzel_high_a = (0.5 + (ads.fm_subaudible_tone_det_freq * FM_GOERTZEL_HIGH) * FM_SUBAUDIBLE_GOERTZEL_WINDOW * (size/2)/IQ_SAMPLE_RATE);
     ads.fm_goertzel_high_b = (2*PI*ads.fm_goertzel_high_a)/(FM_SUBAUDIBLE_GOERTZEL_WINDOW*size/2);
     ads.fm_goertzel_high_sin = sin(ads.fm_goertzel_high_b);
     ads.fm_goertzel_high_cos = cos(ads.fm_goertzel_high_b);
@@ -298,7 +298,7 @@ void AudioManagement_CalcSubaudibleDetFreq(void)
     //
     // Terms for "below" detection frequency
     //
-    ads.fm_goertzel_low_a = (0.5 + (ads.fm_subaudible_tone_det_freq * FM_GOERTZEL_LOW) * FM_SUBAUDIBLE_GOERTZEL_WINDOW * (size/2)/48000);
+    ads.fm_goertzel_low_a = (0.5 + (ads.fm_subaudible_tone_det_freq * FM_GOERTZEL_LOW) * FM_SUBAUDIBLE_GOERTZEL_WINDOW * (size/2)/IQ_SAMPLE_RATE);
     ads.fm_goertzel_low_b = (2*PI*ads.fm_goertzel_low_a)/(FM_SUBAUDIBLE_GOERTZEL_WINDOW*size/2);
     ads.fm_goertzel_low_sin = sin(ads.fm_goertzel_low_b);
     ads.fm_goertzel_low_cos = cos(ads.fm_goertzel_low_b);
@@ -306,7 +306,7 @@ void AudioManagement_CalcSubaudibleDetFreq(void)
     //
     // Terms for the actual detection frequency
     //
-    ads.fm_goertzel_ctr_a = (0.5 + ads.fm_subaudible_tone_det_freq * FM_SUBAUDIBLE_GOERTZEL_WINDOW * (size/2)/48000);
+    ads.fm_goertzel_ctr_a = (0.5 + ads.fm_subaudible_tone_det_freq * FM_SUBAUDIBLE_GOERTZEL_WINDOW * (size/2)/IQ_SAMPLE_RATE);
     ads.fm_goertzel_ctr_b = (2*PI*ads.fm_goertzel_ctr_a)/(FM_SUBAUDIBLE_GOERTZEL_WINDOW*size/2);
     ads.fm_goertzel_ctr_sin = sin(ads.fm_goertzel_ctr_b);
     ads.fm_goertzel_ctr_cos = cos(ads.fm_goertzel_ctr_b);

--- a/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
@@ -1740,7 +1740,7 @@ static void calculate_dBm(void)
         float32_t buff_len = (float32_t) FFT_IQ_BUFF_LEN;
         float32_t width;
 
-        float32_t bin_BW = (float32_t) (48000.0 * 2.0 / buff_len);
+        float32_t bin_BW = (float32_t) (IQ_SAMPLE_RATE_F * 2.0 / buff_len);
         // width of a 256 tap FFT bin = 187.5Hz
         // we have to take into account the magnify mode
         // --> recalculation of bin_BW

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -5632,7 +5632,7 @@ void UiDriverDisplayFilterBW()
         break;
     }
     //
-    calc = 48000/((1 << sd.magnify) * FILT_DISPLAY_WIDTH);		// magnify mode is on
+    calc = IQ_SAMPLE_RATE/((1 << sd.magnify) * FILT_DISPLAY_WIDTH);		// magnify mode is on
     if(!sd.magnify)	 	// is magnify mode on?
     {
         if(ts.iq_freq_mode == FREQ_IQ_CONV_P6KHZ)			// line is to left if in "RX LO HIGH" mode


### PR DESCRIPTION
There was a long term issue with FM TX and 12 khz freq offset. The offset
was always +/-6khz. Never 12khz. This is fixed now.

As part of this issue search I replaced all uses of 48000 with IQ_SAMP_RATE
where appropriate. Since IQ Sample Rate equals Audio Sample Rate this also
includes the audio part for obvious reasons.
