### PR TITLE
Fix for issue #613. Now demodulated SSB audio in right sideband

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -2828,8 +2828,17 @@ static void audio_rx_processor(AudioSample_t * const src, AudioSample_t * const 
         case DEMOD_FM:
             audio_demod_fm(blockSize);
             break;
-        case DEMOD_USB:
         case DEMOD_DIGI:
+            if (ts.digi_lsb)
+            {
+                arm_sub_f32(adb.i_buffer, adb.q_buffer, adb.a_buffer, blockSize);   // difference of I and Q - LSB
+            }
+            else
+            {
+                arm_add_f32(adb.i_buffer, adb.q_buffer, adb.a_buffer, blockSize);   // sum of I and Q - USB
+            }
+            break;
+        case DEMOD_USB:
         default:
             arm_add_f32(adb.i_buffer, adb.q_buffer, adb.a_buffer, blockSize);   // sum of I and Q - USB
             break;

--- a/mchf-eclipse/drivers/cat/cat_driver.c
+++ b/mchf-eclipse/drivers/cat/cat_driver.c
@@ -403,7 +403,8 @@ void CatDriverFT817CheckAndExecute()
                     if(ts.flags1 & FLAGS1_CAT_IN_SANDBOX)			// if running in sandbox store active band
                         ts.cat_band_index = ts.band;
                     ts.cw_lsb = new_lsb;
-                    UiInitRxParms(new_mode);
+                    RadioManagement_SetDemodMode(new_mode);
+                    UiDriverUpdateDisplayAfterParamChange();
                 }
             }
             break;

--- a/mchf-eclipse/drivers/ui/ui_driver.h
+++ b/mchf-eclipse/drivers/ui/ui_driver.h
@@ -1,16 +1,16 @@
 /*  -*-  mode: c; tab-width: 4; indent-tabs-mode: t; c-basic-offset: 4; coding: utf-8  -*-  */
 /************************************************************************************
-**                                                                                 **
-**                               mcHF QRP Transceiver                              **
-**                             K Atanassov - M0NKA 2014                            **
-**                                                                                 **
-**---------------------------------------------------------------------------------**
-**                                                                                 **
-**  File name:                                                                     **
-**  Description:                                                                   **
-**  Last Modified:                                                                 **
-**  Licence:		CC BY-NC-SA 3.0                                                **
-************************************************************************************/
+ **                                                                                 **
+ **                               mcHF QRP Transceiver                              **
+ **                             K Atanassov - M0NKA 2014                            **
+ **                                                                                 **
+ **---------------------------------------------------------------------------------**
+ **                                                                                 **
+ **  File name:                                                                     **
+ **  Description:                                                                   **
+ **  Last Modified:                                                                 **
+ **  Licence:		CC BY-NC-SA 3.0                                                **
+ ************************************************************************************/
 
 #ifndef __UI_DRIVER_H
 #define __UI_DRIVER_H
@@ -387,16 +387,20 @@ void 	UiDriverChangeTuningStep(uchar is_up);
 //
 void 	uiCodecMute(uchar val);
 
-void	UiInitRxParms(uint16_t new_dmod_mode);
+void	UiDriverUpdateDisplayAfterParamChange();
 
 void    UiDriver_KeyTestScreen();
 void UiDriver_ShowStartUpScreen(ulong hold_time);
 
 bool	check_tp_coordinates(uint8_t,uint8_t,uint8_t,uint8_t);
 
+void RadioManagement_SetDemodMode(uint32_t new_mode);
 void RadioManagement_SwitchTxRx(uint8_t txrx_mode, bool tune_mode);
 void RadioManagement_UpdateFrequencyFast(uint8_t txrx_mode);
 uint8_t RadioManagement_GetBand(ulong freq);
+bool RadioManagementLSBActive(uint16_t dmod_mode);
+
+
 
 void UiDriverSetDemodMode(uint32_t new_mode); // switch to different demodulation mode.
 
@@ -420,7 +424,7 @@ void UiDriver_DoCrossCheck(char cross[],char* xt_corr, char* yt_corr);
 // UI Driver State machine definitions
 enum
 {
-//STATE_SPECTRUM_DISPLAY = 0,	//
+    //STATE_SPECTRUM_DISPLAY = 0,	//
     STATE_S_METER = 0,				//
     STATE_SWR_METER,				//
     STATE_HANDLE_POWERSUPPLY,		//

--- a/mchf-eclipse/main.c
+++ b/mchf-eclipse/main.c
@@ -585,7 +585,7 @@ int main(void)
 
     AudioFilter_SetDefaultMemories();
 
-    UiInitRxParms(ts.dmod_mode);
+    UiDriverUpdateDisplayAfterParamChange();
 
     ts.rx_gain[RX_AUDIO_SPKR].value_old = 99;		// Force update of volume control
     Codec_Mute(false);					// make sure codec is un-muted


### PR DESCRIPTION
Previously analog demodulation  in Digital modes
(once digital codec was switched off) was in USB. Now it matches the
DI-L (LSB) vs. DI-U (USB)

Also some refactoring without intended functional change
(basically a rename of UiInitRxParm())