### PR TITLE
Bootloader only fixes: Use new poweroff sequence, use dummy EXTI IRQ Handlers

### DIFF
--- a/mchf-eclipse/src/bootloader/bootloader_main.c
+++ b/mchf-eclipse/src/bootloader/bootloader_main.c
@@ -123,7 +123,7 @@ void BL_Idle_Application(void)
     if(mchfBl_ButtonGetState(BUTTON_POWER) == 0 && power_was_up == true)
     {
         // we only switch off, if power button was at least once seen as being released and pressed in the idle loop
-        mcHF_PowerHoldOff();
+        mcHF_PowerOff();
     }
     else
     {
@@ -192,7 +192,7 @@ int BL_MSC_Application(void)
             /* switch off if power button is pressed */
             if(mchfBl_ButtonGetState(BUTTON_POWER) == 0)
             {
-                mcHF_PowerHoldOff();
+                mcHF_PowerOff();
             }
         }
 
@@ -248,6 +248,7 @@ int bootloader_main()
 {
     /* initialization */
     BSP_Init();
+#if 0
     mcHF_PowerHoldOff();
 
 
@@ -258,7 +259,10 @@ int bootloader_main()
         // we wait for a longer time
         HAL_Delay(300);
     }
+#else
+#endif
     mcHF_PowerHoldOn();
+    HAL_Delay(50);
 
     if (mchfBl_ButtonGetState(BUTTON_BANDP) == 0)
     {

--- a/mchf-eclipse/src/bootloader/command.c
+++ b/mchf-eclipse/src/bootloader/command.c
@@ -31,7 +31,7 @@
 /* Private defines -----------------------------------------------------------*/
 #define UPLOAD_FILENAME            "0:mchfold.bin"
 #define DOWNLOAD_FILENAME          "0:mchf.bin"
-#define VERSION                    "Version: 3.2.4"
+#define VERSION                    "Version: 3.2.5"
 #define AUTHOR                     "Author: DF8OE"
 
 #define BUFFER_SIZE        ((uint16_t)512*64)
@@ -57,7 +57,7 @@ void Wait(int time)
     // we show the error message until user presses power...
     if(mchfBl_ButtonGetState(BUTTON_POWER) == 0)
     {
-        mcHF_PowerHoldOff();
+        mcHF_PowerOff();
     }
 }
 

--- a/mchf-eclipse/src/bootloader/mchf_boot_hw.c
+++ b/mchf-eclipse/src/bootloader/mchf_boot_hw.c
@@ -123,3 +123,18 @@ uint32_t mchfBl_ButtonGetState(Button_TypeDef Button)
 {
     return HAL_GPIO_ReadPin(BUTTON_PORT[Button], BUTTON_PIN[Button]);
 }
+
+void mcHF_PowerOff()
+{
+    GPIO_InitTypeDef GPIO_InitStructure;
+
+    GPIO_InitStructure.Mode = GPIO_MODE_INPUT;
+    GPIO_InitStructure.Pull = GPIO_PULLUP;
+    GPIO_InitStructure.Pin = GPIO_PIN[PWR_HOLD];
+    GPIO_InitStructure.Speed = GPIO_SPEED_FAST;
+
+    HAL_GPIO_Init(GPIO_PORT[PWR_HOLD], &GPIO_InitStructure);
+
+    while(1) { asm("nop"); }
+    // never reached
+}

--- a/mchf-eclipse/src/bootloader/mchf_boot_hw.c
+++ b/mchf-eclipse/src/bootloader/mchf_boot_hw.c
@@ -138,3 +138,31 @@ void mcHF_PowerOff()
     while(1) { asm("nop"); }
     // never reached
 }
+
+// These interrupt handlers match the one found in the main firmware but
+// do nothing, since we don't want to handle PTT / Paddle interrupts etc.
+// FIXME: This is a kind of a hack to prevent problematic hardware (protection diodes)
+// from preventing boot-up. Better fix the hardware.
+
+#ifdef STM32F7
+/**
+* @brief This function handles EXTI line0 interrupt.
+*/
+void EXTI0_IRQHandler(void)
+{
+}
+
+/**
+* @brief This function handles EXTI line1 interrupt.
+*/
+void EXTI1_IRQHandler(void)
+{
+}
+
+/**
+* @brief This function handles EXTI line[15:10] interrupts.
+*/
+void EXTI15_10_IRQHandler(void)
+{
+}
+#endif

--- a/mchf-eclipse/src/bootloader/mchf_boot_hw.h
+++ b/mchf-eclipse/src/bootloader/mchf_boot_hw.h
@@ -72,6 +72,11 @@ void mchfBl_PinToggle(Led_TypeDef Led);
 void mchfBl_ButtonInit(Button_TypeDef Button, ButtonMode_TypeDef Button_Mode);
 uint32_t mchfBl_ButtonGetState(Button_TypeDef Button);
 
+void mcHF_PowerOff();
+
+/*
+ * Just toggles the PowerHold Pin, but does not stop execution
+ */
 inline void mcHF_PowerHoldOff()
 {
     mchfBl_PinOn(PWR_HOLD);


### PR DESCRIPTION
Changed bootloader code to use proper poweroff sequence

PowerOff is identical to firmware poweroff (but not yet shared code).
May cause trouble if the MCU resets during poweroff.
EXPERIMENTAL

 "Fixing" F7 Z-Diode bootloader issue

Some z-diodes on Paddle & PTT input cause trouble on the F7
by sporadically issuing interrupts due to (unintended) detection of falling edge.
We keep the interrupts on but ignore them now (as opposed to enter
the default endless loop handler). The change applies to  F7 only, F4 uses the configured handlers, which do nothing already (in the bootloader, firmware is different).
