### PR TITLE
Issue #675: Reverted I2C speeds back to previous values.

### DIFF
--- a/mchf-eclipse/hardware/mchf_hw_i2c.c
+++ b/mchf-eclipse/hardware/mchf_hw_i2c.c
@@ -21,9 +21,9 @@
 #define I2C1_LONG_TIMEOUT          		((uint32_t)(300 * I2C1_FLAG_TIMEOUT))
 
 // #define I2C1_SPEED             		    400000 // too high, does not work
-// #define I2C1_SPEED             		    100000
-#define I2C1_SPEED                      200000
-//#define I2C1_SPEED           			25000
+#define I2C1_SPEED             		    100000
+// #define I2C1_SPEED                      200000
+// #define I2C1_SPEED           			25000
 
 // I2C peripheral configuration defines (control interface of the si570)
 #define SI570_I2C                      	I2C1

--- a/mchf-eclipse/hardware/mchf_hw_i2c2.c
+++ b/mchf-eclipse/hardware/mchf_hw_i2c2.c
@@ -18,7 +18,7 @@
 #include "mchf_hw_i2c.h"
 #include "mchf_hw_i2c2.h"
 
-#define I2C2_SPEED             			400000 // was 25000
+#define I2C2_SPEED             			25000
 
 // I2C peripheral configuration defines (control interface of the si570)
 #define I2C2_CLK                  	RCC_APB1Periph_I2C2


### PR DESCRIPTION
Needs a more conservative approach. E.g. with autochecking of working speeds.