### PR TITLE
use single screen init function

### DIFF
--- a/mchf-eclipse/hardware/mchf_board.c
+++ b/mchf-eclipse/hardware/mchf_board.c
@@ -545,7 +545,7 @@ static void mchf_board_band_cntr_init(void)
     BAND2_PIO->BSRR = BAND2;
 }
 
-static void mchf_board_touchscreen_init()
+void mchf_board_touchscreen_init()
 {
     GPIO_InitTypeDef GPIO_InitStructure;
 

--- a/mchf-eclipse/hardware/mchf_board.h
+++ b/mchf-eclipse/hardware/mchf_board.h
@@ -1062,6 +1062,7 @@ inline bool mchf_dit_line_pressed() {
 
 unsigned int mchf_board_get_ramsize();
 void mchf_board_detect_ramsize();
+void mchf_board_touchscreen_init();
 
 // in main.c
 void CriticalError(ulong error);

--- a/mchf-eclipse/src/bootloader/bootloader_main.c
+++ b/mchf-eclipse/src/bootloader/bootloader_main.c
@@ -14,6 +14,7 @@
 
 #include "flash_if.h"
 #include "mchf_boot_hw.h"
+#include "hardware/mchf_board.h"
 #include "command.h"
 #include "fatfs.h"
 #include "usb_host.h"
@@ -59,21 +60,7 @@ static void BL_DisplayInit()
     MX_SPI2_Init();
     MX_GPIO_Init();
 
-    GPIO_InitTypeDef GPIO_InitStructure;
-
-    GPIO_InitStructure.Mode     = GPIO_MODE_INPUT;
-    GPIO_InitStructure.Pull     = GPIO_PULLUP;
-    GPIO_InitStructure.Speed    = GPIO_SPEED_FREQ_VERY_HIGH;
-
-    GPIO_InitStructure.Pin = TP_IRQ;
-    HAL_GPIO_Init(TP_IRQ_PIO, &GPIO_InitStructure);
-
-    GPIO_InitStructure.Mode     = GPIO_MODE_OUTPUT_PP;
-
-    GPIO_InitStructure.Pin = TP_CS;
-    HAL_GPIO_Init(TP_CS_PIO, &GPIO_InitStructure);
-
-    GPIO_SetBits(TP_CS_PIO, TP_CS);
+	mchf_board_touchscreen_init();
 
     UiLcdHy28_Init();
     UiLcdHy28_LcdClear(Black);


### PR DESCRIPTION
Found duplicate screen init code in bootloader. 
The screen init will now be in 1 function and it's same for bootloader and mcHF.
Reduce the lines of C code, but bootloader binary will almost be the same.
 