### PR TITLE
Added 500 Hz tuning step

### DIFF
--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -241,10 +241,11 @@ const ulong tune_steps[T_STEP_MAX_STEPS] =
     T_STEP_1HZ,
     T_STEP_10HZ,
     T_STEP_100HZ,
+    T_STEP_500HZ,
     T_STEP_1KHZ,
     T_STEP_5KHZ,
     T_STEP_9KHZ,
-	T_STEP_10KHZ,
+    T_STEP_10KHZ,
     T_STEP_100KHZ,
     T_STEP_1MHZ,
     T_STEP_10MHZ

--- a/mchf-eclipse/drivers/ui/ui_driver.h
+++ b/mchf-eclipse/drivers/ui/ui_driver.h
@@ -36,6 +36,7 @@ enum UpdateFrequencyMode_t
 #define 	T_STEP_1HZ					1
 #define 	T_STEP_10HZ					10
 #define 	T_STEP_100HZ					100
+#define 	T_STEP_500HZ					500
 #define 	T_STEP_1KHZ					1000
 #define 	T_STEP_5KHZ					5000
 #define 	T_STEP_9KHZ					9000
@@ -49,6 +50,7 @@ enum
     T_STEP_1HZ_IDX = 0,
     T_STEP_10HZ_IDX,
     T_STEP_100HZ_IDX,
+    T_STEP_500HZ_IDX,
     T_STEP_1KHZ_IDX,
     T_STEP_5KHZ_IDX,
     T_STEP_9KHZ_IDX,


### PR DESCRIPTION
As most stations try to transmit on a round frequency number of 1.0 kHz or 0.5 kHz I added the 500 Hz frequency step. It's also a nice compromise in speed between 1 kHz and 100 Hz tuning.