### PR TITLE
Fixed No Bootloader Display on SPI Displays, fixed Eclipse problem

### DIFF
--- a/mchf-eclipse/.settings/ilg.gnuarmeclipse.managedbuild.cross.prefs
+++ b/mchf-eclipse/.settings/ilg.gnuarmeclipse.managedbuild.cross.prefs
@@ -1,2 +1,0 @@
-buildTools.path=/opt/gcc-arm-none-eabi-5_4-2016q3/bin
-eclipse.preferences.version=1

--- a/mchf-eclipse/src/bootloader/bootloader_main.c
+++ b/mchf-eclipse/src/bootloader/bootloader_main.c
@@ -73,6 +73,8 @@ static void BL_DisplayInit()
     GPIO_InitStructure.Pin = TP_CS;
 
     HAL_GPIO_Init(TP_CS_PIO, &GPIO_InitStructure);
+
+    GPIO_SetBits(TP_CS_PIO, TP_CS);
 #endif
 
     UiLcdHy28_Init();


### PR DESCRIPTION
- Eclipse: Removed problematic file from build settings
- actual set TP_CS to inactive in bootloader code