### PR TITLE
new SAM/AM filters reflecting SAM capabilities

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_filter.c
+++ b/mchf-eclipse/drivers/audio/audio_filter.c
@@ -563,7 +563,7 @@ const FilterPathDescriptor FilterPathInfo[AUDIO_FILTER_PATH_NUM] =
         &FirRxInterpolate_4_10k, &IIR_aa_10k
     },
 
-/*    //###################################################################################################################################
+    //###################################################################################################################################
     // These are the "new" AM/SAM filters, January 2017
     // designed for an IIR lowpass stopband frequency that is exactly the same as the filter bandwidth
     // In sideband-selected SAM, there is no FIR filter, so the IIR has to do all the work
@@ -696,8 +696,8 @@ const FilterPathDescriptor FilterPathInfo[AUDIO_FILTER_PATH_NUM] =
         &FirRxInterpolate_4_10k, &IIR_aa_10k
     },
 
-*/
 
+/*
 //###################################################################################################################################
 // AM filters: designed for an IIR lowpass stopband frequency that is approx. 1.8 times higher than the FIR bandwidth
 //  --> an AM 2.5kHz filter has 2.5kHz of audio when centre tuned, but can have up to 1.8 * 2.5kHz = 4.6kHz of bandwidth (IIR filter!)
@@ -840,7 +840,7 @@ const FilterPathDescriptor FilterPathInfo[AUDIO_FILTER_PATH_NUM] =
     },
 
 
-
+*/
 
 
 


### PR DESCRIPTION
Complete rebuild of all SAM/AM filters.
All filters now have an IIR filter reflecting the exact filter bandwidth.
Advantage: (much) better selectivity with SAM/AM
Disadvantage: audio response cannot be adjusted any more by simple offtuning in AM/SAM