### PR TITLE
real SAM demodulation prototype working

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -2640,9 +2640,9 @@ static void AudioDriver_DemodSAM(int16_t blockSize)
 {
 	// new synchronous AM PLL & PHASE detector
 	// wdsp Warren Pratt, 2016
-	const float32_t DF = 1.0;
-	const float32_t pll_fmin = -4000.0;
-	const float32_t pll_fmax = +4000.0;
+	const static float32_t DF = 1.0;
+	const static float32_t pll_fmin = -4000.0;
+	const static float32_t pll_fmax = +4000.0;
 	// DX adjustments: zeta = 0.15, omegaN = 100.0
 	// very stable, but does not lock very fast
 	// standard settings: zeta = 1.0, omegaN = 250.0
@@ -2651,24 +2651,24 @@ static void AudioDriver_DemodSAM(int16_t blockSize)
 	// DX = 0.2, 70
 	// medium 0.6, 200
 	// fast 1.2, 500
-	const float32_t zeta = 1.0; // 0.01;// 0.001; // 0.1; //0.65; // PLL step response: smaller, slower response 1.0 - 0.1
+	const static float32_t zeta = 1.0; // 0.01;// 0.001; // 0.1; //0.65; // PLL step response: smaller, slower response 1.0 - 0.1
 	const float32_t omegaN = 500.0; //200.0; // PLL bandwidth 50.0 - 1000.0
 
 	  //pll
 	//const float32_t omega_min = 2.0 * 3.141592653589793f * pll_fmin * DF / IQ_SAMPLE_RATE_F;
-	const float32_t  omega_min = (2.0 * 3.141592653589793f * pll_fmin * DF / IQ_SAMPLE_RATE_F);
-	const float32_t  omega_max = (2.0 * 3.141592653589793f * pll_fmax * DF / IQ_SAMPLE_RATE_F);
-	const float32_t  g1 = (1.0 - exp(-2.0 * omegaN * zeta * DF / IQ_SAMPLE_RATE_F));
-	const float32_t  g2 = (- g1 + 2.0 * (1 - exp(- omegaN * zeta * DF / IQ_SAMPLE_RATE_F)
+	const static float32_t  omega_min = (2.0 * 3.141592653589793f * pll_fmin * DF / IQ_SAMPLE_RATE_F);
+	const static float32_t  omega_max = (2.0 * 3.141592653589793f * pll_fmax * DF / IQ_SAMPLE_RATE_F);
+	const static float32_t  g1 = (1.0 - exp(-2.0 * omegaN * zeta * DF / IQ_SAMPLE_RATE_F));
+	const static float32_t  g2 = (- g1 + 2.0 * (1 - exp(- omegaN * zeta * DF / IQ_SAMPLE_RATE_F)
 			* cosf(omegaN * DF / IQ_SAMPLE_RATE_F * sqrtf(1.0 - zeta * zeta))));
 
 	  //fade leveler
-	const float32_t tauR = 0.02; // original 0.02;
-	const float32_t tauI = 1.4; // original 1.4;
-	const float32_t  mtauR = (exp(- DF / (IQ_SAMPLE_RATE_F * tauR))); //0.99948;
-	const float32_t onem_mtauR = (1.0 - mtauR);
-	const float32_t  mtauI = (exp(- DF / (IQ_SAMPLE_RATE_F * tauI))); //0.99999255955;
-	const float32_t  onem_mtauI = (1.0 - mtauI);
+	const static float32_t tauR = 0.02; // original 0.02;
+	const static float32_t tauI = 1.4; // original 1.4;
+	const static float32_t  mtauR = (exp(- DF / (IQ_SAMPLE_RATE_F * tauR))); //0.99948;
+	const static float32_t onem_mtauR = (1.0 - mtauR);
+	const static float32_t  mtauI = (exp(- DF / (IQ_SAMPLE_RATE_F * tauI))); //0.99999255955;
+	const static float32_t  onem_mtauI = (1.0 - mtauI);
 	//*****************************
 		static float32_t Sin = 0.0;
 		static float32_t Cos = 0.0;
@@ -2679,7 +2679,7 @@ static void AudioDriver_DemodSAM(int16_t blockSize)
 		static float32_t fil_out = 0.0;
 		static float32_t del_out = 0.0;
 		static float32_t omega2 = 0.01;
-		static float32_t dc = 0.0;
+		static float32_t dc27 = 0.0;
 		static float32_t dc_insert = 0.0;
 
 
@@ -2689,27 +2689,33 @@ static void AudioDriver_DemodSAM(int16_t blockSize)
         {
             Sin = sinf(phs);
             Cos = cosf(phs);
-//            tmp_re = Cos * adb.i_buffer[i] - Sin * adb.q_buffer[i];
-//            tmp_im = Cos * adb.q_buffer[i] + Sin * adb.i_buffer[i];
-            tmp_re = Cos * adb.q_buffer[i] - Sin * adb.i_buffer[i];
-            tmp_im = Cos * adb.i_buffer[i] + Sin * adb.q_buffer[i];
+            tmp_re = Cos * adb.i_buffer[i] - Sin * adb.q_buffer[i];
+            tmp_im = Cos * adb.q_buffer[i] + Sin * adb.i_buffer[i];
+//            tmp_re = Cos * adb.q_buffer[i] - Sin * adb.i_buffer[i];
+//            tmp_im = Cos * adb.i_buffer[i] + Sin * adb.q_buffer[i];
             //            phzerror = atan2f(tmp_im, tmp_re);
-            phzerror = atan2f(tmp_re, tmp_im);
+            phzerror = atan2f(tmp_im, tmp_re);
 
                 del_out = fil_out;
                 omega2 = omega2 + g2 * phzerror;
-                if (omega2 < omega_min) omega2 = omega_min;
-                else if (omega2 > omega_max) omega2 = omega_max;
+                if (omega2 < omega_min)
+                {
+                    omega2 = omega_min;
+                }
+                else if (omega2 > omega_max)
+                {
+                    omega2 = omega_max;
+                }
                 fil_out = g1 * phzerror + omega2;
                 phs = phs + del_out;
 
 
             // "fade leveler", taken from Warren Pratts� WDSP / HPSDR, 2016
             // http://svn.tapr.org/repos_sdr_hpsdr/trunk/W5WC/PowerSDR_HPSDR_mRX_PS/Source/wdsp/
-            dc = mtauR * dc + onem_mtauR * tmp_re;
+/*            dc27 = mtauR * dc27 + onem_mtauR * tmp_re;
             dc_insert = mtauI * dc_insert + onem_mtauI * tmp_re;
-            tmp_re = tmp_re + dc_insert - dc;
-
+            tmp_re = tmp_re + dc_insert - dc27;
+*/
             adb.b_buffer[i] = tmp_re;
 
             // wrap round 2PI, modulus
@@ -2818,7 +2824,7 @@ static void AudioDriver_RxProcessor(AudioSample_t * const src, AudioSample_t * c
 
     // Apply I/Q amplitude correction
     arm_scale_f32(adb.i_buffer, ts.rx_adj_gain_var.i, adb.i_buffer, blockSize);
-    arm_scale_f32(adb.q_buffer, ts.rx_adj_gain_var.q, adb.q_buffer, blockSize);
+    arm_scale_f32(adb.q_buffer, ts.rx_adj_gain_var.q, adb.q_buffer, blockSize); // TODO: we need only scale one channel! DD4WH, Dec 2016
 
 
     // Apply I/Q phase correction
@@ -2887,12 +2893,12 @@ static void AudioDriver_RxProcessor(AudioSample_t * const src, AudioSample_t * c
             }
             break;
         case DEMOD_SAM:
-//        	AudioDriver_DemodSAM(blockSize);
+        	AudioDriver_DemodSAM(blockSize);
         	// TODO: the above is "real" SAM, old SAM mode (below) should be renamed and implemented as DSB (double sideband mode)
 
-            arm_sub_f32(adb.i_buffer, adb.q_buffer, adb.f_buffer, blockSize);   // difference of I and Q - LSB
-            arm_add_f32(adb.i_buffer, adb.q_buffer, adb.e_buffer, blockSize);   // sum of I and Q - USB
-            arm_add_f32(adb.e_buffer, adb.f_buffer, adb.a_buffer, blockSize);   // sum of LSB & USB = DSB
+//            arm_sub_f32(adb.i_buffer, adb.q_buffer, adb.f_buffer, blockSize);   // difference of I and Q - LSB
+//            arm_add_f32(adb.i_buffer, adb.q_buffer, adb.e_buffer, blockSize);   // sum of I and Q - USB
+//            arm_add_f32(adb.e_buffer, adb.f_buffer, adb.a_buffer, blockSize);   // sum of LSB & USB = DSB
 
             break;
         case DEMOD_FM:
@@ -2916,7 +2922,7 @@ static void AudioDriver_RxProcessor(AudioSample_t * const src, AudioSample_t * c
             break;
         }
 
-        if(dmod_mode != DEMOD_FM)       // are we NOT in FM mode?  If we are not, do decimation, filtering, DSP notch/noise reduction, etc.
+        if(dmod_mode != DEMOD_FM && dmod_mode != DEMOD_SAM)       // are we NOT in FM mode?  If we are not, do decimation, filtering, DSP notch/noise reduction, etc.
         {
             // Do decimation down to lower rate to reduce processor load
             if (DECIMATE_RX.numTaps > 0)

--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -524,6 +524,37 @@ void AudioDriver_Init(void)
     ads.fm_subaudible_tone_detected = 0;	// TRUE if subaudible tone has been detected
     //
     ads.decimation_rate	=	RX_DECIMATION_RATE_12KHZ;		// Decimation rate, when enabled
+
+
+
+    ads.DF = 1.0;
+    ads.pll_fmin = -2500.0;
+    ads.pll_fmax = +2500.0;
+    // DX adjustments: zeta = 0.15, omegaN = 100.0
+    // very stable, but does not lock very fast
+    // standard settings: zeta = 1.0, omegaN = 250.0
+    // maybe user can choose between slow (DX), medium, fast SAM PLL
+    // zeta / omegaN
+    // DX = 0.2, 70
+    // medium 0.6, 200
+    // fast 1.0, 500
+    ads.zeta = 0.4; // 0.01;// 0.001; // 0.1; //0.65; // PLL step response: smaller, slower response 1.0 - 0.1
+    ads.omegaN = 200.0; //200.0; // PLL bandwidth 50.0 - 1000.0
+
+      //pll
+    ads.omega_min = (2.0 * PI * ads.pll_fmin * ads.DF / IQ_SAMPLE_RATE_F); //-0.5235987756; //
+    ads.omega_max = (2.0 * PI * ads.pll_fmax * ads.DF / IQ_SAMPLE_RATE_F); //0.5235987756; //
+    ads.g1 = (1.0 - exp(-2.0 * ads.omegaN * ads.zeta * ads.DF / IQ_SAMPLE_RATE_F)); //0.0082987073611; //
+    ads.g2 = (- ads.g1 + 2.0 * (1 - exp(- ads.omegaN * ads.zeta * ads.DF / IQ_SAMPLE_RATE_F)
+          * cosf(ads.omegaN * ads.DF / IQ_SAMPLE_RATE_F * sqrtf(1.0 - ads.zeta * ads.zeta)))); //0.01036367597097734813032783691644; //
+      //fade leveler
+    ads.tauR = 0.02; // original 0.02;
+    ads.tauI = 1.4; // original 1.4;
+    ads.mtauR = 0.99896; //(exp(- DF / (IQ_SAMPLE_RATE_F * tauR))); //0.99948;
+    ads.onem_mtauR = (1.0 - ads.mtauR);
+    ads.mtauI = 0.999985119; //(exp(- DF / (IQ_SAMPLE_RATE_F * tauI))); //0.99999255955;
+    ads.onem_mtauI = (1.0 - ads.mtauI);
+
     //
     //
     AudioManagement_CalcAGCDecay();	// initialize AGC decay ("hang time") values
@@ -2640,35 +2671,6 @@ static void AudioDriver_DemodSAM(int16_t blockSize)
 {
 	// new synchronous AM PLL & PHASE detector
 	// wdsp Warren Pratt, 2016
-	const static float32_t DF = 1.0;
-	const static float32_t pll_fmin = -4000.0;
-	const static float32_t pll_fmax = +4000.0;
-	// DX adjustments: zeta = 0.15, omegaN = 100.0
-	// very stable, but does not lock very fast
-	// standard settings: zeta = 1.0, omegaN = 250.0
-	// maybe user can choose between slow (DX), medium, fast SAM PLL
-	// zeta / omegaN
-	// DX = 0.2, 70
-	// medium 0.6, 200
-	// fast 1.2, 500
-	const static float32_t zeta = 1.0; // 0.01;// 0.001; // 0.1; //0.65; // PLL step response: smaller, slower response 1.0 - 0.1
-	const float32_t omegaN = 500.0; //200.0; // PLL bandwidth 50.0 - 1000.0
-
-	  //pll
-	//const float32_t omega_min = 2.0 * 3.141592653589793f * pll_fmin * DF / IQ_SAMPLE_RATE_F;
-	const static float32_t  omega_min = (2.0 * 3.141592653589793f * pll_fmin * DF / IQ_SAMPLE_RATE_F);
-	const static float32_t  omega_max = (2.0 * 3.141592653589793f * pll_fmax * DF / IQ_SAMPLE_RATE_F);
-	const static float32_t  g1 = (1.0 - exp(-2.0 * omegaN * zeta * DF / IQ_SAMPLE_RATE_F));
-	const static float32_t  g2 = (- g1 + 2.0 * (1 - exp(- omegaN * zeta * DF / IQ_SAMPLE_RATE_F)
-			* cosf(omegaN * DF / IQ_SAMPLE_RATE_F * sqrtf(1.0 - zeta * zeta))));
-
-	  //fade leveler
-	const static float32_t tauR = 0.02; // original 0.02;
-	const static float32_t tauI = 1.4; // original 1.4;
-	const static float32_t  mtauR = (exp(- DF / (IQ_SAMPLE_RATE_F * tauR))); //0.99948;
-	const static float32_t onem_mtauR = (1.0 - mtauR);
-	const static float32_t  mtauI = (exp(- DF / (IQ_SAMPLE_RATE_F * tauI))); //0.99999255955;
-	const static float32_t  onem_mtauI = (1.0 - mtauI);
 	//*****************************
 		static float32_t Sin = 0.0;
 		static float32_t Cos = 0.0;
@@ -2682,8 +2684,6 @@ static void AudioDriver_DemodSAM(int16_t blockSize)
 		static float32_t dc27 = 0.0;
 		static float32_t dc_insert = 0.0;
 
-
-
           // Wheatley 2011 cuteSDR & Warren Pratt�s WDSP, 2016
         for(int i = 0; i < blockSize; i++)
         {
@@ -2694,36 +2694,64 @@ static void AudioDriver_DemodSAM(int16_t blockSize)
 //            tmp_re = Cos * adb.q_buffer[i] - Sin * adb.i_buffer[i];
 //            tmp_im = Cos * adb.i_buffer[i] + Sin * adb.q_buffer[i];
             //            phzerror = atan2f(tmp_im, tmp_re);
-            phzerror = atan2f(tmp_im, tmp_re);
+            phzerror = - atan2f(tmp_im, tmp_re);
+//            phzerror = atan2f(tmp_re, tmp_im);
 
                 del_out = fil_out;
-                omega2 = omega2 + g2 * phzerror;
-                if (omega2 < omega_min)
+                omega2 = omega2 + ads.g2 * phzerror;
+                if (omega2 < ads.omega_min)
                 {
-                    omega2 = omega_min;
+                    omega2 = ads.omega_min;
                 }
-                else if (omega2 > omega_max)
+                else if (omega2 > ads.omega_max)
                 {
-                    omega2 = omega_max;
+                    omega2 = ads.omega_max;
                 }
-                fil_out = g1 * phzerror + omega2;
+                fil_out = ads.g1 * phzerror + omega2;
                 phs = phs + del_out;
-
 
             // "fade leveler", taken from Warren Pratts� WDSP / HPSDR, 2016
             // http://svn.tapr.org/repos_sdr_hpsdr/trunk/W5WC/PowerSDR_HPSDR_mRX_PS/Source/wdsp/
-/*            dc27 = mtauR * dc27 + onem_mtauR * tmp_re;
-            dc_insert = mtauI * dc_insert + onem_mtauI * tmp_re;
+            dc27 = ads.mtauR * dc27 + ads.onem_mtauR * tmp_re;
+            dc_insert = ads.mtauI * dc_insert + ads.onem_mtauI * tmp_re;
             tmp_re = tmp_re + dc_insert - dc27;
-*/
-            adb.b_buffer[i] = tmp_re;
+
+            adb.a_buffer[i] = tmp_re;
 
             // wrap round 2PI, modulus
-            while (phs >= 2.0 * PI) phs -= 2.0 * PI;
-            while (phs < 0.0) phs += 2.0 * PI;
+            while (phs >= 2.0 * PI) phs -= (2.0 * PI);
+            while (phs < 0.0) phs += (2.0 * PI);
         }
 
 }
+
+
+/*
+if (a->levelfade)
+{
+    a->dc = a->mtauR * a->dc + a->onem_mtauR * audio;
+    a->dc_insert = a->mtauI * a->dc_insert + a->onem_mtauI * corr[0];
+    audio += a->dc_insert - a->dc;
+}
+a->out_buff[2 * i + 0] = audio;
+a->out_buff[2 * i + 1] = audio;
+
+if ((corr[0] == 0.0) && (corr[1] == 0.0)) corr[0] = 1.0;
+det = atan2(corr[1], corr[0]);
+del_out = a->fil_out;
+a->omega += a->g2 * det;
+if (a->omega < a->omega_min) a->omega = a->omega_min;
+if (a->omega > a->omega_max) a->omega = a->omega_max;
+a->fil_out = a->g1 * det + a->omega;
+a->phs += del_out;
+while (a->phs >= TWOPI) a->phs -= TWOPI;
+while (a->phs < 0.0) a->phs += TWOPI;
+*/
+
+
+
+
+
 
 
 //
@@ -2863,9 +2891,11 @@ static void AudioDriver_RxProcessor(AudioSample_t * const src, AudioSample_t * c
         // which case there is ***NO*** audio phase shift applied to the I/Q channels.
         //
         //
+        if(ts.dmod_mode != DEMOD_SAM)
+        {
         arm_fir_f32(&FIR_I,adb.i_buffer, adb.i_buffer,blockSize);   // in AM: lowpass filter, in other modes: Hilbert lowpass 0 degrees
         arm_fir_f32(&FIR_Q,adb.q_buffer, adb.q_buffer,blockSize);   // in AM: lowpass filter, in other modes: Hilbert lowpass -90 degrees
-
+        }
 
         switch(dmod_mode)
         {
@@ -2922,7 +2952,7 @@ static void AudioDriver_RxProcessor(AudioSample_t * const src, AudioSample_t * c
             break;
         }
 
-        if(dmod_mode != DEMOD_FM && dmod_mode != DEMOD_SAM)       // are we NOT in FM mode?  If we are not, do decimation, filtering, DSP notch/noise reduction, etc.
+        if(dmod_mode != DEMOD_FM)       // are we NOT in FM mode?  If we are not, do decimation, filtering, DSP notch/noise reduction, etc.
         {
             // Do decimation down to lower rate to reduce processor load
             if (DECIMATE_RX.numTaps > 0)

--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -538,8 +538,8 @@ void AudioDriver_Init(void)
     // DX = 0.2, 70
     // medium 0.6, 200
     // fast 1.0, 500
-    ads.zeta = 0.4; // 0.01;// 0.001; // 0.1; //0.65; // PLL step response: smaller, slower response 1.0 - 0.1
-    ads.omegaN = 200.0; //200.0; // PLL bandwidth 50.0 - 1000.0
+    ads.zeta = 0.8; // 0.01;// 0.001; // 0.1; //0.65; // PLL step response: smaller, slower response 1.0 - 0.1
+    ads.omegaN = 250.0; //200.0; // PLL bandwidth 50.0 - 1000.0
 
       //pll
     ads.omega_min = (2.0 * PI * ads.pll_fmin * ads.DF / IQ_SAMPLE_RATE_F); //-0.5235987756; //
@@ -2891,11 +2891,10 @@ static void AudioDriver_RxProcessor(AudioSample_t * const src, AudioSample_t * c
         // which case there is ***NO*** audio phase shift applied to the I/Q channels.
         //
         //
-        if(ts.dmod_mode != DEMOD_SAM)
-        {
+
         arm_fir_f32(&FIR_I,adb.i_buffer, adb.i_buffer,blockSize);   // in AM: lowpass filter, in other modes: Hilbert lowpass 0 degrees
         arm_fir_f32(&FIR_Q,adb.q_buffer, adb.q_buffer,blockSize);   // in AM: lowpass filter, in other modes: Hilbert lowpass -90 degrees
-        }
+
 
         switch(dmod_mode)
         {

--- a/mchf-eclipse/drivers/audio/audio_driver.h
+++ b/mchf-eclipse/drivers/audio/audio_driver.h
@@ -151,6 +151,36 @@ typedef struct AudioDriverState
     //
     SoftDds					beep;				// this is the actively-used DDS tone word for the radio's beep generator
     float					beep_loudness_factor;	// this is used to set the beep loudness
+
+    float32_t DF;
+    float32_t pll_fmin;
+    float32_t pll_fmax;
+    // DX adjustments: zeta = 0.15, omegaN = 100.0
+    // very stable, but does not lock very fast
+    // standard settings: zeta = 1.0, omegaN = 250.0
+    // maybe user can choose between slow (DX), medium, fast SAM PLL
+    // zeta / omegaN
+    // DX = 0.2, 70
+    // medium 0.6, 200
+    // fast 1.2, 500
+    float32_t zeta; // 0.01;// 0.001; // 0.1; //0.65; // PLL step response: smaller, slower response 1.0 - 0.1
+    float32_t omegaN; //200.0; // PLL bandwidth 50.0 - 1000.0
+
+      //pll
+    //const float32_t omega_min = 2.0 * 3.141592653589793f * pll_fmin * DF / IQ_SAMPLE_RATE_F;
+    float32_t  omega_min; // (2.0 * 3.141592653589793f * pll_fmin * DF / IQ_SAMPLE_RATE_F);
+    float32_t  omega_max; //(2.0 * 3.141592653589793f * pll_fmax * DF / IQ_SAMPLE_RATE_F);
+    float32_t  g1; //(1.0 - exp(-2.0 * omegaN * zeta * DF / IQ_SAMPLE_RATE_F));
+    float32_t  g2; //(- g1 + 2.0 * (1 - exp(- omegaN * zeta * DF / IQ_SAMPLE_RATE_F)
+        //  * cosf(omegaN * DF / IQ_SAMPLE_RATE_F * sqrtf(1.0 - zeta * zeta))));
+
+      //fade leveler
+    float32_t tauR; // original 0.02;
+    float32_t tauI; // original 1.4;
+    float32_t  mtauR; //(exp(- DF / (IQ_SAMPLE_RATE_F * tauR))); //0.99948;
+    float32_t onem_mtauR;
+    float32_t  mtauI; //(exp(- DF / (IQ_SAMPLE_RATE_F * tauI))); //0.99999255955;
+    float32_t  onem_mtauI;
     //
     // The following are pre-calculated terms for the Goertzel functions used for subaudible tone detection
 

--- a/mchf-eclipse/drivers/audio/audio_filter.c
+++ b/mchf-eclipse/drivers/audio/audio_filter.c
@@ -591,13 +591,13 @@ const FilterPathDescriptor FilterPathInfo[AUDIO_FILTER_PATH_NUM] =
     },
 
     {
-        AUDIO_2P1KHZ, "AM", FILTER_MASK_AM, 1, Q_NUM_TAPS, iq_rx_am_3k6_coeffs, iq_rx_am_2k3_coeffs, &FirRxDecimate,
+        AUDIO_2P1KHZ, "AM", FILTER_MASK_AM, 1, Q_NUM_TAPS, iq_rx_am_3k6_coeffs, iq_rx_am_3k6_coeffs, &FirRxDecimate,
         RX_DECIMATION_RATE_12KHZ, &IIR_3k6_LPF,
         &FirRxInterpolate_4_5k, &IIR_aa_5k
     },
 
     {
-        AUDIO_2P3KHZ, "AM", FILTER_MASK_AM, 1, Q_NUM_TAPS, iq_rx_am_3k6_coeffs, iq_rx_am_2k3_coeffs, &FirRxDecimate,
+        AUDIO_2P3KHZ, "AM", FILTER_MASK_AM, 1, Q_NUM_TAPS, iq_rx_am_3k6_coeffs, iq_rx_am_3k6_coeffs, &FirRxDecimate,
         RX_DECIMATION_RATE_12KHZ, &IIR_4k2_LPF,
         &FirRxInterpolate_4_5k, &IIR_aa_5k
     },
@@ -713,25 +713,33 @@ const FilterPathDescriptor FilterPathInfo[AUDIO_FILTER_PATH_NUM] =
 
 
     {
-        AUDIO_1P8KHZ, "SAM", FILTER_MASK_SAM, 1, I_NUM_TAPS, i_rx_3k6_coeffs, q_rx_3k6_coeffs, &FirRxDecimate,
+        AUDIO_1P8KHZ, "SAM", FILTER_MASK_SAM, 1, I_NUM_TAPS, iq_rx_am_3k6_coeffs, iq_rx_am_3k6_coeffs, &FirRxDecimate,
         RX_DECIMATION_RATE_12KHZ, &IIR_1k8_LPF,
         &FirRxInterpolate, NULL
     },
 
     {
-        AUDIO_2P3KHZ, "SAM", FILTER_MASK_SAM, 1, I_NUM_TAPS, i_rx_3k6_coeffs, q_rx_3k6_coeffs, &FirRxDecimate,
+        AUDIO_2P3KHZ, "SAM", FILTER_MASK_SAM, 1, I_NUM_TAPS, iq_rx_am_3k6_coeffs, iq_rx_am_3k6_coeffs, &FirRxDecimate,
         RX_DECIMATION_RATE_12KHZ, &IIR_2k3_LPF,
         &FirRxInterpolate, NULL
     },
 
+    /*
+             AUDIO_2P5KHZ, "AM", FILTER_MASK_AM, 1, Q_NUM_TAPS, iq_rx_am_3k6_coeffs, iq_rx_am_3k6_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_4k6_LPF,
+        &FirRxInterpolate_4_5k, &IIR_aa_5k
+
+     */
+
+
     {
-        AUDIO_2P9KHZ, "SAM", FILTER_MASK_SAM, 1, I_NUM_TAPS, i_rx_3k6_coeffs, q_rx_3k6_coeffs, &FirRxDecimate,
+        AUDIO_2P9KHZ, "SAM", FILTER_MASK_SAM, 1, I_NUM_TAPS, iq_rx_am_3k6_coeffs, iq_rx_am_3k6_coeffs, &FirRxDecimate,
         RX_DECIMATION_RATE_12KHZ, &IIR_2k9_LPF,
         &FirRxInterpolate, NULL
     },
 
     {
-        AUDIO_3P4KHZ, "SAM", FILTER_MASK_SAM, 1, I_NUM_TAPS, i_rx_3k6_coeffs, q_rx_3k6_coeffs, &FirRxDecimate,
+        AUDIO_3P4KHZ, "SAM", FILTER_MASK_SAM, 1, I_NUM_TAPS, iq_rx_am_3k6_coeffs, iq_rx_am_3k6_coeffs, &FirRxDecimate,
         RX_DECIMATION_RATE_12KHZ, &IIR_3k4_LPF,
         &FirRxInterpolate, NULL
     },
@@ -740,19 +748,19 @@ const FilterPathDescriptor FilterPathInfo[AUDIO_FILTER_PATH_NUM] =
 	// now I have implemented the IIR_aa_5k antialiasing filter in SAM 4k2 and 4k8 filters and all the aliases
 	// are down by at least 60dB below signal level
     {
-        AUDIO_4P2KHZ, "SAM", FILTER_MASK_SAM, 1, I_NUM_TAPS, i_rx_4k5_coeffs, q_rx_4k5_coeffs, &FirRxDecimate,
+        AUDIO_4P2KHZ, "SAM", FILTER_MASK_SAM, 1, I_NUM_TAPS, iq_rx_am_4k5_coeffs, iq_rx_am_4k5_coeffs, &FirRxDecimate,
         RX_DECIMATION_RATE_12KHZ, &IIR_4k2_LPF,
         &FirRxInterpolate_4_5k, &IIR_aa_5k
     },
 
     {
-        AUDIO_4P8KHZ, "SAM", FILTER_MASK_SAM, 1, I_NUM_TAPS, i_rx_5k_coeffs, q_rx_5k_coeffs, &FirRxDecimate,
+        AUDIO_4P8KHZ, "SAM", FILTER_MASK_SAM, 1, I_NUM_TAPS, iq_rx_am_5k_coeffs, iq_rx_am_5k_coeffs, &FirRxDecimate,
         RX_DECIMATION_RATE_12KHZ, &IIR_4k8_LPF,
         &FirRxInterpolate_4_5k, &IIR_aa_5k
     },
 
     {
-        AUDIO_7P5KHZ, "SAM", FILTER_MASK_SAM, 1, I_NUM_TAPS, i_rx_7k5_coeffs, q_rx_7k5_coeffs, &FirRxDecimateMinLPF,
+        AUDIO_7P5KHZ, "SAM", FILTER_MASK_SAM, 1, I_NUM_TAPS, iq_rx_am_7k5_coeffs, iq_rx_am_7k5_coeffs, &FirRxDecimateMinLPF,
         RX_DECIMATION_RATE_24KHZ, NULL,
         &FirRxInterpolate10KHZ, NULL
     }


### PR DESCRIPTION
Try demod_mode SAM: it is now implemented as a real synchronous AM demodulator.
It detects the phase difference between the LO frequency and the carrier frequency and uses a 2nd order PLL and an NCO to lock exactly onto the carrier of an AM station. The locking process is determined by some constant variables, those have to be tweaked in the next days and will probably be made user-definable.
Can you hear the heterodyne sound before the locking? That is absolutely normal in SAM mode and shows that the PLL is doing a good job.
The implementation made use of the open source wdsp lib by Warren Pratt. Thanks, Warren!
