### PR TITLE
Fixed spike at begin of each CW transmission and also all other spikes

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -2888,10 +2888,14 @@ static void AudioDriver_RxProcessor(AudioSample_t * const src, AudioSample_t * c
 
     float32_t usb_audio_gain = ts.rx_gain[RX_AUDIO_DIG].value/31.0;
 
-    if (ts.audio_dac_muting_flag)
+    if (do_mute_output)
     {
         memset(dst,0,blockSize*sizeof(*dst));
         // Pause or inactivity
+        if (ts.audio_dac_muting_buffer_count > 0)
+        {
+            ts.audio_dac_muting_buffer_count--;
+        }
     }
 
     // Transfer processed audio to DMA buffer

--- a/mchf-eclipse/drivers/audio/codec/codec.c
+++ b/mchf-eclipse/drivers/audio/codec/codec.c
@@ -212,7 +212,8 @@ void Codec_SwitchMicTxRxMode(uint8_t txrx_mode)
  */
 void Codec_PrepareTx(uint8_t current_txrx_mode)
 {
-    if(ts.dmod_mode != DEMOD_CW)                    // are we in a voice mode?
+    // if(ts.dmod_mode != DEMOD_CW)                    // are we in a voice mode?
+    // FIXME: Remove commented out "if" above, if the CW guys accept that this works as wanted.
     {
         Codec_LineInGainAdj(0); // yes - momentarily mute LINE IN audio if in LINE IN mode until we have switched to TX
 

--- a/mchf-eclipse/drivers/audio/cw/cw_gen.c
+++ b/mchf-eclipse/drivers/audio/cw/cw_gen.c
@@ -556,4 +556,8 @@ void CwGen_DitIRQ(void)
     }
 }
 
-
+void CwGen_PrepareTx()
+{
+    CwGen_SetSpeed();
+    ps.key_timer        = 0;
+}

--- a/mchf-eclipse/drivers/audio/cw/cw_gen.h
+++ b/mchf-eclipse/drivers/audio/cw/cw_gen.h
@@ -18,6 +18,7 @@
 
 // Exports
 void 	CwGen_Init();
+void    CwGen_PrepareTx();
 void    CwGen_SetSpeed();
 
 bool	CwGen_Process(float32_t *i_buffer,float32_t *q_buffer,ulong size);

--- a/mchf-eclipse/drivers/ui/ui_driver.h
+++ b/mchf-eclipse/drivers/ui/ui_driver.h
@@ -365,7 +365,7 @@ void 	UiDriver_UpdateFrequency(bool force_update, enum UpdateFrequencyMode_t mod
 
 void    UiDriver_FrequencyUpdateLOandDisplay(bool full_update);
 void 	RadioManagement_SetBandPowerFactor(uchar band);
-void 	RadioManagement_EnablePABias(void);
+void 	RadioManagement_SetPaBias();
 //
 //void 	UiDriverChangeFilter(uchar ui_only_update);
 void 	RadioManagement_SetBandPowerFactor(uchar band);

--- a/mchf-eclipse/drivers/ui/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/ui_menu.c
@@ -3339,7 +3339,7 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
 
             if(tchange)
             {
-                RadioManagement_EnablePABias();
+                RadioManagement_SetPaBias();
             }
             if(ts.pa_cw_bias < MIN_BIAS_SETTING)
             {
@@ -3363,7 +3363,7 @@ static void UiDriverUpdateConfigMenuLines(uchar index, uchar mode, int pos)
 
             if(tchange)
             {
-                RadioManagement_EnablePABias();
+                RadioManagement_SetPaBias();
             }
             if(ts.pa_bias < MIN_BIAS_SETTING)
             {

--- a/mchf-eclipse/hardware/mchf_board.h
+++ b/mchf-eclipse/hardware/mchf_board.h
@@ -1113,6 +1113,7 @@ typedef struct TransceiverState
     bool	dvmode;					// TRUE if alternate (stripped-down) RX and TX functions (USB-only) are to be used
     uchar	txrx_switch_audio_muting_timing;			// timing value used for muting TX audio when keying PTT to suppress "click" or "thump"
     ulong	audio_dac_muting_timer;			// timer value used for muting TX audio when keying PTT to suppress "click" or "thump"
+    uint32_t audio_dac_muting_buffer_count; // the audio dac out will be muted for number of buffers
     uchar	filter_disp_colour;			// used to hold the current color of the line that indicates the filter passband/bandwidth
     bool	audio_dac_muting_flag;			// when TRUE, audio is to be muted after PTT/keyup
     bool	vfo_mem_flag;				// when TRUE, memory mode is enabled

--- a/mchf-eclipse/hardware/mchf_board.h
+++ b/mchf-eclipse/hardware/mchf_board.h
@@ -1339,6 +1339,16 @@ inline void MchfBoard_EnableTXSignalPath(bool tx_enable)
     }
 }
 
+/**
+ * @brief set PA bias at the LM2931CDG (U18) using DAC Channel 2
+ */
+inline void MchfBoard_SetPaBiasValue(uint16_t bias)
+{
+    // Set DAC Channel 1 DHR12L register
+    DAC_SetChannel2Data(DAC_Align_8b_R,bias);
+
+}
+
 void MchfBoard_HandlePowerDown();
 
 void MchfBoard_SelectLpfBpf(uint8_t group);

--- a/mchf-eclipse/support/MCHF.launch
+++ b/mchf-eclipse/support/MCHF.launch
@@ -32,7 +32,7 @@
 <intAttribute key="org.eclipse.cdt.debug.gdbjtag.core.portNumber" value="3333"/>
 <booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setPcRegister" value="false"/>
 <booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setResume" value="false"/>
-<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setStopAt" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setStopAt" value="true"/>
 <stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.stopAt" value="main"/>
 <stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.symbolsFileName" value=""/>
 <stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.symbolsOffset" value=""/>


### PR DESCRIPTION
during RX/TX switching. I hope at least.

Now for me TX/RX Mute Delay works perfectly even if set to 0ms.
Was no longer able to create any unwanted spike at begin OR end of transmission

PLEASE TEST MY CW CHANGE CAREFULLY. It should not affect anything (and removed the
CW noise), but you never know.