### PR TITLE
Improved I2C Si570 error recovery

### DIFF
--- a/mchf-eclipse/drivers/ui/oscillator/ui_si570.c
+++ b/mchf-eclipse/drivers/ui/oscillator/ui_si570.c
@@ -511,10 +511,10 @@ void Si570_CalculateStartupFrequency()
         uchar dummy;
 
         // test for hardware address of SI570
-        os.si570_address = (0x50 << 1);
+        os.si570_address = (0x55 << 1);
         if(mchf_hw_i2c1_ReadRegister(os.si570_address, (os.base_reg), &dummy) != 0)
         {
-            os.si570_address = (0x55 << 1);
+            os.si570_address = (0x50 << 1);
         }
 
         // make sure everything is cleared and in initial state

--- a/mchf-eclipse/drivers/ui/radio_management.c
+++ b/mchf-eclipse/drivers/ui/radio_management.c
@@ -319,13 +319,20 @@ bool RadioManagement_ChangeFrequency(bool force_update, uint32_t dial_freq,uint8
             }
             // Set frequency
             ts.last_lo_result = Si570_SetFrequency(ts.tune_freq_req,ts.freq_cal,df.temp_factor, 0);
-            df.temp_factor_changed = false;
             ts.last_tuning = ts.sysclock;
-            ts.tune_freq = ts.tune_freq_req;        // frequency change required - update change detector
-            // Save current freq
-            df.tune_old = dial_freq*TUNE_MULT;
+
+            // if i2c error or verify error, there is a chance that we can fix that, so we mark this
+            // as NOT executed, in all other cases we assume the change has happened (but may prevent TX)
+            if (ts.last_lo_result != SI570_I2C_ERROR && ts.last_lo_result != SI570_ERROR_VERIFY)
+            {
+                df.temp_factor_changed = false;
+                ts.tune_freq = ts.tune_freq_req;        // frequency change required - update change detector
+                // Save current freq
+                df.tune_old = dial_freq*TUNE_MULT;
+            }
             if (ts.last_lo_result == SI570_OK || ts.last_lo_result == SI570_TUNE_LIMITED)
             {
+
                 ts.tx_disable &= ~TX_DISABLE_OUTOFRANGE;
             }
             else

--- a/mchf-eclipse/hardware/mchf_hw_i2c.c
+++ b/mchf-eclipse/hardware/mchf_hw_i2c.c
@@ -286,20 +286,37 @@ void mchf_hw_i2c1_reset(void)
 
 uint16_t mchf_hw_i2c1_WriteRegister(uchar I2CAddr, uchar RegisterAddr, uchar RegisterValue)
 {
-    return MCHF_I2C_WriteRegister(I2C1, I2CAddr, &RegisterAddr, 1, RegisterValue);
+    uint16_t res = MCHF_I2C_WriteRegister(I2C1, I2CAddr, &RegisterAddr, 1, RegisterValue);
+#ifdef DEBUG_I2C1_ISSUES
+    while (res) { asm ("nop"); }
+#endif
+    return res;
 }
 
 uint16_t mchf_hw_i2c1_WriteBlock(uchar I2CAddr,uchar RegisterAddr, uchar *data, ulong size)
 {
-    return MCHF_I2C_WriteBlock(I2C1, I2CAddr,&RegisterAddr, 1, data, size);
+    uint16_t res = MCHF_I2C_WriteBlock(I2C1, I2CAddr,&RegisterAddr, 1, data, size);
+#ifdef DEBUG_I2C1_ISSUES
+    while (res) { asm ("nop"); }
+#endif
+    return res;
 }
 
 uint16_t mchf_hw_i2c1_ReadRegister(uchar I2CAddr,uchar RegisterAddr, uchar *RegisterValue)
 {
-    return MCHF_I2C_ReadRegister(I2C1, I2CAddr,&RegisterAddr, 1, RegisterValue);
+    uint16_t res = MCHF_I2C_ReadRegister(I2C1, I2CAddr,&RegisterAddr, 1, RegisterValue);
+#ifdef DEBUG_I2C1_ISSUES
+    while (res) { asm ("nop"); }
+#endif
+    return res;
+
 }
 
 uint16_t mchf_hw_i2c1_ReadData(uchar I2CAddr,uchar RegisterAddr, uchar *data, ulong size)
 {
-    return MCHF_I2C_ReadBlock(I2C1, I2CAddr, &RegisterAddr, 1, data, size);
+    uint16_t res =  MCHF_I2C_ReadBlock(I2C1, I2CAddr, &RegisterAddr, 1, data, size);
+#ifdef DEBUG_I2C1_ISSUES
+    while (res) { asm ("nop"); }
+#endif
+    return res;
 }


### PR DESCRIPTION
If even an I2C error is reported, the tuning will be retried later.
Other errors remain handled as before. In my case I could easily get
the red digits when running the I2C with 400kHz. The red digits were
briefly visible and then disappeard.
Often there was a click audible in this case.