### PR TITLE
dBm display now uses real time averaging of all samples

### DIFF
--- a/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
@@ -1349,7 +1349,7 @@ static void UiSpectrum_CalculateDBm()
 
     // FIXME: since implementation of the Zoom FFT, the dBm display does only show correct values when in 1x magnify mode!
     // probably because of differing gains in the IIR filters used as decimation filters in the Zoom FFT
-    if(ts.sysclock > ts.dBm_count + 19)
+//    if(ts.sysclock > ts.dBm_count + 19)
     {
         if( ts.txrx_mode == TRX_MODE_RX && ((ts.s_meter != DISPLAY_S_METER_STD) || (ts.display_dbm != DISPLAY_S_METER_STD )))
         {
@@ -1529,7 +1529,7 @@ static void UiSpectrum_CalculateDBm()
             sm.dbm = m_AverageMagdbm; // write average into variable for S-meter display
             sm.dbmhz = m_AverageMagdbmhz; // write average into variable for S-meter display
         }
-        ts.dBm_count = ts.sysclock;				// reset timer
+//        ts.dBm_count = ts.sysclock;				// reset timer
         UiSpectrum_DisplayDbm();
     }
 }

--- a/mchf-eclipse/hardware/mchf_board.h
+++ b/mchf-eclipse/hardware/mchf_board.h
@@ -1192,7 +1192,7 @@ typedef struct TransceiverState
 
     bool	AM_experiment;			// for AM demodulation experiments, not for "public" use
 //    bool	dBm_Hz_Test;			// for testing only
-    ulong	dBm_count;				// timer for calculating RX dBm
+//    ulong	dBm_count;				// timer for calculating RX dBm
     uchar 	display_dbm;			// display dbm or dbm/Hz or OFF
     uchar	s_meter;				// defines S-Meter style/configuration
 	uint8_t	meter_colour_up;

--- a/mchf-eclipse/main.c
+++ b/mchf-eclipse/main.c
@@ -430,7 +430,7 @@ void TransceiverStateInit(void)
     ts.AM_experiment = 1;					// for AM demodulation experiments, not for "public" use
     ts.s_meter = 0;							// S-Meter configuration, 0 = old school, 1 = dBm-based, 2=dBm/Hz-based
     ts.display_dbm = 0;						// style of dBm display, 0=OFF, 1= dbm, 2= dbm/Hz
-    ts.dBm_count = 0;						// timer start
+//    ts.dBm_count = 0;						// timer start
     ts.tx_filter = 0;						// which TX filter has been chosen by the user
     ts.iq_auto_correction = 1;              // disable/enable automatic IQ correction
     ts.twinpeaks_tested = 2;                // twinpeak_tested = 2 --> wait for system to warm up


### PR DESCRIPTION
Signal power calculation (dBm display and S-Meter non-old school mode) is now done on all samples and no longer on a subset of 1/20th of the samples.
Leads to much better accuracy, I hope.