### PR TITLE
Fix: AM TX at correct frequency. (was inverted, i.e. +6khz were -6khz offset).

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -3183,7 +3183,7 @@ void AudioDriver_tx_am_sideband_processor(float32_t* I_buffer, float32_t* Q_buff
     //
     // check and apply correct translate mode
     //
-    audio_rx_freq_conv(blockSize, (ts.iq_freq_mode == FREQ_IQ_CONV_M6KHZ || ts.iq_freq_mode == FREQ_IQ_CONV_M12KHZ));
+    audio_rx_freq_conv(blockSize, (ts.iq_freq_mode == FREQ_IQ_CONV_P6KHZ || ts.iq_freq_mode == FREQ_IQ_CONV_P12KHZ));
 }
 
 static inline void AudioDriver_tx_filter_audio(bool do_bandpass, bool do_bass_treble, float32_t* inBlock, float32_t* outBlock, const uint16_t blockSize)

--- a/mchf-eclipse/drivers/audio/audio_management.c
+++ b/mchf-eclipse/drivers/audio/audio_management.c
@@ -184,15 +184,20 @@ void AudioManagement_CalcTxIqGainAdj(void)
     //
 	// please note that the RX adjustments for gain are negative (in function AudioManagement_CalcRxIqGainAdj)
 	// and the adjustments for TX are positive
-    if(ts.dmod_mode == DEMOD_AM)    // is it AM mode?
-        ts.tx_adj_gain_var_i = -(float)ts.tx_iq_am_gain_balance;     // get current gain balance adjustment setting for AM
-    else if(ts.dmod_mode == DEMOD_FM)   // is it in FM mode?
-        ts.tx_adj_gain_var_i = -(float)ts.tx_iq_fm_gain_balance;     // get current gain balance adjustment setting for FM
-    else if(ts.dmod_mode == DEMOD_LSB)
-        ts.tx_adj_gain_var_i = (float)ts.tx_iq_lsb_gain_balance;        // get current gain balance adjustment setting for LSB
-    else
-        ts.tx_adj_gain_var_i = (float)ts.tx_iq_usb_gain_balance;        // get current gain adjustment setting for USB and other non AM/FM modes
-
+    switch(ts.dmod_mode)
+    {
+    case DEMOD_AM:    // is it AM mode?
+        ts.tx_adj_gain_var_i = ts.tx_iq_am_gain_balance;     // get current gain balance adjustment setting for AM
+        break;
+    case DEMOD_FM:   // is it in FM mode?
+        ts.tx_adj_gain_var_i = ts.tx_iq_fm_gain_balance;     // get current gain balance adjustment setting for FM
+        break;
+    case DEMOD_LSB:
+        ts.tx_adj_gain_var_i = ts.tx_iq_lsb_gain_balance;        // get current gain balance adjustment setting for LSB
+        break;
+    default:
+        ts.tx_adj_gain_var_i = ts.tx_iq_usb_gain_balance;        // get current gain adjustment setting for USB and other non AM/FM modes
+    }
     //
     ts.tx_adj_gain_var_i /= SCALING_FACTOR_IQ_AMPLITUDE_ADJUST;       // fractionalize it
     ts.tx_adj_gain_var_q = -ts.tx_adj_gain_var_i;               // get "invert" of it


### PR DESCRIPTION
Change: All IQ Balance values have now same sign. To achieve this,
we reverse the reverse polarity of AM and FM gain balance settings.

All gain balance values should be more or less identical in value
according to our experiments. This is the next step to introduce a new
scheme for handling the IQ balance/phase settings.
