### PR TITLE
Start fixing debug build

### DIFF
--- a/mchf-embitz/Readme.md
+++ b/mchf-embitz/Readme.md
@@ -11,7 +11,7 @@ It is a light and fast IDE compared to Eclipse but with a lot of handy and power
 ### Prerequisites
 
   * EmBitz works on windows 7 and up.
-  * Optional : Building the mcHF firmware with the bundled GNU ARM toolchain 5.4 is fine, but you can install independent 
+  * Optional : Building the mcHF firmware with the bundled GNU ARM toolchain 5.4 is fine, but you can install independent
 [GNU ARM Embedded Toolchains](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads) if you prefer another toolchain version.
   * Optional : EmBitz doesn't include any Git interface or plugin, an external Git tool is needed to publish your modifications on GitHub. [GitHub Desktop](https://desktop.github.com/) or [SmartGit](https://www.syntevo.com/smartgit/) are very easy to use. Read the explanations by DF8OE in the [CONTRIBUTING.md](https://github.com/df8oe/mchf-github/blob/active-devel/CONTRIBUTING.md) file.
 
@@ -19,8 +19,16 @@ It is a light and fast IDE compared to Eclipse but with a lot of handy and power
 
   * Open the *mchf-embitz.eworkspace* file into EmBitz (File/Open/Workspace files menu)
   * Change the *ar* toolchain archiver to *arm-none-eabi-gcc-ar.exe* (Settings/Tools/Global Compiler Settings/Toolchain Executables), this is to allow link time optimization of libraries
-  * Select the **Release** target of all projects and build them
+  * Select the **Release** target of all projects and build them.
   * The ready to flash *mchf.bin* file is in mchf-embitz/bin/Release directory.
+
+### Debugging
+
+EmBitz uses own tailor made GDB debuggers, allowing some features such as live variables and "hot" connect to running targets without stopping. The integrated ARM GDB supports the inexpensive ST-LINK V2 clones from Ebay.
+
+  * Select the **Debug** target of all projects and build them.
+  * Press and hold the **POWER** button of the mcHF radio and start the debug session with the F8 key. The GDB is started and automatically flashes the firmware onto the CPU. Don't release the **POWER** button until the main firmware is run to the point where the GPIO pin controlling the power (POWERDOWN signal) is set.
+  ** Once powered on, the firmware could be reseted or halted and breakpoints could be set without loosing the power.
 
 Have fun - Open-Source opens possibilities!
 

--- a/mchf-embitz/cmsis_dsp.ebp
+++ b/mchf-embitz/cmsis_dsp.ebp
@@ -14,7 +14,7 @@
 				<Option compiler="armgcc_eb" />
 				<Option projectDeviceOptionsRelation="0" />
 				<Compiler>
-					<Add option="-O0" />
+					<Add option="-O2" />
 					<Add option="-g2" />
 				</Compiler>
 				<Cpp>

--- a/mchf-embitz/mchf.ebp
+++ b/mchf-embitz/mchf.ebp
@@ -16,9 +16,8 @@
 				<Compiler>
 					<Add option="-std=gnu11" />
 					<Add option="-Wunused-function" />
-					<Add option="-O0" />
+					<Add option="-O2" />
 					<Add option="-g2" />
-					<Add option="-fgnu89-inline" />
 				</Compiler>
 				<Cpp>
 					<Add option="-std=gnu++11" />
@@ -29,7 +28,7 @@
 					<Add option="--gdwarf-2" />
 				</Assembler>
 				<Linker>
-					<Add option="-T..\mchf-eclipse\arm-gcc-link-1024k.ld" />
+					<Add option="-T..\mchf-eclipse\arm-gcc-link.ld" />
 					<Add library="bin\Debug\libstm32f4xxhal.a" />
 					<Add library="bin\Debug\libcmsisdsp.a" />
 				</Linker>
@@ -655,9 +654,42 @@
 			<Option compilerVar="CC" />
 		</Unit>
 		<Unit filename="..\mchf-eclipse\support\hex2dfu\hex2dfu.py" />
+		<Unit filename="Readme.md" />
 		<Extensions>
 			<code_completion />
-			<debugger />
+			<debugger>
+				<target_debugging_settings target="Debug" active_interface="ST-link">
+					<debug_interface interface_id="OpenOCD" ip_address="" ip_port="" path="" executable="" description="" dont_start_server="false" backoff_time="" options="0" reg_filter="0" active_family="" gdb_before_conn="" gdb_after_conn="">
+						<family_options family_id="All">
+							<option opt_id="ID_BOARD_CH" opt_value="" />
+							<option opt_id="ID_INTERFACE_CH" opt_value="stlink-v2" />
+							<option opt_id="ID_TARGET_CH" opt_value="stm32f4x" />
+							<option opt_id="ID_TEXTCTRL1" opt_value="1800" />
+							<option opt_id="ID_HW_BKP_LIMIT" opt_value="" />
+							<option opt_id="ID_RESET_CH" opt_value="halt" />
+							<option opt_id="ID_LOAD_PROGRAM" opt_value="1" />
+							<option opt_id="ID_SEMIHOST_CHECK" opt_value="0" />
+							<option opt_id="ID_ADD_COMMANDS" opt_value="" />
+							<option opt_id="ID_ADD_CMNDS" opt_value="" />
+						</family_options>
+					</debug_interface>
+					<debug_interface interface_id="ST-link" ip_address="localhost" ip_port="4242" path="${EMBITZ}\share\contrib" executable="STLinkGDB.exe" description="" dont_start_server="false" backoff_time="1000" options="0" reg_filter="0" active_family="STMicroelectronics" gdb_before_conn="" gdb_after_conn="">
+						<family_options family_id="STMicroelectronics">
+							<option opt_id="ID_JTAG_SWD" opt_value="swd" />
+							<option opt_id="ID_VECTOR_START" opt_value="0x08000000" />
+							<option opt_id="ID_RESET_TYPE" opt_value="System" />
+							<option opt_id="ID_LOAD_PROGRAM" opt_value="1" />
+							<option opt_id="ID_SEMIHOST_CHECK" opt_value="0" />
+							<option opt_id="ID_RAM_EXEC" opt_value="0" />
+							<option opt_id="ID_VEC_TABLE" opt_value="1" />
+							<option opt_id="ID_DONT_CONN_RESET" opt_value="0" />
+							<option opt_id="ID_ALL_MODE_DEBUG" opt_value="0" />
+							<option opt_id="ID_DEV_ADDR" opt_value="" />
+							<option opt_id="ID_VERBOSE_LEVEL" opt_value="3" />
+						</family_options>
+					</debug_interface>
+				</target_debugging_settings>
+			</debugger>
 			<envvars />
 			<DoxyBlocks>
 				<comment_style block="0" line="0" />

--- a/mchf-embitz/stm32f4xx_hal.ebp
+++ b/mchf-embitz/stm32f4xx_hal.ebp
@@ -14,7 +14,7 @@
 				<Option compiler="armgcc_eb" />
 				<Option projectDeviceOptionsRelation="0" />
 				<Compiler>
-					<Add option="-O0" />
+					<Add option="-O2" />
 					<Add option="-g2" />
 				</Compiler>
 				<Cpp>


### PR DESCRIPTION
Hi Andreas

This is another addition to the EmBitz IDE support that allows debugging using a ST-LINK V2 dongle. The debug session is managed by EmBitz through its embedded GDB. Still no change to the mchf-eclipse directory. The Readme file at the root of the mchf-embitz directory is updated with some explanations on how to start a debug session.

Best 73
Nicolas F4FHH