### PR TITLE
Preliminary fix for #589

### DIFF
--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -1596,6 +1596,14 @@ static bool RadioManagement_HandleLoTemperatureDrift()
                 retval = true;
                 lo.temp = temp;
             }
+            else
+            {
+                // TODO: Find out why the MCP9801 crashes the I2C bus if
+                // used with FreeDV
+                // Github Issue #589
+                mchf_hw_i2c2_init();
+            }
+
         }
     }
     return retval;


### PR DESCRIPTION
The symptom is a crashed I2C bus. It happens with just the MCP9801
enabled on the bus. Not clear yet why and why only in FreeDV but the
reset fixes that once it happens.
