### PR TITLE
Changed touchscreen behavior in digital mode.

### DIFF
--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -818,6 +818,10 @@ void UiDriver_HandleTouchScreen()
             else
             {
                 ts.dvmode = false;
+                if (ts.dmod_mode == DEMOD_DIGI)
+                {
+                    RadioManagement_SetDemodMode(ts.digi_lsb?DEMOD_LSB:DEMOD_LSB);
+                }
             }
             RadioManagement_ChangeCodec(ts.digital_mode,ts.dvmode);
             UiDriverUpdateDisplayAfterParamChange();


### PR DESCRIPTION
If digital is active, touching digital again switches straight to
corresponding SSB mode instead of monitor mode.
This might be the implementation of the idea in #625.

It is not tested but should work as expected given the complexity of the change. 