### PR TITLE
Made the USB TX Audio Streaming more flexible

### DIFF
--- a/mchf-eclipse/drivers/ui/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/ui_menu.c
@@ -4130,8 +4130,28 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
         }
         break;
     case MENU_DEBUG_TX_AUDIO:  // Step size button swap on/off
-            tchange = UiDriverMenuItemChangeEnableOnOff(var, mode, &ts.debug_tx_audio,0,options,&clr);
+        tchange = UiDriverMenuItemChangeUInt8(var, mode, &ts.stream_tx_audio,
+                0,
+                STREAM_TX_AUDIO_NUM-1,
+                STREAM_TX_AUDIO_OFF,
+                1);
+        switch(ts.stream_tx_audio)
+        {
+        case STREAM_TX_AUDIO_OFF:
+            txt_ptr = "     Off";
             break;
+        case STREAM_TX_AUDIO_SRC:
+            txt_ptr = "  Source";
+            break;
+        case STREAM_TX_AUDIO_FILT:
+            txt_ptr = "Filtered";
+            break;
+        case STREAM_TX_AUDIO_DIGIQ:
+            txt_ptr = "Final IQ";
+            break;
+        }
+        break;
+
     default:						// Move to this location if we get to the bottom of the table!
         txt_ptr = "ERROR!";
         break;

--- a/mchf-eclipse/hardware/mchf_board.h
+++ b/mchf-eclipse/hardware/mchf_board.h
@@ -1200,7 +1200,12 @@ typedef struct TransceiverState
 
 	uint16_t ramsize; // in KB, this is used to distinguish  between 192 and 256 kB models.
 
-	uint8_t debug_tx_audio; // send tx audio via usb back to pc if value != 0;
+	uint8_t stream_tx_audio; // send tx audio via usb back
+#define STREAM_TX_AUDIO_OFF     0  // send nothing
+#define STREAM_TX_AUDIO_SRC     1  // send source audio stream (from CODEC)
+#define STREAM_TX_AUDIO_FILT    2  // send processed audio stream (after filtering)
+#define STREAM_TX_AUDIO_DIGIQ   3  // send final IQ signal
+#define STREAM_TX_AUDIO_NUM   4  // how many choices
 
 	// Freedv Test DL2FW
 	bool	FDV_TX_encode_ready;


### PR DESCRIPTION
You may now select if:
- the original input data,
- the filtered audio (before it is being modulated) [SSB, other modes may not give useful output here]
- the generated IQ
- or nothing is streamed
Default is nothing is streamed, turn on in menu "Debug".
Selection is NOT stored in EEPROM.