### PR TITLE
Fixed missing response on FT817_MODE_SET and other minor CAT issues (…

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -3809,7 +3809,7 @@ static void AudioDriver_RxProcessor(AudioSample_t * const src, AudioSample_t * c
                         !((dmod_mode == DEMOD_LSB || dmod_mode == DEMOD_USB || dmod_mode == DEMOD_CW) && FilterPathInfo[ts.filter_path].FIR_I_coeff_file == i_rx_new_coeffs)) // in SAM mode, the decimation is done in both I & Q path --> AudioDriver_Demod_SAM
                 {
                     // TODO HILBERT
-                    // for filter BW <= 3k6 and LSB/USB/CW, don´t do decimation, we are already in 12ksps
+                    // for filter BW <= 3k6 and LSB/USB/CW, don't do decimation, we are already in 12ksps
                     arm_fir_decimate_f32(&DECIMATE_RX, adb.a_buffer, adb.a_buffer, blockSize);      // LPF built into decimation (Yes, you can decimate-in-place!)
                 }
 
@@ -3989,7 +3989,7 @@ static void AudioDriver_RxProcessor(AudioSample_t * const src, AudioSample_t * c
             {
                 arm_scale_f32(
                         adb.a_buffer,
-                        (ts.flags2 & FLAGS2_FM_MODE_DEVIATION_5KHZ)? FM_RX_SCALING_5K : FM_RX_SCALING_2K5,
+                        RadioManagement_FmDevIs5khz() ? FM_RX_SCALING_5K : FM_RX_SCALING_2K5,
                                 adb.b_buffer,
                                 blockSizeDecim);  // apply fixed amount of audio gain scaling to make the audio levels correct along with AGC
                 if(ts.agc_wdsp)
@@ -4349,7 +4349,7 @@ static void AudioDriver_TxProcessorFM(AudioSample_t * const src, AudioSample_t *
     float32_t fm_mod_mult;
     // Fill I and Q buffers with left channel(same as right)
     //
-    if(ts.flags2 & FLAGS2_FM_MODE_DEVIATION_5KHZ)   // are we in 5 kHz modulation mode?
+    if(RadioManagement_FmDevIs5khz())   // are we in 5 kHz modulation mode?
     {
         fm_mod_mult = 2;    // yes - multiply all modulation factors by 2
     }

--- a/mchf-eclipse/drivers/cat/cat_driver.c
+++ b/mchf-eclipse/drivers/cat/cat_driver.c
@@ -648,7 +648,7 @@ static void CatDriver_HandleCloneOut()
     {
         // go back to normal CAT MODE and prepare for next round
         ft817.cloneout_state = CLONEOUT_INIT;
-        ft817.state = CAT_CAT;
+        ft817.state = CAT_INIT;
         break;
     }
     }
@@ -734,7 +734,7 @@ static void CatDriver_HandleCloneIn()
     {
         // go back to normal CAT MODE and prepare for next round
         ft817.clonein_state = CLONEIN_INIT;
-        ft817.state = CAT_CAT;
+        ft817.state = CAT_INIT;
         break;
     }
     }
@@ -745,7 +745,7 @@ static void CatDriver_HandleCloneIn()
 bool CatDriver_CloneOutStart()
 {
     bool retval = false;
-    if (ft817.state == CAT_CAT || ft817.state == CAT_INIT)
+    if (ft817.state == CAT_CAT)
     {
         retval = true;
         ft817.state = CAT_CLONEOUT;
@@ -757,7 +757,7 @@ bool CatDriver_CloneOutStart()
 bool CatDriver_CloneInStart()
 {
     bool retval = false;
-    if (ft817.state == CAT_CAT || ft817.state == CAT_INIT)
+    if (ft817.state == CAT_CAT)
     {
         retval = true;
         ft817.state = CAT_CLONEIN;
@@ -767,272 +767,296 @@ bool CatDriver_CloneInStart()
 }
 
 
-void CatDriver_HandleProtocol()
+static void CatDriver_HandleCommands()
 {
     uint8_t bc = 0;
     uint8_t resp[32];
 
-    if (CatDriver_GetInterfaceState() == CAT_DISCONNECTED)
-    {
-        cat_buffer_reset();
-        ft817.state = CAT_CAT;
-        ft817.cloneout_state = CLONEOUT_INIT;
-    }
-    else
-    {
-        if (ft817.state == CAT_CLONEOUT)
-        {
-            CatDriver_HandleCloneOut();
-            return;
-        }
-        if (ft817.state == CAT_CLONEIN)
-        {
-            CatDriver_HandleCloneIn();
-            return;
-        }
+    cat_driver_sync_data();
 
-        cat_driver_sync_data();
-
-        while (CatDriver_InterfaceBufferGetData(ft817.req,5))
-        {
+    while (CatDriver_InterfaceBufferGetData(ft817.req,5))
+    {
 #ifdef DEBUG_FT817
-            int debug_idx;
-            for (debug_idx = 0; debug_idx < 5 && ft817.cmd_cntr < FT817_MAX_CMD; debug_idx++ )
-            {
-                ft817.reqs[ft817.cmd_cntr*5+debug_idx] = ft817.req[debug_idx];
-            }
-            ft817.cmd_cntr++;
+        int debug_idx;
+        for (debug_idx = 0; debug_idx < 5 && ft817.cmd_cntr < FT817_MAX_CMD; debug_idx++ )
+        {
+            ft817.reqs[ft817.cmd_cntr*5+debug_idx] = ft817.req[debug_idx];
+        }
+        ft817.cmd_cntr++;
 #endif
 
-            switch((Ft817_CatCmd_t)ft817.req[4])
+        switch((Ft817_CatCmd_t)ft817.req[4])
+        {
+        case FT817_SET_FREQ:
+        {
+            ulong f = 0;
+            ulong fdelta;
+
+            if(ts.xlat == 0)
             {
-            case FT817_SET_FREQ:
+                fdelta = (ts.tx_audio_source == TX_AUDIO_DIGIQ)?AudioDriver_GetTranslateFreq()*4:0;
+                // If we are in DIGITAL IQ Output mode, use real tune frequency frequency instead
+                // translated RX frequency
+            }
+            else
             {
-                ulong f = 0;
-                ulong fdelta;
+                fdelta = 0;
+            }
 
-                if(ts.xlat == 0)
-                {
-                    fdelta = (ts.tx_audio_source == TX_AUDIO_DIGIQ)?AudioDriver_GetTranslateFreq()*4:0;
-                    // If we are in DIGITAL IQ Output mode, use real tune frequency frequency instead
-                    // translated RX frequency
-                }
-                else
-                {
-                    fdelta = 0;
-                }
+            int fidx;
+            for (fidx = 0; fidx < 4; fidx++)
+            {
+                f *= 100;
+                f +=  (ft817.req[fidx] >> 4) * 10 + (ft817.req[fidx] & 0x0f);
+            }
+            f *= TUNE_MULT*10;
+            df.tune_new = f - fdelta;
 
-                int fidx;
-                for (fidx = 0; fidx < 4; fidx++)
-                {
-                    f *= 100;
-                    f +=  (ft817.req[fidx] >> 4) * 10 + (ft817.req[fidx] & 0x0f);
-                }
-                f *= TUNE_MULT*10;
-                df.tune_new = f - fdelta;
+            resp[0] = 0;
+            bc = 1;
+            if(ts.flags1 & FLAGS1_CAT_IN_SANDBOX)           // if running in sandbox store active band
+            {
+                ts.cat_band_index = ts.band;
+            }
+        }
+        break;
 
-                resp[0] = 0;
-                bc = 1;
-                if(ts.flags1 & FLAGS1_CAT_IN_SANDBOX)			// if running in sandbox store active band
+        case FT817_GET_FREQ:
+        {
+            ulong fdelta;
+
+            if(ts.xlat == 0)
+            {
+                fdelta = (ts.tx_audio_source == TX_AUDIO_DIGIQ)?AudioDriver_GetTranslateFreq()*TUNE_MULT:0;
+                // If we are in DIGITAL IQ Output mode, send real tune frequency frequency instead
+                // translated RX frequency
+            }
+            else
+            {
+                fdelta = 0;
+            }
+
+            ulong f = (df.tune_new + fdelta  + (TUNE_MULT*10/2))/ (TUNE_MULT*10);
+            ulong fbcd = 0;
+            int fidx;
+            for (fidx = 0; fidx < 8; fidx++)
+            {
+                fbcd >>= 4;
+                fbcd |= (f % 10) << 28;
+                f = f / 10;
+            }
+
+            resp[0] = (uint8_t)(fbcd >> 24);
+            resp[1] = (uint8_t)(fbcd >> 16);
+            resp[2] = (uint8_t)(fbcd >> 8);
+            resp[3] = (uint8_t)fbcd;
+        }
+        switch(ts.dmod_mode)
+        {
+        case DEMOD_LSB:
+            resp[4] = 0;
+            break;
+        case DEMOD_USB:
+            resp[4] = 1;
+            break;
+        case DEMOD_CW:
+            resp[4] = 2 + (ts.cw_lsb==true?1:0);
+            break;
+            // return 3 if CW in LSB aka CW-R
+        case DEMOD_SAM:
+        case DEMOD_AM:
+            resp[4] = 4;
+            break;
+        case DEMOD_FM:
+            resp[4] = 8;
+            break;
+        default:
+            resp[4] = 1;
+        }
+        bc = 5;
+        break;
+        case FT817_MODE_SET:
+        {
+            resp[0] = 0; // ACK
+            bc = 1;
+
+            uint32_t new_mode = ts.dmod_mode;
+            uint32_t new_cwlsb = ts.cw_lsb;
+            uint32_t new_fmdev5khz = RadioManagement_FmDevIs5khz();
+            switch (ft817.req[0])
+            {
+            case 0: // LSB
+                new_mode = DEMOD_LSB;
+                break;
+            case 1: // USB
+                new_mode = DEMOD_USB;
+                break;
+            case 2: // CW
+                new_cwlsb = false;
+                new_mode = DEMOD_CW;
+                break;
+            case 3: // CW-R
+                new_cwlsb = true;
+                new_mode = DEMOD_CW;
+                break;
+            case 4: // AM
+                new_mode = DEMOD_AM;
+                break;
+            case 8: // FM
+                new_fmdev5khz = true;
+                new_mode = DEMOD_FM;
+                break;
+            case 0x88: // FM-N
+                new_fmdev5khz = false;
+                new_mode = DEMOD_FM;
+                break;
+            case 0x0a: // DIG - SSB, side band controlled by some menu configuration in ft817, we use USB here
+                new_mode = DEMOD_USB;
+                break;
+            case 0x0c: // PKT - FM, 9k6
+                new_mode = DEMOD_FM;
+                break;
+            default:
+                resp[0] = 0xFF; // NACK
+            }
+            if  (new_mode != ts.dmod_mode || new_cwlsb != ts.cw_lsb || new_fmdev5khz != RadioManagement_FmDevIs5khz() )
+            {
+                if(ts.flags1 & FLAGS1_CAT_IN_SANDBOX)           // if running in sandbox store active band
                 {
                     ts.cat_band_index = ts.band;
                 }
-            }
-            break;
-
-            case FT817_GET_FREQ:
-            {
-                ulong fdelta;
-
-                if(ts.xlat == 0)
-                {
-                    fdelta = (ts.tx_audio_source == TX_AUDIO_DIGIQ)?AudioDriver_GetTranslateFreq()*TUNE_MULT:0;
-                    // If we are in DIGITAL IQ Output mode, send real tune frequency frequency instead
-                    // translated RX frequency
-                }
-                else
-                {
-                    fdelta = 0;
-                }
-
-                ulong f = (df.tune_new + fdelta  + (TUNE_MULT*10/2))/ (TUNE_MULT*10);
-                ulong fbcd = 0;
-                int fidx;
-                for (fidx = 0; fidx < 8; fidx++)
-                {
-                    fbcd >>= 4;
-                    fbcd |= (f % 10) << 28;
-                    f = f / 10;
-                }
-
-                resp[0] = (uint8_t)(fbcd >> 24);
-                resp[1] = (uint8_t)(fbcd >> 16);
-                resp[2] = (uint8_t)(fbcd >> 8);
-                resp[3] = (uint8_t)fbcd;
-            }
-            switch(ts.dmod_mode)
-            {
-            case DEMOD_LSB:
-                resp[4] = 0;
-                break;
-            case DEMOD_USB:
-                resp[4] = 1;
-                break;
-            case DEMOD_CW:
-                resp[4] = 2 + (ts.cw_lsb==true?1:0);
-                break;
-                // return 3 if CW in LSB aka CW-R
-            case DEMOD_SAM:
-            case DEMOD_AM:
-                resp[4] = 4;
-                break;
-            case DEMOD_FM:
-                resp[4] = 8;
-                break;
-            default:
-                resp[4] = 1;
-            }
-            bc = 5;
-            break;
-            case 7: /* set mode */
-            {
-                uint32_t new_mode = ts.dmod_mode;
-                uint32_t new_lsb = ts.cw_lsb;
-                switch (ft817.req[0])
-                {
-                case 0: // LSB
-                    new_mode = DEMOD_LSB;
-                    break;
-                case 1: // USB
-                    new_mode = DEMOD_USB;
-                    break;
-                case 2: // CW
-                    new_lsb = false;
-                    new_mode = DEMOD_CW;
-                    break;
-                case 3: // CW-R
-                    new_lsb = true;
-                    new_mode = DEMOD_CW;
-                    break;
-                case 4: // AM
-                    new_mode = DEMOD_AM;
-                    break;
-                case 8: // FM
-                case 0x88: // FM-N
-                    new_mode = DEMOD_FM;
-                    break;
-                case 0x0a: // DIG - SSB, side band controlled by some menu configuration in ft817, we use USB here
-                    new_mode = DEMOD_USB;
-                    break;
-                case 0x0c: // PKT - FM, 9k6
-                    new_mode = DEMOD_FM;
-                    break;
-                }
-                if  (new_mode != ts.dmod_mode || new_lsb != ts.cw_lsb )
-                {
-                    if(ts.flags1 & FLAGS1_CAT_IN_SANDBOX)			// if running in sandbox store active band
-                    {
-                        ts.cat_band_index = ts.band;
-                    }
-                    ts.cw_lsb = new_lsb;
-                    RadioManagement_SetDemodMode(new_mode);
-                    UiDriver_UpdateDisplayAfterParamChange();
-                }
-            }
-            break;
-            case FT817_PTT_ON:
-                resp[0] = cat_driver.cat_ptt_active?0xF0:0x00;
-                /* 0xF0 if PTT was already on */
-
-                if(RadioManagement_IsTxDisabled() == false)
-                {
-                    ts.ptt_req = true;
-                    cat_driver.cat_ptt_active = true;
-                }
-
-                bc = 1;
-                break;
-            case FT817_PWR_ON:
-                resp[0] = 0;
-                bc = 1;
-                break;
-            case FT817_TOGGLE_VFO:
-                UiDriver_ToggleVfoAB();
-                resp[0] = 0;
-                bc = 1;
-                break;
-            case FT817_SPLIT_ON:
-                UiDriver_SetSplitMode(true);
-                resp[0] = 0;
-                bc = 1;
-                break;
-            case FT817_SPLIT_OFF:
-                UiDriver_SetSplitMode(false);
-                resp[0] = 0;
-                bc = 1;
-                break;
-            case FT817_PTT_OFF:
-                resp[0] = cat_driver.cat_ptt_active?0x00:0xF0; /* 0xF0 if PTT was already off */
-                ts.ptt_req = false;
-                cat_driver.cat_ptt_active = false;
-                bc = 1;
-                break;
-            case FT817_A7: /* A7 */
-                resp[0]=0xA7;
-                resp[1]=0x02;
-                resp[2]=0x00;
-                resp[3]=0x04;
-                resp[4]=0x67;
-                resp[5]=0xD8;
-                resp[6]=0xBF;
-                resp[7]=0xD8;
-                resp[8]=0xBF;
-                bc = 9;
-                break;
-            case FT817_EEPROM_READ:
-                // we let all EEPROM read fail
-                // with a full simulation, we would return from 0 to 0x1925 two bytes: data@addr + data@(addr+1)
-                // and above 0x1925 only 1 byte.
-                resp[0]=0x00;
-                bc = 1;
-                break;
-            case FT817_EEPROM_WRITE:
-                resp[0] = 0;
-                bc = 1;
-                break;
-            case FT817_READ_TX_STATE:
-                if(RadioManagement_IsTxDisabled()||(ts.txrx_mode != TRX_MODE_TX))
-                {
-                    resp[0] = 0;
-                }
-                else
-                {
-                    resp[0] =((uint8_t)round(swrm.fwd_pwr)<<4)+(uint8_t)round(swrm.vswr_dampened);
-                }
-                bc = 1;
-                break;
-            case FT817_READ_RX_STATE: /* E7 */
-                resp[0] = (uint8_t)round(sm.s_count*0.5);	//S-Meter signal
-                bc = 1;
-                break;
-            case FT817_PTT_STATE:
-                // FT-817 responds 0xFF if not TX and 0x00 if TX
-                // This differs from KA7OEI description but has been verified
-                // with the real thing.
-                resp[0]=ts.txrx_mode == TRX_MODE_TX?0x00:0xFF;
-                if(RadioManagement_IsTxDisabled())
-                {
-                    resp[0] =0xFF;
-                }
-                bc = 1;
-                break;
-            case 255: /* FF sent out by HRD */
-                break;
-                // default:
-                // while (1);
+                RadioManagement_FmDevSet5khz(new_fmdev5khz);
+                ts.cw_lsb = new_cwlsb;
+                RadioManagement_SetDemodMode(new_mode);
+                UiDriver_UpdateDisplayAfterParamChange();
             }
         }
-        CatDriver_InterfaceBufferPutData(resp,bc);
-        /* Return data back */
+        break;
+        case FT817_PTT_ON:
+            resp[0] = cat_driver.cat_ptt_active?0xF0:0x00;
+            /* 0xF0 if PTT was already on */
+
+            if(RadioManagement_IsTxDisabled() == false)
+            {
+                ts.ptt_req = true;
+                cat_driver.cat_ptt_active = true;
+            }
+
+            bc = 1;
+            break;
+        case FT817_PWR_ON:
+            resp[0] = 0;
+            bc = 1;
+            break;
+        case FT817_TOGGLE_VFO:
+            UiDriver_ToggleVfoAB();
+            resp[0] = 0;
+            bc = 1;
+            break;
+        case FT817_SPLIT_ON:
+            UiDriver_SetSplitMode(true);
+            resp[0] = 0;
+            bc = 1;
+            break;
+        case FT817_SPLIT_OFF:
+            UiDriver_SetSplitMode(false);
+            resp[0] = 0;
+            bc = 1;
+            break;
+        case FT817_PTT_OFF:
+            resp[0] = cat_driver.cat_ptt_active?0x00:0xF0; /* 0xF0 if PTT was already off */
+            ts.ptt_req = false;
+            cat_driver.cat_ptt_active = false;
+            bc = 1;
+            break;
+        case FT817_A7: /* A7 */
+            resp[0]=0xA7;
+            resp[1]=0x02;
+            resp[2]=0x00;
+            resp[3]=0x04;
+            resp[4]=0x67;
+            resp[5]=0xD8;
+            resp[6]=0xBF;
+            resp[7]=0xD8;
+            resp[8]=0xBF;
+            bc = 9;
+            break;
+        case FT817_EEPROM_READ:
+            // we let all EEPROM read fail
+            // with a full simulation, we would return from 0 to 0x1925 two bytes: data@addr + data@(addr+1)
+            // and above 0x1925 only 1 byte.
+            resp[0]=0x00;
+            bc = 1;
+            break;
+        case FT817_EEPROM_WRITE:
+            resp[0] = 0;
+            bc = 1;
+            break;
+        case FT817_READ_TX_STATE:
+            if(RadioManagement_IsTxDisabled()||(ts.txrx_mode != TRX_MODE_TX))
+            {
+                resp[0] = 0;
+            }
+            else
+            {
+                resp[0] =((uint8_t)round(swrm.fwd_pwr)<<4)+(uint8_t)round(swrm.vswr_dampened);
+            }
+            bc = 1;
+            break;
+        case FT817_READ_RX_STATE: /* E7 */
+            resp[0] = (uint8_t)round(sm.s_count*0.5);   //S-Meter signal
+            bc = 1;
+            break;
+        case FT817_PTT_STATE:
+            // FT-817 responds 0xFF if not TX and 0x00 if TX
+            // This differs from KA7OEI description but has been verified
+            // with the real thing.
+            resp[0]=ts.txrx_mode == TRX_MODE_TX?0x00:0xFF;
+            if(RadioManagement_IsTxDisabled())
+            {
+                resp[0] =0xFF;
+            }
+            bc = 1;
+            break;
+        case 255: /* FF sent out by HRD */
+            break;
+            // default:
+            // while (1);
+        }
+    }
+    CatDriver_InterfaceBufferPutData(resp,bc);
+    /* Return data back */
+}
+
+void CatDriver_HandleProtocol()
+{
+
+    if (CatDriver_GetInterfaceState() == CAT_DISCONNECTED)
+    {
+        if (ft817.state != CAT_INIT)
+        {
+            cat_buffer_reset();
+            ft817.state = CAT_INIT;
+        }
+    }
+    else
+    {
+        switch(ft817.state)
+        {
+        case CAT_CLONEOUT:
+            CatDriver_HandleCloneOut();
+            break;
+        case CAT_CLONEIN:
+            CatDriver_HandleCloneIn();
+            break;
+        case CAT_INIT:
+            ft817.cloneout_state = CLONEOUT_INIT;
+            ft817.clonein_state = CLONEIN_INIT;
+            ft817.state = CAT_CAT;
+            /* no break */
+        case CAT_CAT:
+            CatDriver_HandleCommands();
+            break;
+        }
     }
 }

--- a/mchf-eclipse/drivers/ui/menu/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu.c
@@ -935,17 +935,14 @@ void UiMenu_UpdateItem(uint16_t select, uint16_t mode, int pos, int var, char* o
     case MENU_FM_DEV_MODE:  // Select +/- 2.5 or 5 kHz deviation on RX and TX
         if(ts.iq_freq_mode)
         {
-            temp_var_u8 = ts.flags2 & FLAGS2_FM_MODE_DEVIATION_5KHZ;
+            temp_var_u8 = RadioManagement_FmDevIs5khz();
             var_change = UiDriverMenuItemChangeEnableOnOff(var, mode, &temp_var_u8,0,options,&clr);
             if(var_change)
             {
-                if(temp_var_u8) // band up/down swap is to be enabled
-                    ts.flags2 |= FLAGS2_FM_MODE_DEVIATION_5KHZ;     // set 5 kHz mode
-                else            // band up/down swap is to be disabled
-                    ts.flags2 &= ~FLAGS2_FM_MODE_DEVIATION_5KHZ;        // set 2.5 kHz mode
+                RadioManagement_FmDevSet5khz(temp_var_u8 != 0); // band up/down swap is to be enabled
             }
 
-            if(ts.flags2 & FLAGS2_FM_MODE_DEVIATION_5KHZ)               // Check state of bit indication 2.5/5 kHz
+            if(RadioManagement_FmDevIs5khz())               // Check state of bit indication 2.5/5 kHz
             {
                 txt_ptr = "+-5k (Wide)";        // Bit is set - 5 kHz
             }

--- a/mchf-eclipse/drivers/ui/radio_management.c
+++ b/mchf-eclipse/drivers/ui/radio_management.c
@@ -1009,7 +1009,7 @@ uint32_t RadioManagement_NextDemodMode(uint32_t loc_mode, bool alternate_mode)
                 break;
             case DEMOD_FM:
                 // toggle between narrow and wide fm
-                ts.flags2 ^= FLAGS2_FM_MODE_DEVIATION_5KHZ;
+                RadioManagement_FmDevSet5khz( !RadioManagement_FmDevIs5khz() );
             }
             // if there is no explicit alternative mode
             // we return the original mode.
@@ -1311,5 +1311,28 @@ void RadioManagement_ToggleVfoAB()
     if(ts.dmod_mode != vfo[vfo_new].band[ts.band].decod_mode)
     {
         RadioManagement_SetDemodMode(vfo[vfo_new].band[ts.band].decod_mode);
+    }
+}
+
+/**
+ * @returns true == fm deviation 5khz, false == fm deviation = 2.5khz
+ */
+bool RadioManagement_FmDevIs5khz()
+{
+    return (ts.flags2 & FLAGS2_FM_MODE_DEVIATION_5KHZ) != 0;
+}
+
+/**
+ * @param is5khz true == fm deviation 5khz, false == fm deviation = 2.5khz
+ */
+void RadioManagement_FmDevSet5khz(bool is5khz)
+{
+    if (is5khz)
+    {
+        ts.flags2 |= FLAGS2_FM_MODE_DEVIATION_5KHZ;
+    }
+    else
+    {
+        ts.flags2 &= ~FLAGS2_FM_MODE_DEVIATION_5KHZ;
     }
 }

--- a/mchf-eclipse/drivers/ui/radio_management.h
+++ b/mchf-eclipse/drivers/ui/radio_management.h
@@ -200,10 +200,14 @@ bool RadioManagement_UsesBothSidebands(uint16_t dmod_mode);
 bool RadioManagement_IsPowerFactorReduce(uint32_t freq);
 void RadioManagement_ToggleVfoAB();
 
+bool RadioManagement_FmDevIs5khz();
+void RadioManagement_FmDevSet5khz(bool is5khz);
+
 inline void RadioManagement_ToggleVfoMem()
 {
     ts.vfo_mem_flag = ! ts.vfo_mem_flag;
 }
+
 
 
 #endif /* DRIVERS_UI_RADIO_MANAGEMENT_H_ */

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -1825,7 +1825,7 @@ void UiDriver_ShowMode()
     case DEMOD_FM:
 
 
-        txt = (ts.flags2 & FLAGS2_FM_MODE_DEVIATION_5KHZ)?"FM-W":"FM-N";
+        txt = RadioManagement_FmDevIs5khz() ? "FM-W" : "FM-N";
         {
             if(ts.txrx_mode == TRX_MODE_RX)
             {


### PR DESCRIPTION
…#876).

The FT817 protocol selection state machine now properly uses the states.
The FT817_MODE_SET command now sets narrow/normal deviation according to
mode, and sends a response back.
Part of this was refactoring the access to the Fm Deviation Mode setting.