### PR TITLE
In AGC WDSP, NB encoder is now AGC mode encoder

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -1893,7 +1893,6 @@ void AGC_prep()
 //    tau_hang_decay = 0.100;          // tau_hang_decay
 
   //calculate internal parameters
-
     if(ts.agc_wdsp_switch_mode)
     {
     switch (ts.agc_wdsp_mode)
@@ -1914,12 +1913,12 @@ void AGC_prep()
       break;
     case 3: //agcMED
 //      hang_thresh = 1.0;
-      hangtime = 0.000;
+      hangtime = 0.250;
       ts.agc_wdsp_tau_decay = 250;
       break;
     case 4: //agcFAST
 //      hang_thresh = 1.0;
-      hangtime = 0.000;
+      hangtime = 0.100;
       ts.agc_wdsp_tau_decay = 50;
       break;
     case 0: //agcFrank --> very long

--- a/mchf-eclipse/drivers/ui/menu/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu.c
@@ -1156,6 +1156,10 @@ void UiMenu_UpdateItem(uint16_t select, uint16_t mode, int pos, int var, char* o
             {
             case 1:       //
                 txt_ptr = "    WDSP AGC";        //
+                if(ts.s_meter == 0) // old school S-Meter does not work with WDSP AGC, so we switch to dBm S-Meter in that case!
+                    {
+                        ts.s_meter = 1;
+                    }
                 break;
             default:
                 txt_ptr = "Standard AGC";        //


### PR DESCRIPTION
AGC Standard: everything as usual.
AGC WDSP: encoder 2 adjusts:
AGC threshold (box "AGC") and 
AGC mode (box under AGC shows AGC mode: "vLO","LON","MED","SLO","FAS","OFF", and under that the AGC decay value in milliseconds / 10.
When switching to WDSP AGC, S-Meter is forced to dBm-base to prevent having a non-functional oldschool S-Meter.