### PR TITLE
Modified Handling of Mode button (part 2)

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -1420,6 +1420,8 @@ static void audio_freedv_rx_processor (AudioSample_t * const src, AudioSample_t 
     static FDV_Audio_Buffer* out_buffer = NULL;
     static int16_t modulus_NF = 0, modulus_MOD = 0;
 
+    bool lsb_active = (ts.dmod_mode == DEMOD_LSB || (ts.dmod_mode == DEMOD_DIGI && ts.digi_lsb == true));
+
     // If source is digital usb in, pull from USB buffer, discard line or mic audio and
     // let the normal processing happen
 
@@ -1447,7 +1449,7 @@ static void audio_freedv_rx_processor (AudioSample_t * const src, AudioSample_t 
             if (k % 6 == modulus_NF)  //every 6th sample has to be catched -> downsampling by 6
             {
 
-        	if (ts.dmod_mode == DEMOD_LSB)
+        	if (lsb_active == true)
         	  {
 
         	    fdv_iq_buff[FDV_TX_fill_in_pt].samples[trans_count_in].real = ((int32_t)adb.q_buffer[k]);
@@ -3458,7 +3460,8 @@ static void audio_dv_tx_processor (AudioSample_t * const src, AudioSample_t * co
 #endif
 
         // apply I/Q amplitude & phase adjustments
-        audio_tx_final_iq_processing(20.0*SSB_GAIN_COMP, ts.dmod_mode != DEMOD_LSB, dst, blockSize);
+        bool swap = ts.dmod_mode == DEMOD_USB || (ts.dmod_mode == DEMOD_DIGI && ts.digi_lsb == false);
+        audio_tx_final_iq_processing(20.0*SSB_GAIN_COMP, swap, dst, blockSize);
     }
     else
     {

--- a/mchf-eclipse/main.c
+++ b/mchf-eclipse/main.c
@@ -147,7 +147,7 @@ void EXTI0_IRQHandler(void)
             cw_gen_dah_IRQ();		// Yes - go to CW state machine
         }
         // PTT activate
-        else if((ts.dmod_mode == DEMOD_USB)||(ts.dmod_mode == DEMOD_LSB) || (ts.dmod_mode == DEMOD_AM) || (ts.dmod_mode == DEMOD_FM))
+        else if(ts.dmod_mode != DEMOD_SAM)
         {
             if(mchf_ptt_dah_line_pressed())
             {	// was PTT line low?


### PR DESCRIPTION
Now Digital Mode selection is almost fully working and briefly tested.

The promised documentation will be put into the Wiki:

https://github.com/df8oe/mchf-github/wiki/Operating-Manual#g1---mode-switch--131
