### PR TITLE
Fixed DTR not controlled by USB (#842),  MinGW build issue (#840)

### DIFF
--- a/mchf-eclipse/basesw/mcHF/Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Src/usbd_cdc.c
+++ b/mchf-eclipse/basesw/mcHF/Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Src/usbd_cdc.c
@@ -634,7 +634,7 @@ static uint8_t  USBD_CDC_Setup (USBD_HandleTypeDef *pdev,
     else
     {
       ((USBD_CDC_ItfTypeDef *)pdev->pUserData)->Control(req->bRequest,
-                                                        (uint8_t*)req,
+                                                        (uint8_t*)&req->wValue,
                                                         0);
     }
     break;

--- a/mchf-eclipse/include.mak
+++ b/mchf-eclipse/include.mak
@@ -36,3 +36,4 @@ basesw/mcHF/Middlewares/Third_Party/FatFs/src/drivers \
 basesw/mcHF/Middlewares/ST/STM32_USB_Device_Library/Class/MSC/Inc \
 basesw/mcHF/Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Inc \
 drivers/usb/device/class/composite \
+


### PR DESCRIPTION
Now CW with UCX and other tools using DTR works as before in 1.6.0 (#842)
MinGW should no longer have issues with the make process (#840)