### PR TITLE
DC elimination problem (hopefully) solved

### DIFF
--- a/mchf-eclipse/drivers/audio/codec/codec.c
+++ b/mchf-eclipse/drivers/audio/codec/codec.c
@@ -364,7 +364,8 @@ void Codec_VolumeSpkr(uint8_t vol)
 
     lv += 0x2F; // volume offset, all lower values including 0x2F represent muting
     // Reg 02: Speaker - variable volume, change at zero crossing in order to prevent audible clicks
-    Codec_WriteRegister(W8731_LEFT_HEADPH_OUT,lv); // (lv | W8731_HEADPH_OUT_ZCEN));
+//    Codec_WriteRegister(W8731_LEFT_HEADPH_OUT,lv); // (lv | W8731_HEADPH_OUT_ZCEN));
+    Codec_WriteRegister(W8731_LEFT_HEADPH_OUT,(lv | W8731_HEADPH_OUT_ZCEN));
 }
 /**
  * @brief audio volume control in TX and RX modes for lineout [right headphone]

--- a/mchf-eclipse/main.c
+++ b/mchf-eclipse/main.c
@@ -427,7 +427,7 @@ void TransceiverStateInit(void)
     ts.treble_gain = 0;						// gain of the high shelf EQ filter
     ts.tx_bass_gain = 4;					// gain of the TX low shelf EQ filter
     ts.tx_treble_gain = 4;					// gain of the TX high shelf EQ filter
-    ts.AM_experiment = 0;					// for AM demodulation experiments, not for "public" use
+    ts.AM_experiment = 1;					// for AM demodulation experiments, not for "public" use
     ts.s_meter = 0;							// S-Meter configuration, 0 = old school, 1 = dBm-based, 2=dBm/Hz-based
     ts.display_dbm = 0;						// style of dBm display, 0=OFF, 1= dbm, 2= dbm/Hz
     ts.dBm_count = 0;						// timer start


### PR DESCRIPTION
DC was not properly eliminated in AM & SAM mode. This did not cause problems until we wanted to use the codecs´ zero-crossing pop-elimination-property. Then DC causes the volume to not properly follow the AF gain setting, because DC prevents the signal to cross zero, especially when signals are very large (strong carriers).
Now AM and SAM use a DC elimination highpass 1st order IIR filter to eliminate the DC.
Fade leveler ON is a setting for AM & SAM that does NOT properly eliminate DC, so use that with care!
Fade leveler default is OFF now.
Fade leveler will be modified/switched off in the near future, but we need it in this commit for testing purposes.