### PR TITLE
I2C Bus changes: Reduced initial speed to 100k, reenabled I2C speed setting via menu

### DIFF
--- a/mchf-eclipse/basesw/mcHF/Src/i2c.c
+++ b/mchf-eclipse/basesw/mcHF/Src/i2c.c
@@ -59,7 +59,7 @@ void MX_I2C1_Init(void)
 {
 
   hi2c1.Instance = I2C1;
-  hi2c1.Init.ClockSpeed = 200000;
+  hi2c1.Init.ClockSpeed = 100000;
   hi2c1.Init.DutyCycle = I2C_DUTYCYCLE_16_9;
   hi2c1.Init.OwnAddress1 = 102;
   hi2c1.Init.AddressingMode = I2C_ADDRESSINGMODE_7BIT;

--- a/mchf-eclipse/drivers/ui/lcd/ui_lcd_hy28.h
+++ b/mchf-eclipse/drivers/ui/lcd/ui_lcd_hy28.h
@@ -131,8 +131,8 @@ typedef struct
     uint8_t raw;
     uint8_t x;
     uint8_t y;
-    uint8_t present;
-    uint8_t reversed;
+    bool present;
+    bool reversed;
 } mchf_touchscreen_t;
 
 

--- a/mchf-eclipse/drivers/ui/menu/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu.c
@@ -2144,12 +2144,12 @@ void UiMenu_UpdateItem(uint16_t select, uint16_t mode, int pos, int var, char* o
             if (temp_var_u8)
             {
                 ts.flags1 |= FLAGS1_REVERSE_TOUCHSCREEN;
-                ts.tp->reversed = 1;
+                ts.tp->reversed = true;
             }
             else
             {
                 ts.flags1 &= ~FLAGS1_REVERSE_TOUCHSCREEN;
-                ts.tp->reversed = 0;
+                ts.tp->reversed = false;
             }
         }
         break;

--- a/mchf-eclipse/drivers/ui/menu/ui_menu_structure.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu_structure.c
@@ -173,7 +173,7 @@ const MenuDescriptor confGroup[] =
     { MENU_CONF, MENU_ITEM, CONFIG_BEEP_VOLUME, NULL, "Beep Volume", UiMenuDesc("Set beep volume.") },
 
     // USB CAT Related
-    { MENU_CONF, MENU_ITEM, CONFIG_CAT_ENABLE, NULL, "CAT Mode", UiMenuDesc("Enabled the FT 817 emulation via USB. See Wiki for more information.") },
+    //{ MENU_CONF, MENU_ITEM, CONFIG_CAT_ENABLE, NULL, "CAT Mode", UiMenuDesc("Enabled the FT 817 emulation via USB. See Wiki for more information.") },
     { MENU_CONF, MENU_ITEM, CONFIG_CAT_IN_SANDBOX, NULL, "CAT Running In Sandbox", UiMenuDesc("If On, frequency Changes made via CAT will not automatically switch bands and affect the manually selected frequencies.") },
     { MENU_CONF, MENU_ITEM, CONFIG_CAT_XLAT, NULL, "CAT-DIQ-FREQ-XLAT", UiMenuDesc("Select which frequency is reported via CAT Interface to the connected PC in Digital IQ Mode. If ON, it reports the displayed frequency. If OFF, it reports the center frequency, which is more useful with SDR programs.") },
 

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -872,12 +872,16 @@ void UiDriver_Init()
     UiDriver_InitFrequency();
 
     // Load stored data from eeprom or calibrate touchscreen
-    if (UiDriver_LoadSavedConfigurationAtStartup() == false && UiDriver_TouchscreenCalibration() == false)
+    bool run_keytest = (UiDriver_LoadSavedConfigurationAtStartup() == false && UiDriver_TouchscreenCalibration() == false);
+
+    // now run all inits which need to be done BEFORE going into test screen mode
+    UiLcdHy28_TouchscreenInit(ts.flags1 & FLAGS1_REVERSE_TOUCHSCREEN);
+
+    if (run_keytest)
     {
         UiDriver_KeyTestScreen();
     }
 
