### PR TITLE
Improved Power Level Control

### DIFF
--- a/mchf-eclipse/drivers/ui/menu/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu.c
@@ -560,8 +560,8 @@ bool __attribute__ ((noinline)) UiDriverMenuBandPowerAdjust(int var, uint8_t mod
     {
         tchange = UiDriverMenuItemChangeUInt8(var, mode, adj_ptr,
                                               TX_POWER_FACTOR_MIN,
-                                              TX_POWER_FACTOR_MAX,
-                                              bandInfo[band_mode].default_pf,
+                                              RadioManagement_IsPowerFactorReduce(df.tune_old/TUNE_MULT)?TX_POWER_FACTOR_MAX:TX_POWER_FACTOR_MAX/4,
+                                              TX_POWER_FACTOR_MIN,
                                               1
                                              );
 
@@ -569,7 +569,9 @@ bool __attribute__ ((noinline)) UiDriverMenuBandPowerAdjust(int var, uint8_t mod
         {
             RadioManagement_SetBandPowerFactor(ts.band);	// yes, update the power factor
             if(!ts.iq_freq_mode)	// Is translate mode *NOT* active?
+            {
                 Codec_TxSidetoneSetgain(ts.txrx_mode);				// adjust the sidetone gain
+            }
         }
     }
     else	// not enabled

--- a/mchf-eclipse/drivers/ui/radio_management.h
+++ b/mchf-eclipse/drivers/ui/radio_management.h
@@ -222,6 +222,7 @@ void RadioManagement_HandleRxIQSignalCodecGain();
 const cw_mode_map_entry_t* RadioManagement_CWConfigValueToModeEntry(uint8_t cw_offset_mode);
 uint8_t RadioManagement_CWModeEntryToConfigValue(const cw_mode_map_entry_t* mode_entry);
 bool RadioManagement_UsesBothSidebands(uint16_t dmod_mode);
+bool RadioManagement_IsPowerFactorReduce(uint32_t freq);
 
 
 #endif /* DRIVERS_UI_RADIO_MANAGEMENT_H_ */


### PR DESCRIPTION
- fix for previous commit (did not really control the max power level)
- added "dynamic" power adjust factor upper limit (depending on adjust value resolution)
- set all power defaults to min level instead of "special" values per band since these were not really useful anyway