### PR TITLE
Changed GPIO config to see if it changes I2C issues

### DIFF
--- a/mchf-eclipse/drivers/ui/menu/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu.c
@@ -3053,6 +3053,33 @@ void UiMenu_UpdateItem(uint16_t select, uint16_t mode, int pos, int var, char* o
         }
         break;
 
+    case MENU_DEBUG_I2C1_SPEED:      //
+        var_change = UiDriverMenuItemChangeUInt32(var, mode, &ts.i2c_speed[I2C_BUS_1],
+                1,
+                20,
+                I2C1_SPEED_DEFAULT,
+                1
+        );
+        if(var_change)
+        {
+            mchf_hw_i2c1_init();
+        }
+        snprintf(options, 32, " %3dkHz",(unsigned int)(ts.i2c_speed[I2C_BUS_1]*I2C_BUS_SPEED_MULT) / 1000 );
+        break;
+    case MENU_DEBUG_I2C2_SPEED:      //
+        var_change = UiDriverMenuItemChangeUInt32(var, mode, &ts.i2c_speed[I2C_BUS_2],
+                1,
+                20,
+                I2C2_SPEED_DEFAULT,
+                1
+        );
+        if(var_change)
+        {
+            mchf_hw_i2c2_init();
+        }
+        snprintf(options, 32, " %3ukHz",(unsigned int)(ts.i2c_speed[I2C_BUS_2]*I2C_BUS_SPEED_MULT) / 1000 );
+        break;
+
     default:                        // Move to this location if we get to the bottom of the table!
         txt_ptr = "ERROR!";
         break;

--- a/mchf-eclipse/drivers/ui/menu/ui_menu_internal.h
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu_internal.h
@@ -203,6 +203,8 @@ enum
 //    MENU_FP_SAM_03,
 //    MENU_FP_SAM_04,
     MENU_DEBUG_TX_AUDIO,
+    MENU_DEBUG_I2C1_SPEED,
+    MENU_DEBUG_I2C2_SPEED,
     //
     MAX_RADIO_CONFIG_ITEM   // Number of radio configuration menu items - This must ALWAYS remain as the LAST item!
 };

--- a/mchf-eclipse/drivers/ui/menu/ui_menu_structure.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu_structure.c
@@ -323,7 +323,9 @@ const MenuDescriptor infoGroup[] =
 
 const MenuDescriptor debugGroup[] =
 {
-    { MENU_DEBUG, MENU_ITEM, MENU_DEBUG_TX_AUDIO, NULL,"TX Audio via USB", UiMenuDesc(":soon:") },
+    { MENU_DEBUG, MENU_ITEM, MENU_DEBUG_TX_AUDIO, NULL,"TX Audio via USB", UiMenuDesc("If enabled, send generated audio to PC during TX.") },
+    { MENU_DEBUG, MENU_ITEM, MENU_DEBUG_I2C1_SPEED, NULL,"I2C1 Bus Speed", UiMenuDesc("Changes speed of the I2C1 bus (Si570 oscillator and MCP9801 temp sensor). Be careful with speeds above 200 kHz. Not stored permanently (yet), reboot will bring back default speeds.") },
+    { MENU_DEBUG, MENU_ITEM, MENU_DEBUG_I2C2_SPEED, NULL,"I2C2 Bus Speed", UiMenuDesc("Changes speed of the I2C2 bus (Audio Codec and I2C EEPROM). Be careful with speeds above 100 kHz. Not stored permanently (yet), reboot will bring back default speeds.") },
     { MENU_DEBUG, MENU_STOP, 0, NULL, NULL, UiMenuDesc("") }
 };
 

--- a/mchf-eclipse/hardware/mchf_hw_i2c.c
+++ b/mchf-eclipse/hardware/mchf_hw_i2c.c
@@ -218,9 +218,9 @@ void MchfHw_I2C_GpioInit(I2C_TypeDef* bus)
     GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
     GPIO_InitStructure.GPIO_OType = GPIO_OType_OD;
 
-    GPIO_InitStructure.GPIO_PuPd  = GPIO_PuPd_UP;       // - strong ringing on the bus
+    //GPIO_InitStructure.GPIO_PuPd  = GPIO_PuPd_UP;       // - strong ringing on the bus
     //GPIO_InitStructure.GPIO_PuPd  = GPIO_PuPd_DOWN;   // - makes it better
-    //GPIO_InitStructure.GPIO_PuPd  = GPIO_PuPd_NOPULL; // - same as pull down
+    GPIO_InitStructure.GPIO_PuPd  = GPIO_PuPd_NOPULL; // - same as pull down
 
 
     // Connect pins to I2C peripheral

--- a/mchf-eclipse/hardware/mchf_hw_i2c.c
+++ b/mchf-eclipse/hardware/mchf_hw_i2c.c
@@ -218,9 +218,9 @@ void MchfHw_I2C_GpioInit(I2C_TypeDef* bus)
     GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
     GPIO_InitStructure.GPIO_OType = GPIO_OType_OD;
 
-    //GPIO_InitStructure.GPIO_PuPd  = GPIO_PuPd_UP;       // - strong ringing on the bus
+    GPIO_InitStructure.GPIO_PuPd  = GPIO_PuPd_UP;       // - strong ringing on the bus
     //GPIO_InitStructure.GPIO_PuPd  = GPIO_PuPd_DOWN;   // - makes it better
-    GPIO_InitStructure.GPIO_PuPd  = GPIO_PuPd_NOPULL; // - same as pull down
+    //GPIO_InitStructure.GPIO_PuPd  = GPIO_PuPd_NOPULL; // - same as pull down
 
 
     // Connect pins to I2C peripheral


### PR DESCRIPTION
You can now play with your I2C bus speeds. You may change them to anything between 20 to 400 kHz.
Changes are NOT stored, so reboot brings back default values!