### PR TITLE
Digital Modes now use LSB/USB Auto switch 

### DIFF
--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -4398,6 +4398,12 @@ static bool RadioManagement_IsApplicableDemodMode(uint32_t demod_mode)
         break;
     case DEMOD_DIGI:
         retval = (ts.demod_mode_disable & DEMOD_DIGI_DISABLE) == 0;      // is DIGI enabled?
+        if((ts.lsb_usb_auto_select) && retval == true)       // is auto-select LSB/USB mode enabled AND mode-skip NOT enabled?
+        {
+            // TODO: this is only true for FreeDV, but since we have only FreeDV...
+            ts.digi_lsb = RadioManagement_SSB_AutoSideBand(df.tune_new / TUNE_MULT) == DEMOD_LSB;
+            // is this a voice mode, subject to "auto" LSB/USB select?
+        }
         break;
     case DEMOD_CW:
         retval = (ts.demod_mode_disable & DEMOD_CW_DISABLE) == 0;      // is CW enabled?


### PR DESCRIPTION
to decide which sideband to use by default

If you enable LSB/USB Auto sideband selecting in menu, the digital mode will
use the same sideband as default as in ssb mode.
Also related to #625 
It is not tested but should work as expected given the complexity of the change. 