-    UiLcdHy28_TouchscreenInit(ts.flags1 & FLAGS1_REVERSE_TOUCHSCREEN);
 
     Si570_SetPPM((float)ts.freq_cal/10.0);
 

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -875,7 +875,7 @@ void UiDriver_Init()
     bool run_keytest = (UiDriver_LoadSavedConfigurationAtStartup() == false && UiDriver_TouchscreenCalibration() == false);
 
     // now run all inits which need to be done BEFORE going into test screen mode
-    UiLcdHy28_TouchscreenInit(ts.flags1 & FLAGS1_REVERSE_TOUCHSCREEN);
+    UiLcdHy28_TouchscreenInit(ts.flags1 & FLAGS1_REVERSE_TOUCHSCREEN?true:false);
 
     if (run_keytest)
     {

--- a/mchf-eclipse/hardware/mchf_hw_i2c.c
+++ b/mchf-eclipse/hardware/mchf_hw_i2c.c
@@ -17,18 +17,6 @@
 #include "mchf_hw_i2c.h"
 #include "i2c.h"
 
-
-// I2C peripheral configuration defines (control interface of the si570)
-//#define I2C2_CLK                    RCC_APB1Periph_I2C2
-#define I2C2_GPIO_AF                GPIO_AF_I2C2
-
-
-// I2C peripheral configuration defines (control interface of the si570)
-//w#define I2C1_CLK                  		RCC_APB1Periph_I2C1
-
-// uint32_t i2c_flag_timeout_max = MCHF_I2C_FLAG_TIMEOUT; // lower values, higher timeout!
-uint32_t i2c_event_timeout_max = MCHF_I2C_LONG_TIMEOUT; // lower values, higher timeout!
-
 static inline I2C_HandleTypeDef* mchf_hw_I2c_Bus2Handle(I2C_TypeDef* bus) {
     I2C_HandleTypeDef* hi2c;
     if (bus == I2C1)
@@ -42,100 +30,20 @@ static inline I2C_HandleTypeDef* mchf_hw_I2c_Bus2Handle(I2C_TypeDef* bus) {
     return hi2c;
 }
 
-#if 0
-uint16_t MCHF_I2C_StartTransfer(I2C_TypeDef* bus, uint8_t devaddr, uint8_t* data_ptr, uint16_t data_size, bool isWrite, bool isSingleByteRead)
-{
-    int data_idx;
-
-    // Generate the Start Condition
-    I2C_GenerateSTART(bus, ENABLE);
-    I2C_EventCompleteOrReturn(bus,I2C_EVENT_MASTER_MODE_SELECT, 0xFF00);
-    // Test on I2C2 EV5, Start transmitted successfully and clear it
-    // Send Memory device slave Address for write
-    I2C_Send7bitAddress(bus, devaddr, I2C_Direction_Transmitter);
-    // Test on I2C2 EV6 and clear it
-    I2C_EventCompleteOrReturn(bus,I2C_EVENT_MASTER_TRANSMITTER_MODE_SELECTED, 0xFD00);
-
-    for(data_idx = 0; data_idx < data_size; data_idx++)
-    {
-        I2C_SendData(bus, data_ptr[data_idx]);
-        // Test on I2C2 EV8 and clear it
-        I2C_EventCompleteOrReturn(bus,I2C_EVENT_MASTER_BYTE_TRANSMITTED, 0xFC00);
-        // After transmission of addr, we may have to switch to read mode
-    }
-    if (isWrite == false)
-    {
-        I2C_GenerateSTART(bus, ENABLE);
-
-        I2C_EventCompleteOrReturn(bus,I2C_EVENT_MASTER_MODE_SELECT, 0xFB00);
-        // Test on I2C2 EV5, Start transmitted successfully and clear it
-        // Send Memory device slave Address for read
-        I2C_Send7bitAddress(bus, devaddr+1, I2C_Direction_Receiver);
-        if  (isSingleByteRead)
-        {
-            I2C_AcknowledgeConfig(bus, DISABLE);
-        }
-        else
-        {
-            I2C_AcknowledgeConfig(bus, ENABLE);
-        }
-        I2C_EventCompleteOrReturn(bus,I2C_EVENT_MASTER_RECEIVER_MODE_SELECTED, 0xFA00);
-    }
-    return 0;
-}
-#endif
-
 uint16_t MCHF_I2C_WriteRegister(I2C_TypeDef* bus, uchar I2CAddr,uint16_t addr,uint16_t addr_size, uchar RegisterValue)
 {
     I2C_HandleTypeDef* hi2c = mchf_hw_I2c_Bus2Handle(bus);
     HAL_StatusTypeDef i2cRet = HAL_I2C_Mem_Write(hi2c,I2CAddr,addr,addr_size,&RegisterValue,1,100);
 
-    uint16_t retval =  i2cRet != HAL_OK?0xFF00:0;
-
-#if 0
-    retval = MCHF_I2C_StartTransfer(bus,I2CAddr,addr_ptr,addr_size,true,false);
-    // is write only, is not a single byte READ
-
-    if (!retval)
-    {
-        // Prepare the register value to be sent
-        I2C_SendData(bus, RegisterValue);
-
-        I2C_EventCompleteOrReturn(bus,I2C_EVENT_MASTER_BYTE_TRANSMITTED, 0xFC00);
-        // End the configuration sequence
-        I2C_GenerateSTOP(bus, ENABLE);
-        I2C_FlagStatusOrReturn(bus,I2C_FLAG_STOPF, 0xF000);
-    }
-#endif
-    return retval;
+    return  i2cRet != HAL_OK?0xFF00:0;
 }
 
 uint16_t MCHF_I2C_WriteBlock(I2C_TypeDef* bus, uchar I2CAddr, uint16_t addr, uint16_t addr_size, uint8_t* data, uint32_t size)
 {
-    //printf("i2c write 0x%02x 0x%02x 0x%02x\n\r",I2CAddr,RegisterAddr,RegisterValue);
     I2C_HandleTypeDef* hi2c = mchf_hw_I2c_Bus2Handle(bus);
     HAL_StatusTypeDef i2cRet = HAL_I2C_Mem_Write(hi2c,I2CAddr,addr,addr_size,data,size,100);
 
-    uint16_t retval =  i2cRet != HAL_OK?0xFF00:0;
-
-#if 0
-    retval = MCHF_I2C_StartTransfer(bus,I2CAddr,addr_ptr,addr_size,true,false);
-    // is write only, is not a single byte READ
-
-    if (!retval)
-    {
-        for(uint32_t i = 0; i < size; i++)
-        {
-            // Prepare the register value to be sent
-            I2C_SendData(bus, data[i]);
-            I2C_EventCompleteOrReturn(bus,I2C_EVENT_MASTER_BYTE_TRANSMITTED, 0xFC00);
-        }
-        // End the configuration sequence
-        I2C_GenerateSTOP(bus, ENABLE);
-        I2C_FlagStatusOrReturn(bus,I2C_FLAG_STOPF, 0xF000);
-    }
-#endif
-    return retval;
+    return  i2cRet != HAL_OK?0xFF00:0;
 }
 
 uint16_t MCHF_I2C_ReadRegister(I2C_TypeDef* bus, uchar I2CAddr, uint16_t addr, uint16_t addr_size, uint8_t *RegisterValue)
@@ -143,23 +51,7 @@ uint16_t MCHF_I2C_ReadRegister(I2C_TypeDef* bus, uchar I2CAddr, uint16_t addr, u
     I2C_HandleTypeDef* hi2c = mchf_hw_I2c_Bus2Handle(bus);
     HAL_StatusTypeDef i2cRet = HAL_I2C_Mem_Read(hi2c,I2CAddr,addr,addr_size,RegisterValue,1,100);
 
-    uint16_t retval =  i2cRet != HAL_OK?0xFF00:0;
-#if 0
-    //printf("i2c read\n\r");
-    uint16_t retval = MCHF_I2C_StartTransfer(bus,I2CAddr,addr_ptr,addr_size,false,true);
-    // is read, IS a SINGLE byte READ
-
-    if (!retval)
-    {
-        I2C_EventCompleteOrReturn(bus,I2C_EVENT_MASTER_BYTE_RECEIVED, 0xF900);
-        /* Prepare Stop after receiving data */
-        I2C_GenerateSTOP(bus, ENABLE);
-        I2C_FlagStatusOrReturn(bus,I2C_FLAG_STOPF, 0xF000);
-        /* Receive the Data */
-        *RegisterValue = I2C_ReceiveData(bus);
-    }
-#endif
-    return retval;
+    return  i2cRet != HAL_OK?0xFF00:0;
 }
 
 uint16_t MCHF_I2C_ReadBlock(I2C_TypeDef* bus, uchar I2CAddr,uint16_t addr, uint16_t addr_size, uint8_t *data, uint32_t size)
@@ -168,43 +60,14 @@ uint16_t MCHF_I2C_ReadBlock(I2C_TypeDef* bus, uchar I2CAddr,uint16_t addr, uint1
     I2C_HandleTypeDef* hi2c = mchf_hw_I2c_Bus2Handle(bus);
     HAL_StatusTypeDef i2cRet = HAL_I2C_Mem_Read(hi2c,I2CAddr,addr,addr_size,data,size,100);
 
-    uint16_t retval =  i2cRet != HAL_OK?0xFF00:0;
-#if 0
-    if (size != 0)
-    {
-        retval = MCHF_I2C_StartTransfer(bus,I2CAddr,addr_ptr,addr_size,false,size == 1);
-        // is read, is a not single byte READ unless size == 1
-
-        if (!retval)
-        {
-            int idx;
-            for (idx = 0; idx < size - 1; idx++)
-            {
-                I2C_EventCompleteOrReturn(bus, I2C_EVENT_MASTER_BYTE_RECEIVED, 0xF900);
-                data[idx] = I2C_ReceiveData(bus);
-            }
-            // we have just read the second last byte, now prepare for landing :-)
-            if (size > 1)
-            {
-                I2C_AcknowledgeConfig(bus, DISABLE);
-            }
-            // in case of a single byte read, this has been done already in the start transfer
-            I2C_EventCompleteOrReturn(bus, I2C_EVENT_MASTER_BYTE_RECEIVED, 0xF900);
-            I2C_GenerateSTOP(bus, ENABLE);
-            I2C_FlagStatusOrReturn(bus, I2C_FLAG_STOPF, 0xF000);
-            data[size-1] = I2C_ReceiveData(bus);
-        }
-    }
-    //printf("read done\n\r");
-#endif
-    return retval;
+    return  i2cRet != HAL_OK?0xFF00:0;
 }
 
 /**
  * @brief init I2C
  * @param speed in Hertz !!!
  */
-void MchfHw_I2C_Init(I2C_TypeDef* bus)
+void MchfHw_I2C_ChangeSpeed(I2C_TypeDef* bus)
 {
 
     I2C_HandleTypeDef* hi2c = mchf_hw_I2c_Bus2Handle(bus);
@@ -228,68 +91,15 @@ void MchfHw_I2C_Init(I2C_TypeDef* bus)
 
 void MchfHw_I2C_Reset(I2C_TypeDef* bus)
 {
-#if 0
-    I2C_SoftwareResetCmd(bus, ENABLE);
-    I2C_SoftwareResetCmd(bus, DISABLE);
-
-    I2C_Cmd (bus, DISABLE);
-    non_os_delay();
-    I2C_Cmd (bus, ENABLE);
-#endif
-    MchfHw_I2C_Init(bus);
+    MchfHw_I2C_ChangeSpeed(bus);
 };
-
-void MchfHw_I2C_GpioInit(I2C_TypeDef* bus)
-{
-    // Handled By HAL
-#if 0
-    GPIO_InitTypeDef GPIO_InitStructure;
-
-    GPIO_InitStructure.Mode = GPIO_MODE_AF_OD;
-    GPIO_InitStructure.Speed = GPIO_SPEED_FAST;
-    GPIO_InitStructure.Pull  = GPIO_PULLUP;       // - strong ringing on the bus
-    //GPIO_InitStructure.GPIO_PuPd  = GPIO_PuPd_DOWN;   // - makes it better
-    //GPIO_InitStructure.GPIO_PuPd  = GPIO_PuPd_NOPULL; // - same as pull down
-
-
-    // Connect pins to I2C peripheral
-
-    if (bus == I2C1)
-    {
-        GPIO_InitStructure.Alternate = GPIO_AF4_I2C1;
-
-        GPIO_InitStructure.Pin = I2C1_SCL_PIN;
-        HAL_GPIO_Init(I2C1_SCL_GPIO, &GPIO_InitStructure);
-
-        GPIO_InitStructure.Pin = I2C1_SDA_PIN;
-        HAL_GPIO_Init(I2C1_SDA_GPIO, &GPIO_InitStructure);
-    }
-    else if (bus == I2C2)
-    {
-        GPIO_InitStructure.Alternate = GPIO_AF4_I2C2;
-
-        GPIO_InitStructure.Pin = I2C2_SCL_PIN;
-        HAL_GPIO_Init(I2C2_SCL_GPIO, &GPIO_InitStructure);
-
-        GPIO_InitStructure.Pin = I2C2_SDA_PIN;
-        HAL_GPIO_Init(I2C2_SDA_GPIO, &GPIO_InitStructure);
-    }
-#endif
-}
 
 /*
  * @brief full init of I2C1 including GPIO and bus clock
  */
 void mchf_hw_i2c1_init()
 {
-    // I2C SCL and SDA pins configuration
-    ///MchfHw_I2C_GpioInit(I2C1);
-
-    // Enable the I2C peripheral clock
-    ///RCC_APB1PeriphClockCmd(I2C1_CLK, ENABLE);
-
-    // Enabled I2S peripheral
-    ///MchfHw_I2C_Init(I2C1);
+    MchfHw_I2C_ChangeSpeed(I2C1);
 }
 
 /*
@@ -297,12 +107,7 @@ void mchf_hw_i2c1_init()
  */
 void mchf_hw_i2c2_init()
 {
-    ///MchfHw_I2C_GpioInit(I2C2);
-
-    // Enable the I2C2 peripheral clock
-    ///RCC_APB1PeriphClockCmd(I2C2_CLK, ENABLE);
-
-    ///MchfHw_I2C_Init(I2C2);
+    MchfHw_I2C_ChangeSpeed(I2C2);
 }
 
 void mchf_hw_i2c1_reset(void)
@@ -317,37 +122,20 @@ void mchf_hw_i2c2_reset(void)
 
 uint16_t mchf_hw_i2c1_WriteRegister(uchar I2CAddr, uchar RegisterAddr, uchar RegisterValue)
 {
-    uint16_t res = MCHF_I2C_WriteRegister(I2C1, I2CAddr, RegisterAddr, 1, RegisterValue);
-#ifdef DEBUG_I2C1_ISSUES
-    while (res) { asm ("nop"); }
-#endif
-    return res;
+    return MCHF_I2C_WriteRegister(I2C1, I2CAddr, RegisterAddr, 1, RegisterValue);
 }
 
 uint16_t mchf_hw_i2c1_WriteBlock(uchar I2CAddr,uchar RegisterAddr, uchar *data, ulong size)
 {
-    uint16_t res = MCHF_I2C_WriteBlock(I2C1, I2CAddr,RegisterAddr, 1, data, size);
-#ifdef DEBUG_I2C1_ISSUES
-    while (res) { asm ("nop"); }
-#endif
-    return res;
+    return MCHF_I2C_WriteBlock(I2C1, I2CAddr,RegisterAddr, 1, data, size);
 }
 
 uint16_t mchf_hw_i2c1_ReadRegister(uchar I2CAddr,uchar RegisterAddr, uchar *RegisterValue)
 {
-    uint16_t res = MCHF_I2C_ReadRegister(I2C1, I2CAddr,RegisterAddr, 1, RegisterValue);
-#ifdef DEBUG_I2C1_ISSUES
-    while (res) { asm ("nop"); }
-#endif
-    return res;
-
+    return MCHF_I2C_ReadRegister(I2C1, I2CAddr,RegisterAddr, 1, RegisterValue);
 }
 
 uint16_t mchf_hw_i2c1_ReadData(uchar I2CAddr,uchar RegisterAddr, uchar *data, ulong size)
 {
-    uint16_t res =  MCHF_I2C_ReadBlock(I2C1, I2CAddr, RegisterAddr, 1, data, size);
-#ifdef DEBUG_I2C1_ISSUES
-    while (res) { asm ("nop"); }
-#endif
-    return res;
+    return  MCHF_I2C_ReadBlock(I2C1, I2CAddr, RegisterAddr, 1, data, size);
 }


### PR DESCRIPTION
For I2C Speed: effectively we restored the 1.6.0 behavior now.

Further changes:
Made sure touchscreen is initialized according to loaded configuration
even in key test mode.
Disabled CAT menu (has no function any longer)
Removed no longer needed code from I2C hw layer.
Now includes a fix for reverse touchscreen operation (not restored after reboot issue #845)