### PR TITLE
Reduced TX/RX switching latency and EEPROM save time (EXPERIMENTAL!)

### DIFF
--- a/mchf-eclipse/drivers/ui/radio_management.c
+++ b/mchf-eclipse/drivers/ui/radio_management.c
@@ -446,7 +446,7 @@ void RadioManagement_SwitchTxRx(uint8_t txrx_mode, bool tune_mode)
             // We mute the audio BEFORE we activate the PTT.
             // This is necessary since U3 is switched the instant that we do so,
             // rerouting audio paths and causing all sorts of disruption including CLICKs and squeaks.
-            Codec_PrepareTx(ts.txrx_mode);
+            Codec_PrepareTx(ts.txrx_mode); // 5ms
 
             while (ts.audio_dac_muting_buffer_count >0)
             {
@@ -466,6 +466,7 @@ void RadioManagement_SwitchTxRx(uint8_t txrx_mode, bool tune_mode)
 
         df.tune_new = tune_new;
         RadioManagement_ChangeFrequency(false,df.tune_new/TUNE_MULT, txrx_mode_final);
+        // ts.audio_dac_muting_flag = true; // let the audio being muted initially as long as we need it
 
         // there might have been a band change between the modes, make sure to have the power settings fitting the mode
         if (txrx_mode_final == TRX_MODE_TX)
@@ -513,7 +514,7 @@ void RadioManagement_SwitchTxRx(uint8_t txrx_mode, bool tune_mode)
             else
             {
                 RadioManagement_SetPaBias();
-                uint32_t input_mute_time = 0, dac_mute_time = 2, dac_mute_time_mode = 0, input_mute_time_mode = 0; // aka 1.3ms
+                uint32_t input_mute_time = 0, dac_mute_time = 0, dac_mute_time_mode = 0, input_mute_time_mode = 0; // aka 1.3ms
                 // calculate expire time for audio muting in interrupts, it is 15 interrupts per 10ms
                 dac_mute_time = ts.txrx_switch_audio_muting_timing * 15;
 

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -5917,6 +5917,7 @@ void UiDriver_MainHandler()
 
     uint32_t now = ts.sysclock;
 
+    // START CALLED AS OFTEN AS POSSIBLE
 #ifdef USE_FREEDV
     if (ts.dvmode == true)
     {
@@ -5924,7 +5925,13 @@ void UiDriver_MainHandler()
     }
 #endif // USE_FREEDV
 
+    if (ts.tx_stop_req == true  || ts.ptt_req == true)
+    {
+        RadioManagement_HandlePttOnOff();
+    }
+    // END CALLED AS OFTEN AS POSSIBLE
 
+    // BELOW ALL CALLING IS BASED ON SYSCLOCK 10ms clock
     if (UiDriver_TimerExpireAndRewind(SCTimer_ENCODER_KEYS,now,1))
     {
         // 10ms have elapsed.

--- a/mchf-eclipse/hardware/mchf_hw_i2c.c
+++ b/mchf-eclipse/hardware/mchf_hw_i2c.c
@@ -20,8 +20,9 @@
 #define I2C1_FLAG_TIMEOUT          		((uint32_t)0x500)
 #define I2C1_LONG_TIMEOUT          		((uint32_t)(300 * I2C1_FLAG_TIMEOUT))
 
-//#define I2C1_SPEED             		400000
-#define I2C1_SPEED             			100000
+// #define I2C1_SPEED             		    400000 // too high, does not work
+// #define I2C1_SPEED             		    100000
+#define I2C1_SPEED                      200000
 //#define I2C1_SPEED           			25000
 
 // I2C peripheral configuration defines (control interface of the si570)
@@ -194,7 +195,7 @@ void mchf_hw_i2c1_init(void)
     // CODEC_I2C SCL and SDA pins configuration
     GPIO_InitStructure.GPIO_Pin = I2C1_SCL_PIN|I2C1_SDA_PIN;
     GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF;
-    GPIO_InitStructure.GPIO_Speed = GPIO_Speed_25MHz;
+    GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
     GPIO_InitStructure.GPIO_OType = GPIO_OType_OD;
 
     GPIO_InitStructure.GPIO_PuPd  = GPIO_PuPd_UP;		// - strong ringing on the bus

--- a/mchf-eclipse/hardware/mchf_hw_i2c2.c
+++ b/mchf-eclipse/hardware/mchf_hw_i2c2.c
@@ -18,7 +18,7 @@
 #include "mchf_hw_i2c.h"
 #include "mchf_hw_i2c2.h"
 
-#define I2C2_SPEED             			25000
+#define I2C2_SPEED             			400000 // was 25000
 
 // I2C peripheral configuration defines (control interface of the si570)
 #define I2C2_CLK                  	RCC_APB1Periph_I2C2
@@ -42,7 +42,7 @@ void mchf_hw_i2c2_init(void)
     // I2C2 SCL and SDA pins configuration
     GPIO_InitStructure.GPIO_Pin   = I2C2_SCL_PIN|I2C2_SDA_PIN;
     GPIO_InitStructure.GPIO_Mode  = GPIO_Mode_AF;
-    GPIO_InitStructure.GPIO_Speed = GPIO_Speed_25MHz;
+    GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
     GPIO_InitStructure.GPIO_OType = GPIO_OType_OD;
 
     GPIO_InitStructure.GPIO_PuPd  = GPIO_PuPd_NOPULL;		// we also have ext pullups


### PR DESCRIPTION
By increasing the I2C speed (within permitted speeds) we can
gain significant speedup for I2C routines.
This makes frequency changes faster, audio codec communication faster and also
I2C EEPROM readout faster.
In total this reduced RX to TX time by 12ms (from 23 to 11ms)

I2C EEPROM and Codec 25 khz -> 400 khz
Si570 100 kHz -> 200 kHz (400 kHz do not work).

ATTENTION: THIS MAY CAUSE PROBLEMS ON CERTAIN HARDWARE (especially if long wires are used between RF and UI).
PLEASE TEST AND REPORT.