### PR TITLE
Frequency Storage Label Display and proposal for #408

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -410,18 +410,17 @@ arm_iir_lattice_instance_f32	IIR_FreeDV_RX_Filter;  //DL2FW: temporary installed
 float32_t		iir_FreeDV_RX_state[IIR_RXAUDIO_BLOCK_SIZE + IIR_RXAUDIO_NUM_STAGES];
 
 // S meter public
-__IO	SMeter					sm;
+SMeter					sm;
 
 // Keypad driver publics
 extern __IO	KeypadState				ks;
-//
 
 // ATTENTION: These data structures have been placed in CCM Memory (64k)
 // IF THE SIZE OF  THE DATA STRUCTURE GROWS IT WILL QUICKLY BE OUT OF SPACE IN CCM
 // Be careful! Check mchf-eclipse.map for current allocation
-__IO AudioDriverState   __attribute__ ((section (".ccm")))  ads;
-AudioDriverBuffer   __attribute__ ((section (".ccm")))  adb;
-LMSData                 __attribute__ ((section (".ccm"))) lmsData;
+AudioDriverState   __attribute__ ((section (".ccm"))) ads;
+AudioDriverBuffer  __attribute__ ((section (".ccm"))) adb;
+LMSData            __attribute__ ((section (".ccm"))) lmsData;
 
 #ifdef USE_SNAP
 SnapCarrier   sc;

--- a/mchf-eclipse/drivers/audio/audio_driver.h
+++ b/mchf-eclipse/drivers/audio/audio_driver.h
@@ -564,8 +564,9 @@ void I2S_RX_CallBack(int16_t *src, int16_t *dst, int16_t size, uint16_t ht);
 #endif
 
 // Public Audio
-extern __IO		AudioDriverState	ads;
-extern __IO     SMeter              sm;
+extern AudioDriverState	ads;
+extern SMeter           sm;
+
 // change this to 2048 (=1024 tap FFT), if problems with spectrum display with 7k5 SAM mode persist!
 #define FFT_IQ_BUFF_LEN2 2048
 //#define FFT_IQ_BUFF_LEN2 4096 // = 2048 tap FFT !!! this is very very accurate
@@ -582,8 +583,8 @@ typedef struct SnapCarrier
 	arm_rfft_fast_instance_f32           S; // new and faster real FFT routine
 
     // Samples buffer
-    //
     float32_t   FFT_Samples[FFT_IQ_BUFF_LEN2];
+
 //    float32_t   FFT_Windat[FFT_IQ_BUFF_LEN2];
     // Current data ptr
     ulong   samp_ptr;

--- a/mchf-eclipse/drivers/ui/lcd/ui_lcd_hy28.h
+++ b/mchf-eclipse/drivers/ui/lcd/ui_lcd_hy28.h
@@ -65,6 +65,9 @@
 #define	RX_Grey				RGB(0xb8,0xdb,0xa8)	// slightly green grey
 #define TX_Grey				RGB(0xe8,0xad,0xa0)	// slightly red(ish) grey (more magenta, actually...)
 
+#define SMALL_FONT_WIDTH            8
+#define LARGE_FONT_WIDTH            16
+
 
 #define LCD_DIR_HORIZONTAL	0x0000
 #define LCD_DIR_VERTICAL	0x0001

--- a/mchf-eclipse/drivers/ui/lcd/ui_lcd_hy28_fonts.h
+++ b/mchf-eclipse/drivers/ui/lcd/ui_lcd_hy28_fonts.h
@@ -22,4 +22,5 @@ typedef struct tFont
     unsigned short Height;
 } sFONT;
 
+
 #endif

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -5491,6 +5491,9 @@ static void UiDriver_DisplayLineInModeAndGain(bool encoder_active)
     const char* txt;
     char  txt_buf[5];
 
+    bool gain_external_control = false;
+    // if true, gain is controlled externally and ENC3 encoder does not do anything.
+
     switch (ts.tx_audio_source)
     {
     case TX_AUDIO_MIC:
@@ -5504,15 +5507,24 @@ static void UiDriver_DisplayLineInModeAndGain(bool encoder_active)
         break;
     case TX_AUDIO_DIG:										// Line gain
         txt = "DIG";
+        gain_external_control = true;
         break;
     case TX_AUDIO_DIGIQ:
         txt = "DIQ";
+        gain_external_control = true;
         break;
     default:
         txt = "???";
     }
 
-    snprintf(txt_buf,5,"%2d",ts.tx_gain[ts.tx_audio_source]);
+    if (gain_external_control == true)
+    {
+        snprintf(txt_buf,5,"EXT");
+    }
+    else
+    {
+        snprintf(txt_buf,5,"%2d",ts.tx_gain[ts.tx_audio_source]);
+    }
 
     UiDriverEncoderDisplay(1,2,txt, encoder_active, txt_buf, color);
 }

--- a/mchf-eclipse/hardware/mchf_board.h
+++ b/mchf-eclipse/hardware/mchf_board.h
@@ -1181,6 +1181,9 @@ typedef struct TransceiverState
     ulong	dBm_count;				// timer for calculating RX dBm
     uchar 	display_dbm;			// display dbm or dbm/Hz or OFF
     uchar	s_meter;				// defines S-Meter style/configuration
+#define DISPLAY_S_METER_STD   0
+#define DISPLAY_S_METER_DBM   1
+#define DISPLAY_S_METER_DBMHZ 2
 
 //    #define TX_FILTER_NONE			0
     #define TX_FILTER_SOPRANO		1


### PR DESCRIPTION
In response to #408 Show "EXT" if gain is externally controlled (i.e. from the PC)

and (unrelated)
Added MemoryLabel Display

This label shows the name of the currently select storage.
In VFO Mode this the name of band memory.
Since users may tune to frequencies out of band or even in other bands,
this sometimes created confusion. Now this display always shows the
real storage name (which is the "original" band name.
Once the memory mode is implemented, this would show the memory index or
even name if we decide to assign names to the memories.

I am not totally happy with the generated name, but I think the idea will help to avoid some confusion.
