### PR TITLE
Small Change in Digital Mode Touchscreen Handling and FreeDV code upgrade to r2884

### DIFF
--- a/mchf-eclipse/drivers/freedv/codec2_fft.c
+++ b/mchf-eclipse/drivers/freedv/codec2_fft.c
@@ -8,8 +8,8 @@
 #include "codec2_fft.h"
 #ifdef USE_KISS_FFT
 #include "_kiss_fft_guts.h"
-#endif
 
+#else
 #define FFT_INIT_CACHE_SIZE 4
 const arm_cfft_instance_f32* fft_init_cache[FFT_INIT_CACHE_SIZE];
 
@@ -52,7 +52,7 @@ static const arm_cfft_instance_f32* arm_fft_cache_get(const arm_cfft_instance_f3
     }
     return retval;
 }
-
+#endif
 
 void codec2_fft_free(codec2_fft_cfg cfg)
 {

--- a/mchf-eclipse/drivers/freedv/codec2_fft.h
+++ b/mchf-eclipse/drivers/freedv/codec2_fft.h
@@ -108,4 +108,3 @@ void codec2_fft_inplace(codec2_fft_cfg cfg, codec2_fft_cpx* inout);
 
 
 #endif
-/* DRIVERS_FREEDV_CODEC2_FFT_H_ */

--- a/mchf-eclipse/drivers/freedv/fdmdv.c
+++ b/mchf-eclipse/drivers/freedv/fdmdv.c
@@ -774,8 +774,6 @@ void lpf_peak_pick(float *foff, float *max, COMP pilot_baseband[],
             S[j] = fcmult(hanning[i], pilot_lpf[i]);
         }
 
-        // FIXME: arm_cfft does not seem to do the job here
-        // where as kiss_fft does. Needs investigation
         codec2_fft_inplace(fft_pilot_cfg, S);
 
         /* peak pick and convert to Hz */

--- a/mchf-eclipse/drivers/freedv/fsk.c
+++ b/mchf-eclipse/drivers/freedv/fsk.c
@@ -775,7 +775,7 @@ void fsk2_demod(struct FSK *fsk, uint8_t rx_bits[], float rx_sd[], float fsk_in[
         }
         /* Produce soft decision symbols */
         if(rx_sd != NULL){
-            rx_sd[i] = sqrtf(tmax[1]) - sqrtf(tmax[0]);
+            rx_sd[i] = sqrtf(tmax[0]) - sqrtf(tmax[1]);
         }
         /* Accumulate resampled int magnitude for EbNodB estimation */
         /* Standard deviation is calculated by algorithm devised by crafty soviets */

--- a/mchf-eclipse/drivers/freedv/interp.c
+++ b/mchf-eclipse/drivers/freedv/interp.c
@@ -278,7 +278,7 @@ void interp_Wo2(
   Interpolates centre 10ms sample of energy given two samples 20ms
   apart.
 
-\*--------------------------------------------------------------------------*/
+\*---------------------------------------------------------------------------*/
 
 float interp_energy(float prev_e, float next_e)
 {

--- a/mchf-eclipse/drivers/freedv/nlp.c
+++ b/mchf-eclipse/drivers/freedv/nlp.c
@@ -52,6 +52,7 @@
 #define F0_MAX      500
 #define CNLP        0.3	        /* post processor constant              */
 #define NLP_NTAP 48	        /* Decimation LPF order */
+#undef  POST_PROCESS_MBE        /* choose post processor                */
 
 //#undef DUMP
 
@@ -123,8 +124,10 @@ typedef struct {
     codec2_fft_cfg  fft_cfg;           /* kiss FFT config              */
 } NLP;
 
+#ifdef POST_PROCESS_MBE
 float test_candidate_mbe(COMP Sw[], COMP W[], float f0);
 float post_process_mbe(COMP Fw[], int pmin, int pmax, float gmax, COMP Sw[], COMP W[], float *prev_Wo);
+#endif
 float post_process_sub_multiples(COMP Fw[],
 				 int pmin, int pmax, float gmax, int gmax_bin,
 				 float *prev_Wo);
@@ -319,7 +322,6 @@ float nlp(
 
     PROFILE_SAMPLE_AND_LOG(peakpick, magsq, "      peak pick");
 
-    //#define POST_PROCESS_MBE
     #ifdef POST_PROCESS_MBE
     best_f0 = post_process_mbe(Fw, pmin, pmax, gmax, Sw, W, prev_Wo);
     #else
@@ -419,6 +421,8 @@ float post_process_sub_multiples(COMP Fw[],
 
     return best_f0;
 }
+
+#ifdef POST_PROCESS_MBE
 
 /*---------------------------------------------------------------------------*\
 
@@ -588,3 +592,4 @@ float test_candidate_mbe(
     return error;
 }
 
+#endif

--- a/mchf-eclipse/drivers/freedv/sine.c
+++ b/mchf-eclipse/drivers/freedv/sine.c
@@ -644,7 +644,7 @@ void synthesise(
 
     /* Overlap add to previous samples */
 #ifdef USE_KISS_FFT
-#define    FFTI_FACTOR ((float32_t)1.0)
+#define    FFTI_FACTOR ((float)1.0)
 #else
 #define    FFTI_FACTOR ((float32_t)FFT_DEC)
 #endif

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -791,8 +791,13 @@ void UiDriver_HandleTouchScreen()
             incr_wrap_uint8(&ts.digital_mode,0,1);
             // We limit the reachable modes to the ones truly available
             // which is FreeDV1 for now
+
             if (ts.digital_mode>0)
             {
+                if (ts.dmod_mode != DEMOD_DIGI)
+                {
+                    RadioManagement_SetDemodMode(DEMOD_DIGI);
+                }
                 ts.dvmode = true;
             }
             else


### PR DESCRIPTION
This commit contains a more consistent handling of the touchscreen digital mode box. Like the "normal" mode switch, the touch box now switches to Digital Mode Demodulation. This change is a response to several comments in the forums plus in github issue #596 . 
Let's see if this is the right way to do it. 

The FreeDV code base is now FreeDV SVN R2884. No functional changes introduced by this.
