### PR TITLE
Switched off SNAP and added Inverse Meter on same position

### DIFF
--- a/mchf-eclipse/drivers/ui/menu/ui_menu_structure.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu_structure.c
@@ -176,7 +176,7 @@ const MenuDescriptor confGroup[] =
     { MENU_CONF, MENU_ITEM, CONFIG_VOLTMETER_CALIBRATION,"208","Voltmeter Cal.", UiMenuDesc("Adjusts the displayed value of the voltmeter.") },
     { MENU_CONF, MENU_ITEM, CONFIG_FREQUENCY_CALIBRATE,"230","Freq. Calibrate", UiMenuDesc("Adjust the frequency correction of the local oscillator. Select 1Hz step size and measure TX frequency and adjust until both match. Or receive a know reference signal and zero-beat it and then adjust. More information in the Wiki.") },
     { MENU_CONF, MENU_ITEM, CONFIG_RF_FWD_PWR_NULL,"271","Pwr. Det. Null", UiMenuDesc(":soon:") },
-    { MENU_CONF, MENU_ITEM, CONFIG_FWD_REV_SENSE_SWAP,"276","FWD/REV ADC Swap.", UiMenuDesc(":soon:") },
+    { MENU_CONF, MENU_ITEM, CONFIG_FWD_REV_SENSE_SWAP,"276","SWR/PWR Meter FWD/REV Swap", UiMenuDesc("Exchange the assignment of the Power/SWR FWD and REV measurement ADC. Use if your power meter does not show anything during TX.") },
     { MENU_CONF, MENU_ITEM, CONFIG_80M_RX_IQ_GAIN_BAL,"240", "RX IQ Balance (80m)", UiMenuDesc("IQ Balance Adjust for all receive if frequency translation is NOT OFF. Requires USB/LSB/CW mode to be changeable.See Wiki Adjustments and Calibration.") },
     { MENU_CONF, MENU_ITEM, CONFIG_80M_RX_IQ_PHASE_BAL,"241","RX IQ Phase   (80m)", UiMenuDesc("IQ Phase Adjust for all receive if frequency translation is NOT OFF. Requires USB/LSB/CW mode to be changeable.See Wiki Adjustments and Calibration.") },
     { MENU_CONF, MENU_ITEM, CONFIG_10M_RX_IQ_GAIN_BAL,"242", "RX IQ Balance (10m)", UiMenuDesc("IQ Balance Adjust for all receive if frequency translation is NOT OFF. Requires USB/LSB/CW mode to be changeable.See Wiki Adjustments and Calibration.") },

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -369,11 +369,11 @@ inline uint32_t change_and_limit_uint(volatile uint32_t val, int32_t change, uin
 
 inline uint32_t change_and_wrap_uint(volatile uint32_t val, int32_t change, uint32_t min, uint32_t max)
 {
-    if (change  > (max - val))
+    if (change  > ((int32_t)max - (int32_t)val))
     {
         val = min;
     }
-    else if (change + (int32_t)val <  min)
+    else if ((change + (int32_t)val) <  (int32_t)min)
     {
         val = max;
     }
@@ -1054,6 +1054,22 @@ static void UiDriver_FButton_F1MenuExit()
 }
 
 
+static void UiDriver_FButton_F2SnapMeter()
+{
+    const char* cap;
+    uint32_t color;
+
+#ifdef SNAP
+        cap = "SNAP";
+        color = White;    // yes - indicate with color
+#else
+        color = White;
+        cap = "METER";
+#endif
+    UiDriver_FButtonLabel(2,cap,color);
+}
+
+
 
 static void UiDriver_FButton_F3MemSplit()
 {
@@ -1662,6 +1678,12 @@ static void UiDriver_ProcessFunctionKeyClick(ulong id)
         {
 #ifdef USE_SNAP
             sc.snap = 1;
+#else
+            // Not in MENU mode - select the METER mode
+            decr_wrap_uint8(&ts.tx_meter_mode,0,METER_MAX-1);
+
+            UiDriver_DeleteSMeter();
+            UiDriver_CreateMeters();    // redraw meter
 #endif
         }
     }
@@ -2098,12 +2120,7 @@ static void UiDriver_CreateFunctionButtons(bool full_repaint)
     UiDriver_FButton_F1MenuExit();
 
     // Button F2
-    #ifdef USE_SNAP
-        #define SNAP_COLOR White
-    #else
-        #define SNAP_COLOR Grey1
-    #endif
-    UiDriver_FButtonLabel(2,"SNAP",SNAP_COLOR);
+    UiDriver_FButton_F2SnapMeter();
 
     // Button F3
     UiDriver_FButton_F3MemSplit();

--- a/mchf-eclipse/hardware/mchf_board.h
+++ b/mchf-eclipse/hardware/mchf_board.h
@@ -17,12 +17,12 @@
 // some special switches
 //#define 	DEBUG_BUILD
 
-// #define USE_FREEDV //uncomment to use freedv instead of SNAP function
+#define USE_FREEDV //uncomment to use freedv instead of SNAP function
 // #define DEBUG_FREEDV
 // hardware specific switches
 //#define HY28BHISPEED			true		// uncomment for using new HY28B in SPI with bus speed 50MHz instead of 25MHz
 
-#define USE_FREEDV_AND_SNAP // experimental!!!
+// #define USE_FREEDV_AND_SNAP // experimental!!!
 
 #ifndef USE_FREEDV
   #define USE_SNAP


### PR DESCRIPTION
Short Press: Prev Meter
Long Press: Next Meter (as before)
Fixed small bug with decr_and_wrap

savings from no SNAP are mostly RAM:
WITH SNAP 429196	   5364	  94808	 529368	  813d8	mchf-eclipse.elf
WITHOUT   427724	   5364	  86576	 519664	  7edf0	mchf-eclipse.elf
            1472 FLASH      8232 RAM