### PR TITLE
reorder data items

### DIFF
--- a/mchf-eclipse/misc/serial_eeprom.h
+++ b/mchf-eclipse/misc/serial_eeprom.h
@@ -18,8 +18,8 @@
 
 typedef struct {
     uint32_t size; // in Bytes
-    uint16_t pagesize; // in Bytes
     bool supported; // i.e. big enough to be used
+	uint16_t pagesize; // in Bytes
     const char* name;
 } SerialEEPROM_EEPROMTypeDescriptor;
 


### PR DESCRIPTION
C++ require that data items are in sequence, so the data table now match(in same order) of the struct.
Works in C and C++,  and change should have no impact of the ARM code.   I'm making unit test programs in c++ with Google test tool.  
 
init. of the struct must be in order !
{
                .size = 0,
                .supported = false,
                .pagesize = 0,
                .name = "No EEPROM"
},