### PR TITLE
Properly configured bootloader to use limited font

### DIFF
--- a/mchf-eclipse/drivers/ui/lcd/ui_lcd_hy28_fonts.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_lcd_hy28_fonts.c
@@ -1258,7 +1258,7 @@ const sFONT GL_Font8x12_bold =
 // only upto 0x7F
 const sFONT GL_Font8x12_bold_short =
 {
-    GL_ASCII8x12_bold_Table,
+    GL_ASCII8x12_bold_short_Table,
     8,  /* Width */
     12, /* Height */
 };


### PR DESCRIPTION
Font has no special characters above 0x7f, reduced font flash memory usage by half.