### PR TITLE
prototype: automatic IQ phase & amplitude correction for Rx

### DIFF
--- a/mchf-eclipse/.settings/language.settings.xml
+++ b/mchf-eclipse/.settings/language.settings.xml
@@ -5,7 +5,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-775998172667040546" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings Cross ARM" parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="920987696017410655" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings Cross ARM" parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>
@@ -16,7 +16,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-795612462060582880" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings Cross ARM" parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="862927053429369949" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings Cross ARM" parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>
@@ -27,7 +27,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-775998172667040546" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings Cross ARM" parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="920987696017410655" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings Cross ARM" parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>

--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -2910,6 +2910,20 @@ void set_SAM_PLL_parameters()
         adb.onem_mtauI = (1.0 - adb.mtauI);
 }
 
+float32_t teta1_old = 0.0;
+float32_t teta2_old = 0.0;
+float32_t teta3_old = 0.0;
+float32_t M_c1, M_c2;
+uint8_t IQ_auto_counter;
+
+float32_t sign_new(float32_t x) {
+  if(x < 0)
+    return -1.0;
+    else
+      if(x > 0)
+        return 1.0;
+          else return 0.0;
+}
 
 //
 //*----------------------------------------------------------------------------
@@ -3007,6 +3021,12 @@ static void AudioDriver_RxProcessor(AudioSample_t * const src, AudioSample_t * c
 
     AudioDriver_SpectrumNoZoomProcessSamples(blockSize);
 
+    // artificial amplitude imbalance for testing of the automatic IQ imbalance correction
+    arm_scale_f32 (adb.i_buffer, 1.6, adb.i_buffer, blockSize);
+
+
+    if(!ts.iq_auto_correction)
+    {
     // Apply I/Q amplitude correction
     arm_scale_f32(adb.i_buffer, ts.rx_adj_gain_var.i, adb.i_buffer, blockSize);
     arm_scale_f32(adb.q_buffer, ts.rx_adj_gain_var.q, adb.q_buffer, blockSize); // TODO: we need only scale one channel! DD4WH, Dec 2016
@@ -3014,6 +3034,48 @@ static void AudioDriver_RxProcessor(AudioSample_t * const src, AudioSample_t * c
 
     // Apply I/Q phase correction
     AudioDriver_IQPhaseAdjust(ts.txrx_mode,adb.i_buffer, adb.q_buffer,blockSize);
+    }
+    else
+    {
+        static float32_t teta1 = 0.0;
+        static float32_t teta2 = 0.0;
+        static float32_t teta3 = 0.0;
+        for(i = 0; i < blockSize; i++)
+        {
+            teta1 += sign_new(adb.i_buffer[i]) * adb.q_buffer[i]; // eq (34)
+            teta2 += sign_new(adb.i_buffer[i]) * adb.i_buffer[i]; // eq (35)
+            teta3 += sign_new(adb.q_buffer[i]) * adb.q_buffer[i]; // eq (36)
+//            teta1 += sign_new(adb.q_buffer[i]) * adb.i_buffer[i]; // eq (34)
+//            teta2 += sign_new(adb.q_buffer[i]) * adb.q_buffer[i]; // eq (35)
+//            teta3 += sign_new(adb.i_buffer[i]) * adb.i_buffer[i]; // eq (36)
+            IQ_auto_counter++;
+        }
+        if(IQ_auto_counter >= 3)
+        {
+            teta1 = -0.01 * (teta1 / (float32_t)blockSize / 4.0) + 0.99 * teta1_old; // eq (34) and first order lowpass
+            teta2 = 0.01 * (teta2 / (float32_t)blockSize / 4.0) + 0.99 * teta2_old; // eq (35) and first order lowpass
+            teta3 = 0.01 * (teta3 / (float32_t)blockSize / 4.0) + 0.99 * teta3_old; // eq (36) and first order lowpass
+            M_c1 = teta1 / teta2; // eq (30)
+            M_c2 = sqrtf((teta3 * teta3 - teta1 * teta1) / (teta2 * teta2)); // eq (31)
+            teta1_old = teta1;
+            teta2_old = teta2;
+            teta3_old = teta3;
+            teta1 = 0.0;
+            teta2 = 0.0;
+            teta3 = 0.0;
+            IQ_auto_counter = 0;
+        }
+                // first correct Q and then correct I --> this order is crucially important!
+        for(i = 0; i < blockSize; i++)
+        {   // see fig. 5
+            adb.q_buffer[i] += M_c1 * adb.i_buffer[i];
+//            adb.i_buffer[i] += M_c1 * adb.q_buffer[i];
+        }
+        // see fig. 5
+        arm_scale_f32 (adb.i_buffer, M_c2 / , adb.i_buffer, blockSize);
+//        arm_scale_f32 (adb.q_buffer, M_c2, adb.q_buffer, blockSize);
+    }
+
 
     if(iq_freq_mode)            // is receive frequency conversion to be done?
     {

--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -3072,7 +3072,7 @@ static void AudioDriver_RxProcessor(AudioSample_t * const src, AudioSample_t * c
 //            adb.i_buffer[i] += M_c1 * adb.q_buffer[i];
         }
         // see fig. 5
-        arm_scale_f32 (adb.i_buffer, M_c2 / , adb.i_buffer, blockSize);
+        arm_scale_f32 (adb.i_buffer, M_c2, adb.i_buffer, blockSize);
 //        arm_scale_f32 (adb.q_buffer, M_c2, adb.q_buffer, blockSize);
     }
 

--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -1206,6 +1206,13 @@ void AudioDriver_SetRxAudioProcessing(uint8_t dmod_mode, bool reset_dsp_nr)
         adb.c1[5] = -0.996959189310611;
         adb.c1[6] = -0.999282492800792;
 
+        adb.M_c1 = 0.0;
+        adb.M_c2 = 1.0;
+        adb.teta1_old = 0.0;
+        adb.teta2_old = 0.0;
+        adb.teta3_old = 0.0;
+
+
     AudioFilter_InitRxHilbertFIR(); // this switches the Hilbert/FIR-filters
 
     // Unlock - re-enable filtering
@@ -2910,20 +2917,21 @@ void set_SAM_PLL_parameters()
         adb.onem_mtauI = (1.0 - adb.mtauI);
 }
 
-float32_t teta1_old = 0.0;
-float32_t teta2_old = 0.0;
-float32_t teta3_old = 0.0;
-float32_t M_c1, M_c2;
-uint8_t IQ_auto_counter;
 
-float32_t sign_new(float32_t x) {
+
+
+float32_t sign_new (float32_t x) {
+    return x < 0 ? -1.0 : ( x > 0 ? 1.0 : 0.0);
+}
+
+/*float64_t sign_new(float64_t x) {
   if(x < 0)
     return -1.0;
     else
       if(x > 0)
         return 1.0;
           else return 0.0;
-}
+}*/
 
 //
 //*----------------------------------------------------------------------------
@@ -2945,6 +2953,8 @@ static void AudioDriver_RxProcessor(AudioSample_t * const src, AudioSample_t * c
     const uint8_t tx_audio_source = ts.tx_audio_source;
     const uint8_t iq_freq_mode = ts.iq_freq_mode;
     const uint8_t  dsp_active = ts.dsp_active;
+
+    static uint8_t IQ_auto_counter = 0;
 
     static ulong        i, beep_idx = 0;
 
@@ -3022,7 +3032,7 @@ static void AudioDriver_RxProcessor(AudioSample_t * const src, AudioSample_t * c
     AudioDriver_SpectrumNoZoomProcessSamples(blockSize);
 
     // artificial amplitude imbalance for testing of the automatic IQ imbalance correction
-    arm_scale_f32 (adb.i_buffer, 1.6, adb.i_buffer, blockSize);
+//    arm_scale_f32 (adb.i_buffer, 0.6, adb.i_buffer, blockSize);
 
 
     if(!ts.iq_auto_correction)
@@ -3031,48 +3041,66 @@ static void AudioDriver_RxProcessor(AudioSample_t * const src, AudioSample_t * c
     arm_scale_f32(adb.i_buffer, ts.rx_adj_gain_var.i, adb.i_buffer, blockSize);
     arm_scale_f32(adb.q_buffer, ts.rx_adj_gain_var.q, adb.q_buffer, blockSize); // TODO: we need only scale one channel! DD4WH, Dec 2016
 
-
     // Apply I/Q phase correction
     AudioDriver_IQPhaseAdjust(ts.txrx_mode,adb.i_buffer, adb.q_buffer,blockSize);
     }
+
     else
     {
-        static float32_t teta1 = 0.0;
-        static float32_t teta2 = 0.0;
-        static float32_t teta3 = 0.0;
+
         for(i = 0; i < blockSize; i++)
         {
-            teta1 += sign_new(adb.i_buffer[i]) * adb.q_buffer[i]; // eq (34)
-            teta2 += sign_new(adb.i_buffer[i]) * adb.i_buffer[i]; // eq (35)
-            teta3 += sign_new(adb.q_buffer[i]) * adb.q_buffer[i]; // eq (36)
+            adb.teta1 += sign_new(adb.i_buffer[i]) * adb.q_buffer[i]; // eq (34)
+            adb.teta2 += sign_new(adb.i_buffer[i]) * adb.i_buffer[i]; // eq (35)
+            adb.teta3 += sign_new(adb.q_buffer[i]) * adb.q_buffer[i]; // eq (36)
 //            teta1 += sign_new(adb.q_buffer[i]) * adb.i_buffer[i]; // eq (34)
 //            teta2 += sign_new(adb.q_buffer[i]) * adb.q_buffer[i]; // eq (35)
 //            teta3 += sign_new(adb.i_buffer[i]) * adb.i_buffer[i]; // eq (36)
             IQ_auto_counter++;
         }
-        if(IQ_auto_counter >= 3)
+        if(IQ_auto_counter >= 4)
         {
-            teta1 = -0.01 * (teta1 / (float32_t)blockSize / 4.0) + 0.99 * teta1_old; // eq (34) and first order lowpass
-            teta2 = 0.01 * (teta2 / (float32_t)blockSize / 4.0) + 0.99 * teta2_old; // eq (35) and first order lowpass
-            teta3 = 0.01 * (teta3 / (float32_t)blockSize / 4.0) + 0.99 * teta3_old; // eq (36) and first order lowpass
-            M_c1 = teta1 / teta2; // eq (30)
-            M_c2 = sqrtf((teta3 * teta3 - teta1 * teta1) / (teta2 * teta2)); // eq (31)
-            teta1_old = teta1;
-            teta2_old = teta2;
-            teta3_old = teta3;
-            teta1 = 0.0;
-            teta2 = 0.0;
-            teta3 = 0.0;
+            adb.teta1 = -0.01 * (adb.teta1 / blockSize / 4.0 ) + 0.99 * adb.teta1_old; // eq (34) and first order lowpass
+            adb.teta2 =  0.01 * (adb.teta2 / blockSize / 4.0 ) + 0.99 * adb.teta2_old; // eq (35) and first order lowpass
+            adb.teta3 =  0.01 * (adb.teta3 / blockSize / 4.0 ) + 0.99 * adb.teta3_old; // eq (36) and first order lowpass
+            if(adb.teta2 != 0.0)
+            {
+                adb.M_c1 = adb.teta1 / adb.teta2; // eq (30)
+            }
+            else
+            {
+                adb.M_c1 = 0.0;
+            }
+
+            float32_t help = (adb.teta2 * adb.teta2);
+            if(help > 0.0)
+            {
+                help = (adb.teta3 * adb.teta3 - adb.teta1 * adb.teta1) / help;
+            }
+            if (help > 0.0)
+            {
+                adb.M_c2 = sqrtf(help); // eq (31)
+            }
+            else
+            {
+                adb.M_c2 = 1.0;
+            }
+            adb.teta1_old = adb.teta1;
+            adb.teta2_old = adb.teta2;
+            adb.teta3_old = adb.teta3;
+            adb.teta1 = 0.0;
+            adb.teta2 = 0.0;
+            adb.teta3 = 0.0;
             IQ_auto_counter = 0;
         }
                 // first correct Q and then correct I --> this order is crucially important!
         for(i = 0; i < blockSize; i++)
         {   // see fig. 5
-            adb.q_buffer[i] += M_c1 * adb.i_buffer[i];
+            adb.q_buffer[i] += adb.M_c1 * adb.i_buffer[i];
 //            adb.i_buffer[i] += M_c1 * adb.q_buffer[i];
         }
         // see fig. 5
-        arm_scale_f32 (adb.i_buffer, M_c2, adb.i_buffer, blockSize);
+        arm_scale_f32 (adb.i_buffer, adb.M_c2, adb.i_buffer, blockSize);
 //        arm_scale_f32 (adb.q_buffer, M_c2, adb.q_buffer, blockSize);
     }
 

--- a/mchf-eclipse/drivers/audio/audio_driver.h
+++ b/mchf-eclipse/drivers/audio/audio_driver.h
@@ -117,7 +117,14 @@ typedef struct
     float32_t               onem_mtauI;
     float32_t               c0[SAM_PLL_HILBERT_STAGES];          // Filter coefficients - path 0
     float32_t               c1[SAM_PLL_HILBERT_STAGES];          // Filter coefficients - path 1
-
+    float32_t               teta1;
+    float32_t               teta2;
+    float32_t               teta3;
+    float32_t               teta1_old;
+    float32_t               teta2_old;
+    float32_t               teta3_old;
+    float32_t               M_c1;
+    float32_t               M_c2;
 
 } AudioDriverBuffer;
 

--- a/mchf-eclipse/hardware/mchf_board.h
+++ b/mchf-eclipse/hardware/mchf_board.h
@@ -1198,6 +1198,8 @@ typedef struct TransceiverState
     uchar	s_meter;				// defines S-Meter style/configuration
 	uint8_t	meter_colour_up;
 	uint8_t	meter_colour_down;
+	uchar   iq_auto_correction;     // switch variable for automatic IQ correction
+
 #define DISPLAY_S_METER_STD   0
 #define DISPLAY_S_METER_DBM   1
 #define DISPLAY_S_METER_DBMHZ 2

--- a/mchf-eclipse/main.c
+++ b/mchf-eclipse/main.c
@@ -433,6 +433,7 @@ void TransceiverStateInit(void)
     ts.display_dbm = 0;						// style of dBm display, 0=OFF, 1= dbm, 2= dbm/Hz
     ts.dBm_count = 0;						// timer start
     ts.tx_filter = 0;						// which TX filter has been chosen by the user
+    ts.iq_auto_correction = 0;              // disable/enable automatic IQ correction
 
     ts.FDV_TX_encode_ready = false;		// FREEDV handshaking test DL2FW
     ts.FDV_TX_samples_ready = 0;	// FREEDV handshaking test DL2FW


### PR DESCRIPTION
set  ts.iq_auto_correction = 1; in main.c to try this out. For testing, use line 3035 in audio_driver.c to introduce severe amplitude imbalance.
TODO: allow for flexible choice of the number of samples used to calculate the correction factors.