### PR TITLE
Add Microsoft C defines

### DIFF
--- a/mchf-eclipse/cmsis/arm_math.h
+++ b/mchf-eclipse/cmsis/arm_math.h
@@ -439,6 +439,9 @@ typedef double float64_t;
 #define __SIMD32_TYPE __unaligned int32_t
 #define CMSIS_UNUSED
 
+#elif defined ( _MSC_VER )
+#define __SIMD32_TYPE int32_t
+
 #else
 #error Unknown compiler
 #endif

--- a/mchf-eclipse/cmsis/core_cm4.h
+++ b/mchf-eclipse/cmsis/core_cm4.h
@@ -115,6 +115,10 @@ extern "C" {
 #define __INLINE         inline                                    /*!< inline keyword for COSMIC Compiler. Use -pc99 on compile line */
 #define __STATIC_INLINE  static inline
 
+#elif defined ( _MSC_VER )
+#define __INLINE         inline  
+#define __STATIC_INLINE  static inline
+
 #else
 #error Unknown compiler
 #endif


### PR DESCRIPTION
Add Microsoft C defines.
Prepare unit tests with the MSC compiler