### PR TITLE
Made I2C speed configuration permanent and slight change in I2C dutycyle

### DIFF
--- a/mchf-eclipse/drivers/ui/menu/ui_menu_structure.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu_structure.c
@@ -324,8 +324,8 @@ const MenuDescriptor infoGroup[] =
 const MenuDescriptor debugGroup[] =
 {
     { MENU_DEBUG, MENU_ITEM, MENU_DEBUG_TX_AUDIO, NULL,"TX Audio via USB", UiMenuDesc("If enabled, send generated audio to PC during TX.") },
-    { MENU_DEBUG, MENU_ITEM, MENU_DEBUG_I2C1_SPEED, NULL,"I2C1 Bus Speed", UiMenuDesc("Changes speed of the I2C1 bus (Si570 oscillator and MCP9801 temp sensor). Be careful with speeds above 200 kHz. Not stored permanently (yet), reboot will bring back default speeds.") },
-    { MENU_DEBUG, MENU_ITEM, MENU_DEBUG_I2C2_SPEED, NULL,"I2C2 Bus Speed", UiMenuDesc("Changes speed of the I2C2 bus (Audio Codec and I2C EEPROM). Be careful with speeds above 100 kHz. Not stored permanently (yet), reboot will bring back default speeds.") },
+    { MENU_DEBUG, MENU_ITEM, MENU_DEBUG_I2C1_SPEED, NULL,"I2C1 Bus Speed", UiMenuDesc("Sets speed of the I2C1 bus (Si570 oscillator and MCP9801 temp sensor). Higher speeds provide quicker RX/TX switching but may also cause tuning issues (red digits). Be careful with speeds above 200 kHz. Stored permanently. Will be moved to Configuration menu in future.") },
+    { MENU_DEBUG, MENU_ITEM, MENU_DEBUG_I2C2_SPEED, NULL,"I2C2 Bus Speed", UiMenuDesc("Sets operation speed of the I2C2 bus (Audio Codec and I2C EEPROM). Higher speeds provide quicker RX/TX switching, configuration save and power off. Many mcHF seem to run with 400kHz without problems. Be careful with speeds above 100 kHz. Stored permanently. Will be moved to Configuration menu in future.") },
     { MENU_DEBUG, MENU_STOP, 0, NULL, NULL, UiMenuDesc("") }
 };
 

--- a/mchf-eclipse/drivers/ui/ui_configuration.c
+++ b/mchf-eclipse/drivers/ui/ui_configuration.c
@@ -162,6 +162,8 @@ const ConfigEntryDescriptor ConfigEntryInfo[] =
     { ConfigEntry_Int32_16, EEPROM_SAM_PLL_LOCKING_RANGE,&ads.pll_fmax_int,2500,50,8000},
     { ConfigEntry_Int32_16, EEPROM_SAM_PLL_STEP_RESPONSE,&ads.zeta_int,65,1,100},
     { ConfigEntry_Int32_16, EEPROM_SAM_PLL_BANDWIDTH,&ads.omegaN_int, 250,15,1000},
+    { ConfigEntry_Int32_16, EEPROM_I2C1_SPEED,&ts.i2c_speed[0], I2C1_SPEED_DEFAULT,1,20},
+    { ConfigEntry_Int32_16, EEPROM_I2C2_SPEED,&ts.i2c_speed[1], I2C2_SPEED_DEFAULT,1,20},
 
 	UI_C_EEPROM_BAND_5W_PF( 0,80,m)
     UI_C_EEPROM_BAND_5W_PF(1,60,m)

--- a/mchf-eclipse/drivers/ui/ui_configuration.h
+++ b/mchf-eclipse/drivers/ui/ui_configuration.h
@@ -522,7 +522,9 @@ uint16_t    UiConfiguration_SaveEepromValues(void);
 #define EEPROM_SAM_PLL_LOCKING_RANGE        366     //
 #define EEPROM_SAM_PLL_STEP_RESPONSE        367     //
 #define EEPROM_SAM_PLL_BANDWIDTH            368     //
-#define EEPROM_FIRST_UNUSED 				369		// change this if new value ids are introduced
+#define EEPROM_I2C1_SPEED                   369     //
+#define EEPROM_I2C2_SPEED                   370     //
+#define EEPROM_FIRST_UNUSED 				371		// change this if new value ids are introduced
 
 #define MAX_VAR_ADDR (EEPROM_FIRST_UNUSED - 1)
 

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -1972,7 +1972,7 @@ static void UiDriver_DisplayMemoryLabel()
     {
         char txt[12];
         uint32_t col = White;
-        snprintf(txt,12,"Bnd%s", bandInfo[ts.band].name);
+        snprintf(txt,12,"Bnd%s ", bandInfo[ts.band].name);
         UiLcdHy28_PrintText(161+(SMALL_FONT_WIDTH * 11)+4,  64,txt,col,Black,0);
     }
  }

--- a/mchf-eclipse/hardware/mchf_hw_i2c.c
+++ b/mchf-eclipse/hardware/mchf_hw_i2c.c
@@ -185,7 +185,7 @@ void MchfHw_I2C_Init(I2C_TypeDef* bus)
     // CODEC_I2C peripheral configuration
     I2C_DeInit(bus);
     I2C_InitStructure.I2C_Mode                  = I2C_Mode_I2C;
-    I2C_InitStructure.I2C_DutyCycle             = I2C_DutyCycle_2;
+    I2C_InitStructure.I2C_DutyCycle             = I2C_DutyCycle_16_9;
     I2C_InitStructure.I2C_OwnAddress1           = 0x33;
     I2C_InitStructure.I2C_Ack                   = I2C_Ack_Enable;
     I2C_InitStructure.I2C_AcknowledgedAddress   = I2C_AcknowledgedAddress_7bit;

--- a/mchf-eclipse/main.c
+++ b/mchf-eclipse/main.c
@@ -547,6 +547,10 @@ int main(void)
     // UI HW init
     UiDriver_Init();
 
+    // we now reinit the I2C buses with the configured speed settings. Loading the EEPROM always uses the default speed!
+    mchf_hw_i2c1_init();
+    mchf_hw_i2c2_init();
+
     ts.temp_nb = ts.nb_setting;
     ts.nb_setting = 0;
 


### PR DESCRIPTION
- We store (and use the stored) I2C speed (AFTER reading the EEPROM with default speed).
- The dutycycle was changed to 16:6 to slightly improve the wave form.
- Fixed small issue in Band Memory Name Display.
Please test. Should not make the situation worse.