### PR TITLE
Changed frequency calibration to PPM based corrections

### DIFF
--- a/mchf-eclipse/drivers/ui/menu/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu.c
@@ -23,6 +23,8 @@
 #include "serial_eeprom.h"
 
 #include <stdio.h>
+#include <stdlib.h>
+
 #include "arm_math.h"
 #include "math.h"
 #include "codec.h"
@@ -2276,19 +2278,23 @@ void UiMenu_UpdateItem(uint16_t select, uint16_t mode, int pos, int var, char* o
         if(var >= 1)        // setting increase?
         {
             ts.menu_var_changed = 1;    // indicate that a change has occurred
-            ts.freq_cal += 1;
+            ts.freq_cal += 1; // df.tuning_step;
             var_change = 1;
         }
         else if(var <= -1)      // setting decrease?
         {
             ts.menu_var_changed = 1;    // indicate that a change has occurred
-            ts.freq_cal -= 1;
+            ts.freq_cal -= 1 ; // df.tuning_step;
             var_change = 1;
         }
         if(ts.freq_cal < MIN_FREQ_CAL)
+        {
             ts.freq_cal = MIN_FREQ_CAL;
+        }
         else if(ts.freq_cal > MAX_FREQ_CAL)
+        {
             ts.freq_cal = MAX_FREQ_CAL;
+        }
         //
         if(mode == MENU_PROCESS_VALUE_SETDEFAULT)
         {
@@ -2298,9 +2304,11 @@ void UiMenu_UpdateItem(uint16_t select, uint16_t mode, int pos, int var, char* o
         }
         if(var_change)
         {
-            UiDriver_UpdateFrequency(true,UFM_AUTOMATIC);   // Update LO frequency without checking encoder but overriding "frequency didn't change" detect
+            Si570_SetPPM(((float32_t)ts.freq_cal)/10.0);
+            RadioManagement_ChangeFrequency(true, df.tune_new/TUNE_MULT,ts.txrx_mode);
+            // Update LO frequency by overriding "frequency didn't change" detect
         }
-        snprintf(options,32, "   %d", ts.freq_cal);
+        snprintf(options,32, "%4d.%d ppm", ts.freq_cal/10,abs(ts.freq_cal)%10 );
         break;
     //
     case CONFIG_FREQ_LIMIT_RELAX:   // Enable/disable Frequency tuning limits

--- a/mchf-eclipse/drivers/ui/menu/ui_menu_structure.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu_structure.c
@@ -179,7 +179,7 @@ const MenuDescriptor confGroup[] =
 
     { MENU_CONF, MENU_ITEM, MENU_REVERSE_TOUCHSCREEN, NULL, "Reverse Touchscreen", UiMenuDesc("Some touchscreens have the touch coordiantes reversed. In this case, select ON") },
     { MENU_CONF, MENU_ITEM, CONFIG_VOLTMETER_CALIBRATION, NULL, "Voltmeter Cal.", UiMenuDesc("Adjusts the displayed value of the voltmeter.") },
-    { MENU_CONF, MENU_ITEM, CONFIG_FREQUENCY_CALIBRATE, NULL, "Freq. Calibrate", UiMenuDesc("Adjust the frequency correction of the local oscillator. Step size is always 1Hz. Measure TX frequency. It must be displayed frequency +(USB) or -(LSB) sidetone frequency. Or receive a know reference signal and zero-beat it and then adjust. More information in the Wiki.") },
+    { MENU_CONF, MENU_ITEM, CONFIG_FREQUENCY_CALIBRATE, NULL, "Freq. Calibrate", UiMenuDesc("Adjust the frequency correction of the local oscillator. Measure TX frequency and adjust until both match. Or use receive a know reference signal and zero-beat it and then adjust. More information in the Wiki.") },
     { MENU_CONF, MENU_ITEM, CONFIG_FWD_REV_PWR_DISP, NULL, "Pwr. Display mW", UiMenuDesc("Shows the forward and reverse power values in mW, can be used to calibrate the SWR meter.") },
     { MENU_CONF, MENU_ITEM, CONFIG_RF_FWD_PWR_NULL, NULL, "Pwr. Det. Null", UiMenuDesc(" Set the forward and reverse power sensors ADC zero power offset. This setting is enabled ONLY when Disp. Pwr (mW), is enabled. Needs SWR meter hardware modification to work. See Wiki Adjustment and Calibration.") },
     { MENU_CONF, MENU_ITEM, CONFIG_FWD_REV_SENSE_SWAP, NULL, "SWR/PWR Meter FWD/REV Swap", UiMenuDesc("Exchange the assignment of the Power/SWR FWD and REV measurement ADC. Use if your power meter does not show anything during TX.") },

--- a/mchf-eclipse/drivers/ui/oscillator/ui_si570.h
+++ b/mchf-eclipse/drivers/ui/oscillator/ui_si570.h
@@ -34,13 +34,13 @@ typedef enum
 
 Si570_ResultCodes Si570_ChangeToNextFrequency();
 bool Si570_IsNextStepLarge();
-Si570_ResultCodes Si570_PrepareNextFrequency(ulong freq, int calib, int temp_factor);
-
+Si570_ResultCodes Si570_PrepareNextFrequency(ulong freq, int temp_factor);
+void Si570_SetPPM(float32_t ppm);
 
 
 
 uchar   Si570_ResetConfiguration();
-void 	Si570_CalculateStartupFrequency();
+void 	Si570_Init();
 float   Si570_GetStartupFrequency();
 uint8_t Si570_GetI2CAddress();
 

--- a/mchf-eclipse/drivers/ui/radio_management.c
+++ b/mchf-eclipse/drivers/ui/radio_management.c
@@ -302,7 +302,7 @@ bool RadioManagement_ChangeFrequency(bool force_update, uint32_t dial_freq,uint8
 
         if(ts.sysclock-ts.last_tuning > 5 || ts.last_tuning == 0)     // prevention for SI570 crash due too fast frequency changes
         {
-            Si570_ResultCodes lo_prep_result = Si570_PrepareNextFrequency(ts.tune_freq_req,ts.freq_cal,df.temp_factor);
+            Si570_ResultCodes lo_prep_result = Si570_PrepareNextFrequency(ts.tune_freq_req, df.temp_factor);
             // first check and mute output if a large step is to be done
             if(Si570_IsNextStepLarge() == true)     // did the tuning require that a large tuning step occur?
             {
@@ -386,7 +386,7 @@ void RadioManagement_MuteTemporarilyRxAudio()
 Si570_ResultCodes RadioManagement_ValidateFrequencyForTX(uint32_t dial_freq)
 {
     // we check with the si570 code if the frequency is tunable, we do not tune to it.
-    return Si570_PrepareNextFrequency(RadioManagement_Dial2TuneFrequency(dial_freq, TRX_MODE_TX),ts.freq_cal,df.temp_factor);
+    return Si570_PrepareNextFrequency(RadioManagement_Dial2TuneFrequency(dial_freq, TRX_MODE_TX), df.temp_factor);
 }
 
 

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -867,6 +867,7 @@ void UiDriver_Init()
     // Driver publics init
     UiDriver_PublicsInit();
 
+    Si570_SetPPM((float)ts.freq_cal/10.0);
     // Init frequency publics
     UiDriver_InitFrequency();
 

--- a/mchf-eclipse/hardware/mchf_board.c
+++ b/mchf-eclipse/hardware/mchf_board.c
@@ -684,7 +684,7 @@ void mchf_board_init(void)
     mchf_hw_i2c1_init();
 
     // Get startup frequency of Si570, by DF8OE, 201506
-    Si570_CalculateStartupFrequency();
+    Si570_Init();
 
     SoftTcxo_Init();
 

--- a/mchf-eclipse/hardware/mchf_board.h
+++ b/mchf-eclipse/hardware/mchf_board.h
@@ -519,8 +519,8 @@ extern const ButtonMap  bm_sets[2][BUTTON_NUM];
 #define		TRANSVT_FREQ_A	 	42000000
 
 //
-#define		MIN_FREQ_CAL		-9999		// Minimum and maximum range of frequency calibration in Hz (referenced to 14.000 MHz)
-#define		MAX_FREQ_CAL		9999
+#define		MIN_FREQ_CAL		-999		// Minimum and maximum range of frequency calibration in 10xppm
+#define		MAX_FREQ_CAL		999
 //
 // Total bands supported
 //


### PR DESCRIPTION
Switched to use float64_t for frequency inside ui_si570.c to improve precision
We now stored a ppm correction value which is applied to the base fxtal of the Si570