### PR TITLE
 More reliably power off and bootloader back to normal

### DIFF
--- a/mchf-eclipse/hardware/mchf_board.c
+++ b/mchf-eclipse/hardware/mchf_board.c
@@ -442,7 +442,7 @@ static void mchf_board_power_down_init(void)
     HAL_GPIO_Init(POWER_DOWN_PIO, &GPIO_InitStructure);
 
     // Set initial state - low to enable main regulator
-    POWER_DOWN_PIO->BSRR = POWER_DOWN  << 16U;
+    GPIO_ResetBits(POWER_DOWN_PIO,POWER_DOWN);
 }
 
 // Band control GPIOs setup
@@ -600,8 +600,22 @@ void MchfBoard_HandlePowerDown() {
  */
 void mchf_powerdown()
 {
-    POWER_DOWN_PIO->BSRR = POWER_DOWN;
-    for(;;) {}
+    // we set this to input and add a pullup config
+    // this seems to be more reliably handling power down
+    // on F7 by rising the voltage to high enough levels.
+    // simply setting the OUTPUT to high did not do the trick here
+    // worked on F4, though.
+
+    GPIO_InitTypeDef GPIO_InitStructure;
+
+    GPIO_InitStructure.Mode = GPIO_MODE_INPUT;
+    GPIO_InitStructure.Pull = GPIO_PULLUP;
+    GPIO_InitStructure.Speed = GPIO_SPEED_LOW;
+
+    GPIO_InitStructure.Pin = POWER_DOWN;
+    HAL_GPIO_Init(POWER_DOWN_PIO, &GPIO_InitStructure);
+
+    for(;;) { asm("nop"); }
 }
 //*----------------------------------------------------------------------------
 //* Function Name       : mchf_board_post_init

--- a/mchf-eclipse/src/bootloader/bootloader_main.c
+++ b/mchf-eclipse/src/bootloader/bootloader_main.c
@@ -319,7 +319,6 @@ void mchfBl_CheckAndGoForDfuBoot()
     if(*(uint32_t*)(SRAM2_BASE) == 0x99)
     {
         *(uint32_t*)(SRAM2_BASE) = 0;
-        mchfBl_PinOn(LEDRED);
 #ifndef STM32F7
         __HAL_REMAPMEMORY_SYSTEMFLASH();
 
@@ -341,8 +340,6 @@ void mchfBl_CheckAndGoForDfuBoot()
 
 #endif
         mchfBl_JumpToApplication(dfu_boot_start);
-        mchfBl_PinOn(LEDGREEN);
-        while (1) { asm("nop"); }
         // start the STM32Fxxx bootloader at address dfu_boot_start;
     }
 }


### PR DESCRIPTION
- We now use a different method for disabling power, this works on F7 as well
- Bootloader modifications in last commit reverted back to original code (was debug only)