### PR TITLE
CW via DTR: Fix for previous pull request. Now working as expected.

### DIFF
--- a/mchf-eclipse/.settings/language.settings.xml
+++ b/mchf-eclipse/.settings/language.settings.xml
@@ -5,7 +5,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-282098389430923101" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings Cross ARM" parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-775998172667040546" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings Cross ARM" parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>
@@ -16,7 +16,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-301712678824465435" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings Cross ARM" parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-795612462060582880" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings Cross ARM" parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>
@@ -27,7 +27,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-282098389430923101" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings Cross ARM" parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-775998172667040546" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings Cross ARM" parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>

--- a/mchf-eclipse/drivers/cat/cat_driver.h
+++ b/mchf-eclipse/drivers/cat/cat_driver.h
@@ -29,17 +29,15 @@ typedef enum
 
 
 // Exports
-void cat_driver_init(void);
-void cat_driver_stop(void);
-void cat_driver_thread(void);
+void CatDriver_InitInterface(void);
+void CatDriver_StopInterface(void);
 
-CatInterfaceState cat_driver_state();
-uint8_t cat_driver_get_data(uint8_t* Buf,uint32_t Len);
-uint8_t cat_driver_put_data(uint8_t* Buf,uint32_t Len);
-uint8_t cat_driver_has_data();
-int cat_buffer_add(uint8_t c);
+CatInterfaceState CatDriver_GetInterfaceState();
 
-void CatDriver_FT817CheckAndExecute();
+int CatDriver_InterfaceBufferAddData(uint8_t c);
+
+void CatDriver_HandleProtocol();
+
 bool CatDriver_CloneOutStart();
 bool CatDriver_CloneInStart();
 

--- a/mchf-eclipse/drivers/cat/usb/usbd_cdc_vcp.c
+++ b/mchf-eclipse/drivers/cat/usb/usbd_cdc_vcp.c
@@ -169,12 +169,15 @@ static uint16_t VCP_Ctrl (uint32_t Cmd, uint8_t* Buf, uint32_t Len)
         break;
 
     case SET_CONTROL_LINE_STATE:
-        // byte 3 aka buf[2] has DTR (Bit0) and RTS (Bit1).
+    {
+        // we get wValue here as buffer
+        uint16_t wValue = *(uint16_t*)&(Buf[0]);
+        cdcvcp_ctrllines.dtr = (wValue & 0x01)?1:0;
+        cdcvcp_ctrllines.rts = (wValue & 0x02)?1:0;
 
-        //printf("Set control line state\n");
         /* Not  needed for this driver */
         break;
-
+    }
     case SEND_BREAK:
         /* Not  needed for this driver */
         break;

--- a/mchf-eclipse/drivers/cat/usb/usbd_cdc_vcp.c
+++ b/mchf-eclipse/drivers/cat/usb/usbd_cdc_vcp.c
@@ -240,7 +240,7 @@ uint16_t VCP_DataRx (uint8_t* Buf, uint32_t Len)
 
     for (i = 0; i < Len; i++)
     {
-        cat_buffer_add(Buf[i]);
+        CatDriver_InterfaceBufferAddData(Buf[i]);
     }
     return USBD_OK;
 }

--- a/mchf-eclipse/drivers/ui/menu/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu.c
@@ -2264,11 +2264,11 @@ void UiMenu_UpdateItem(uint16_t select, uint16_t mode, int pos, int var, char* o
         {
             if(ts.flags1 & FLAGS1_CAT_MODE_ACTIVE)
             {
-                cat_driver_init();
+                CatDriver_InitInterface();
             }
             else
             {
-                cat_driver_stop();
+                CatDriver_StopInterface();
             }
         }
         break;

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -5926,7 +5926,7 @@ void UiDriver_MainHandler()
 
     uint32_t now = ts.sysclock;
 
-    CatDriver_FT817CheckAndExecute();
+    CatDriver_HandleProtocol();
 
     // START CALLED AS OFTEN AS POSSIBLE
 #ifdef USE_FREEDV

--- a/mchf-eclipse/main.c
+++ b/mchf-eclipse/main.c
@@ -577,7 +577,7 @@ int main(void)
 
     if (ts.flags1 & FLAGS1_CAT_MODE_ACTIVE)
     {
-        cat_driver_init();
+        CatDriver_InitInterface();
     }
 
 #ifdef USE_FREEDV

--- a/mchf-eclipse/usb/usbd/class/cdc/src/usbd_cdc_core.c
+++ b/mchf-eclipse/usb/usbd/class/cdc/src/usbd_cdc_core.c
@@ -542,7 +542,7 @@ static uint8_t  usbd_cdc_Setup (void  *pdev,
         else /* No Data request */
         {
             /* Transfer the command to the interface layer */
-            APP_FOPS.pIf_Ctrl(req->bRequest, NULL, 0);
+            APP_FOPS.pIf_Ctrl(req->bRequest, (uint8_t*)&req->wValue, 0);
         }
 
         return USBD_OK;


### PR DESCRIPTION
If in CW Mode, doing PTT via FT817 CAT (!!!) will allow to
key the transmitter using the (virtual) DTR of the CAT serial port.
This has been tested with UCXLOG and MAY work with other programs.

See also #773 for a little bit of discussion