### PR TITLE
Splash Screen refactoring (Test required!)

### DIFF
--- a/mchf-eclipse/drivers/ui/ui_configuration.c
+++ b/mchf-eclipse/drivers/ui/ui_configuration.c
@@ -56,6 +56,7 @@ const ConfigEntryDescriptor ConfigEntryInfo[] =
     { ConfigEntry_UInt8, EEPROM_TX_POWER_LEVEL,&ts.power_level,PA_LEVEL_DEFAULT,0,PA_LEVEL_TUNE_KEEP_CURRENT},
     { ConfigEntry_UInt8, EEPROM_CW_KEYER_SPEED,&ts.cw_keyer_speed,CW_KEYER_SPEED_DEFAULT,CW_KEYER_SPEED_MIN, CW_KEYER_SPEED_MAX},
     { ConfigEntry_UInt8, EEPROM_CW_KEYER_MODE,&ts.cw_keyer_mode,CW_KEYER_MODE_IAM_B, 0, CW_KEYER_MAX_MODE},
+    { ConfigEntry_UInt8, EEPROM_CW_KEYER_WEIGHT,&ts.cw_keyer_weight,CW_KEYER_WEIGHT_DEFAULT, CW_KEYER_WEIGHT_MIN, CW_KEYER_WEIGHT_MAX},
     { ConfigEntry_UInt8, EEPROM_CW_SIDETONE_GAIN,&ts.cw_sidetone_gain,DEFAULT_SIDETONE_GAIN,0, SIDETONE_MAX_GAIN},
     { ConfigEntry_Int32_16, EEPROM_FREQ_CAL,&ts.freq_cal,0,MIN_FREQ_CAL,MAX_FREQ_CAL},
     { ConfigEntry_UInt8, EEPROM_AGC_MODE,&ts.agc_mode,AGC_DEFAULT,0,AGC_MAX_MODE},

--- a/mchf-eclipse/drivers/ui/ui_driver.h
+++ b/mchf-eclipse/drivers/ui/ui_driver.h
@@ -286,10 +286,15 @@ void	UiDriver_LcdBlankingStartTimer(void);
 void	UiDriver_ShowDebugText(const char*);
 void 	UiDriver_ChangeTuningStep(uchar is_up);
 void	UiDriver_UpdateDisplayAfterParamChange();
-void    UiDriver_ShowStartUpScreen(uint32_t hold_time);
+
+void    UiDriver_StartUpScreenInit();
+void    UiDriver_StartUpScreenFinish();
+
 void    UiDriver_DoCrossCheck(char cross[],char* xt_corr, char* yt_corr);
 void    UiDriver_ToggleVfoAB();
 void    UiDriver_SetSplitMode(bool mode_active);
+
+void UiDriver_StartupScreen_LogIfProblem(bool isError, const char* txt);
 
 void    UiDriver_BacklightDimHandler();
 //

--- a/mchf-eclipse/hardware/uhsdr_board.c
+++ b/mchf-eclipse/hardware/uhsdr_board.c
@@ -497,7 +497,7 @@ void mchf_board_touchscreen_init()
     GPIO_SetBits(TP_CS_PIO, TP_CS);
 }
 
-void mchf_board_init(void)
+void mchf_board_init_minimal()
 {
     // Enable clock on all ports
     __GPIOA_CLK_ENABLE();
@@ -509,9 +509,16 @@ void mchf_board_init(void)
     // LED init
     mchf_board_led_init();
     MchfBoard_RedLed(LED_STATE_ON);
-
     // Power up hardware
     mchf_board_power_down_init();
+
+    // LCD Init
+    UiLcdHy28_Init();
+}
+
+void mchf_board_init_full()
+{
+
 
     // Filter control lines
     mchf_board_band_cntr_init();
@@ -534,11 +541,6 @@ void mchf_board_init(void)
     // Codec control interface
     mchf_hw_i2c2_init();
 
-    // LCD Init
-    // TODO: remove cast, once volatile is gone for DeviceCode
-    UiLcdHy28_Init();
-    // we could now implement some error strategy if no display is present
-    // i.e. 0 is returned
 
 #ifdef STM32F4
     // on a STM32F4 we can have the internal RTC only if there is an SPI display.

--- a/mchf-eclipse/hardware/uhsdr_board.h
+++ b/mchf-eclipse/hardware/uhsdr_board.h
@@ -1113,8 +1113,9 @@ void MchfBoard_HandlePowerDown();
 
 void MchfBoard_SelectLpfBpf(uint8_t group);
 
-void mchf_board_init(void);
-void mchf_board_post_init(void);
+void mchf_board_init_minimal();
+void mchf_board_init_full();
+void mchf_board_post_init();
 void mchf_reboot();
 void mchf_powerdown();
 

--- a/mchf-eclipse/src/uhsdr_main.c
+++ b/mchf-eclipse/src/uhsdr_main.c
@@ -443,9 +443,17 @@ int mchfMain(void)
 #endif
 
     // HW init
-    mchf_board_init();
-    MchfBoard_GreenLed(LED_STATE_ON);
+    mchf_board_init_minimal();
+    // Show logo & HW Info
+    UiDriver_StartUpScreenInit(2000);
 
+    if (ts.display != DISPLAY_NONE)
+    {
+        // TODO: Better indication of non-detected display
+        MchfBoard_GreenLed(LED_STATE_ON);
+    }
+
+    mchf_board_init_full();
 
     // MchfRtc_FullReset();
     ConfigStorage_Init();
@@ -456,8 +464,6 @@ int mchfMain(void)
     UiLcdHy28_TouchscreenInit(false);
 
 
-    // Show logo & HW Info
-    UiDriver_ShowStartUpScreen(2000);
 
 
     // Extra init
@@ -494,6 +500,9 @@ int mchfMain(void)
     // Audio HW init
     AudioDriver_Init();
 
+    UiDriver_StartupScreen_LogIfProblem(ts.codec_present == false,
+            "Audiocodec WM8371 NOT detected!");
+
     AudioManagement_CalcSubaudibleGenFreq();		// load/set current FM subaudible tone settings for generation
     AudioManagement_CalcSubaudibleDetFreq();		// load/set current FM subaudible tone settings	for detection
     AudioManagement_LoadToneBurstMode();	// load/set tone burst frequency
@@ -501,13 +510,14 @@ int mchfMain(void)
 
     AudioFilter_SetDefaultMemories();
 
-    UiDriver_UpdateDisplayAfterParamChange();
 
     ts.rx_gain[RX_AUDIO_SPKR].value_old = 0;		// Force update of volume control
 
 #ifdef USE_FREEDV
     FreeDV_mcHF_init();
 #endif
+
+    UiDriver_StartUpScreenFinish(2000);
 
     MchfBoard_RedLed(LED_STATE_OFF);
     // Transceiver main loop

--- a/mchf-eclipse/support/OVI40-FW.launch
+++ b/mchf-eclipse/support/OVI40-FW.launch
@@ -9,7 +9,7 @@
 <booleanAttribute key="ilg.gnuarmeclipse.debug.gdbjtag.openocd.doGdbServerAllocateTelnetConsole" value="false"/>
 <booleanAttribute key="ilg.gnuarmeclipse.debug.gdbjtag.openocd.doSecondReset" value="true"/>
 <booleanAttribute key="ilg.gnuarmeclipse.debug.gdbjtag.openocd.doStartGdbServer" value="true"/>
-<booleanAttribute key="ilg.gnuarmeclipse.debug.gdbjtag.openocd.enableSemihosting" value="true"/>
+<booleanAttribute key="ilg.gnuarmeclipse.debug.gdbjtag.openocd.enableSemihosting" value="false"/>
 <stringAttribute key="ilg.gnuarmeclipse.debug.gdbjtag.openocd.firstResetType" value="init"/>
 <stringAttribute key="ilg.gnuarmeclipse.debug.gdbjtag.openocd.gdbClientOtherCommands" value="set mem inaccessible-by-default off"/>
 <stringAttribute key="ilg.gnuarmeclipse.debug.gdbjtag.openocd.gdbClientOtherOptions" value=""/>


### PR DESCRIPTION
The display is now initialized as early as possible.
A new "logging" function can be used during the boot phase to report
issues which in turn will be shown on the Splash screen.
At the end of the boot phase, the "logging" phase is finished
and normal operation is started.
In addition a "no display found" condition is reported (no green led during boot).
Since a screen is not necessary for operating the mcHF via CAT,
normal operation will be enabled despite the display being inaccessible.

PLEASE TEST IF SCREEN INIT WORKS on F4 SPI and PARALLEL.