### PR TITLE
Refactored config storage a little more

### DIFF
--- a/mchf-eclipse/drivers/ui/ui_configuration.c
+++ b/mchf-eclipse/drivers/ui/ui_configuration.c
@@ -670,7 +670,7 @@ uint16_t UiConfiguration_SaveEepromValues(void)
         // because we then can bulk write the data into the I2C later.
         // we don't do this for flash, since we cannot gain anything here.
 
-        if(ts.ser_eeprom_in_use == SER_EEPROM_IN_USE_I2C)
+        if(ts.configstore_in_use == CONFIGSTORE_IN_USE_I2C)
         {
             ConfigStorage_CopySerial2RAMCache();
         }
@@ -728,7 +728,7 @@ uint16_t UiConfiguration_SaveEepromValues(void)
             retval = UiWriteSettingEEPROM_Filter();
         }
 
-        if(retval == HAL_OK && ts.ser_eeprom_in_use == SER_EEPROM_IN_USE_RAMCACHE)
+        if(retval == HAL_OK && ts.configstore_in_use == CONFIGSTORE_IN_USE_RAMCACHE)
         {
             retval = ConfigStorage_CopyRAMCache2Serial();
             // write ram cache to EEPROM and switch back to I2C EEPROM use

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -4970,17 +4970,16 @@ static bool UiDriver_SaveConfiguration()
     const char* txp;
     uint16_t txc;
 
-    switch (ts.ser_eeprom_in_use)
+    switch (ts.configstore_in_use)
     {
-    case SER_EEPROM_IN_USE_NO:
-    case SER_EEPROM_IN_USE_TOO_SMALL:
+    case CONFIGSTORE_IN_USE_FLASH:
         txp = "Saving settings to Flash Memory";
         break;
-    case SER_EEPROM_IN_USE_I2C:
+    case CONFIGSTORE_IN_USE_I2C:
         txp = "Saving settings to I2C EEPROM";
         break;
     default:
-        txp = "Detected I2C problems: Not saving";
+        txp = "Detected problems: Not saving";
         savedConfiguration = false;
     }
     UiLcdHy28_PrintTextCentered(60,176,260,txp,Blue,Black,0);

--- a/mchf-eclipse/hardware/uhsdr_board.h
+++ b/mchf-eclipse/hardware/uhsdr_board.h
@@ -132,12 +132,12 @@ extern const ButtonMap  bm_sets[2][BUTTON_NUM];
 
 struct mchf_waterfall
 {
-    uchar	color_scheme;			// stores waterfall color scheme
-    uchar	vert_step_size;		// vertical step size in waterfall mode
+    uint8_t	color_scheme;			// stores waterfall color scheme
+    uint8_t	vert_step_size;		// vertical step size in waterfall mode
     int32_t	offset;			// offset for waterfall display
     ulong	contrast;			// contrast setting for waterfall display
-	uchar	speed;	// speed of update of the waterfall
-	uchar	nosig_adjust;			// Adjustment for no signal adjustment conditions for waterfall
+	uint8_t	speed;	// speed of update of the waterfall
+	uint8_t	nosig_adjust;			// Adjustment for no signal adjustment conditions for waterfall
 };
 
 // -----------------------------------------------------------------------------
@@ -516,11 +516,11 @@ typedef struct TransceiverState
 #define DEFAULT_RF_CODEC_GAIN_VAL   9       // Default RF gain setting (9 = AUTO mode)
 #define RF_CODEC_GAIN_AUTO   9       // Default RF gain setting (9 = AUTO mode)
 
-    uchar	rf_codec_gain;		// gain for codec (A/D converter) in receive mode
-    uchar 	nb_setting;
-    uchar	cw_sidetone_gain;
-    uchar	pa_bias;
-    uchar	pa_cw_bias;
+    uint8_t	rf_codec_gain;		// gain for codec (A/D converter) in receive mode
+    uint8_t 	nb_setting;
+    uint8_t	cw_sidetone_gain;
+    uint8_t	pa_bias;
+    uint8_t	pa_cw_bias;
 
     // timer for muting of input into signal processing chains (TX/RX)
     uint16_t    audio_processor_input_mute_counter;
@@ -552,19 +552,19 @@ typedef struct TransceiverState
     //uchar	calib_mode;
 
     // Transceiver menu mode variables
-    uchar	menu_mode;		// TRUE if in menu mode
+    uint8_t	menu_mode;		// TRUE if in menu mode
     int16_t	menu_item;		// Used to indicate specific menu item
     int		menu_var;		// Used to change specific menu item
     bool	menu_var_changed;	// TRUE if something changed in a menu and that an EEPROM save should be done!
 
     // Ham band public flag
     // index of bands table in Flash
-    uchar 	band;
+    uint8_t 	band;
     bool	rx_temp_mute;
-    uchar	filter_band;		// filter selection band:  1= 80, 2= 60/40, 3=30/20, 4=17/15/12/10 - used for selection of power detector coefficient selection.
+    uint8_t	filter_band;		// filter selection band:  1= 80, 2= 60/40, 3=30/20, 4=17/15/12/10 - used for selection of power detector coefficient selection.
     //
     // Receive/Transmit public flag
-    uchar 	txrx_mode;
+    uint8_t 	txrx_mode;
 
     // TX/RX IRQ lock, to prevent reentrance
     //uchar	txrx_lock;
@@ -573,14 +573,14 @@ typedef struct TransceiverState
 
 
     // Demodulator mode public flag
-    uchar 	dmod_mode;
+    uint8_t 	dmod_mode;
 
 
-    uchar 	enc_one_mode;
-    uchar 	enc_two_mode;
-    uchar 	enc_thr_mode;
+    uint8_t 	enc_one_mode;
+    uint8_t 	enc_two_mode;
+    uint8_t 	enc_thr_mode;
 
-    uchar	tx_meter_mode;				// meter mode
+    uint8_t	tx_meter_mode;				// meter mode
 
     // Audio filter ID
     // uchar	filter_id;
@@ -594,8 +594,8 @@ typedef struct TransceiverState
     uint16_t  filter_path;
     //
 
-    uchar	filter_cw_wide_disable;		// TRUE if wide filters are disabled in CW mode
-    uchar	filter_ssb_narrow_disable;	// TRUE if narrow filters are disabled in SSB modes
+    uint8_t	filter_cw_wide_disable;		// TRUE if wide filters are disabled in CW mode
+    uint8_t	filter_ssb_narrow_disable;	// TRUE if narrow filters are disabled in SSB modes
     //
     uint16_t	demod_mode_disable;			// TRUE if AM mode is to be disabled
 #define DEMOD_AM_DISABLE    (0x0001)
@@ -606,18 +606,18 @@ typedef struct TransceiverState
 
 
     // AGC mode
-    uchar	agc_mode;
-    uchar	agc_custom_decay;
+    uint8_t	agc_mode;
+    uint8_t	agc_custom_decay;
 
-    uchar	max_rf_gain;
+    uint8_t	max_rf_gain;
 
     // Eth to UI driver requests flag
-    uchar	LcdRefreshReq;
+    uint8_t	LcdRefreshReq;
 
     // Eth to UI public flag
-    uchar	new_band;
-    uchar	new_mode;
-    uchar	new_digi_mode;
+    uint8_t	new_band;
+    uint8_t	new_mode;
+    uint8_t	new_digi_mode;
 
     // Current CW mode
     uint8_t	cw_keyer_mode;
@@ -640,39 +640,39 @@ typedef struct TransceiverState
 
     ulong	audio_spkr_unmute_delay_count;
 
-    uchar	power_level;
+    uint8_t	power_level;
 
-    uchar 	tx_audio_source;
+    uint8_t 	tx_audio_source;
     ulong	tx_mic_gain_mult;
-    uchar	tx_gain[TX_AUDIO_NUM];
+    uint8_t	tx_gain[TX_AUDIO_NUM];
     int16_t	tx_comp_level;			// Used to hold compression level which is used to calculate other values for compression.  0 = manual.
 
     // Global tuning flag - in every demod mode
-    uchar 	tune;
+    uint8_t 	tune;
 
     uint16_t ee_init_stat;
 
-    uchar	powering_down;
+    uint8_t	powering_down;
 
     // Spectrum Scope config - placed here since "sd." not defined at time of init
 
-    uchar	scope_speed;	// update rate for spectrum scope
+    uint8_t	scope_speed;	// update rate for spectrum scope
 
-    uchar	spectrum_filter;	// strength of filter in spectrum scope
+    uint8_t	spectrum_filter;	// strength of filter in spectrum scope
 
-    uchar	scope_trace_colour;	// color of spectrum scope trace;
-    uchar	scope_grid_colour;	// saved color of spectrum scope grid;
+    uint8_t	scope_trace_colour;	// color of spectrum scope trace;
+    uint8_t	scope_grid_colour;	// saved color of spectrum scope grid;
     ulong	scope_grid_colour_active;	// active color of spectrum scope grid;
-    uchar	spectrum_centre_line_colour;	// color of center line of scope grid
+    uint8_t	spectrum_centre_line_colour;	// color of center line of scope grid
     ulong	scope_centre_grid_colour_active;	// active colour of the spectrum scope center grid line
-    uchar	spectrum_freqscale_colour;	// color of spectrum scope frequency scale
-    uchar	scope_rescale_rate;	// rescale rate on the 'scope
-    uchar	scope_agc_rate;		// agc rate on the 'scope
-    uchar	spectrum_db_scale;	// db/Division scale setting on spectrum scope
+    uint8_t	spectrum_freqscale_colour;	// color of spectrum scope frequency scale
+    uint8_t	scope_rescale_rate;	// rescale rate on the 'scope
+    uint8_t	scope_agc_rate;		// agc rate on the 'scope
+    uint8_t	spectrum_db_scale;	// db/Division scale setting on spectrum scope
     //
     bool	radio_config_menu_enable;	// TRUE if radio configuration menu is to be visible
     //
-    uchar	xverter_mode;		// TRUE if transverter mode active
+    uint8_t	xverter_mode;		// TRUE if transverter mode active
     ulong	xverter_offset;		// frequency offset for transverter (added to frequency display)
 
     bool	refresh_freq_disp;		// TRUE if frequency display display is to be refreshed
@@ -681,7 +681,7 @@ typedef struct TransceiverState
     //
 #define ADJ_5W 0
 #define ADJ_FULL_POWER 1
-    uchar	pwr_adj[2][MAX_BAND_NUM];
+    uint8_t	pwr_adj[2][MAX_BAND_NUM];
     //
     ulong	alc_decay;					// adjustable ALC release time - EEPROM read/write version
     ulong	alc_decay_var;				// adjustable ALC release time - working variable version
@@ -689,7 +689,7 @@ typedef struct TransceiverState
     ulong	alc_tx_postfilt_gain_var;	// amount of gain after the TX audio filtering - working variable version
     //
 #define FREQ_STEP_SWAP_BTN	0xf0
-    uchar	freq_step_config;			// configuration of step size (line, step button reversal) - setting any of the 4 upper bits -> step button switch, any of the lower bits -> frequency marker display enabled
+    uint8_t	freq_step_config;			// configuration of step size (line, step button reversal) - setting any of the 4 upper bits -> step button switch, any of the lower bits -> frequency marker display enabled
 
 #define DSP_NR_ENABLE 	  		0x01	// DSP NR mode is on (| 1)
 #define DSP_NR_POSTAGC_ENABLE 	0x02	// DSP NR is to occur post AGC (| 2)
@@ -698,25 +698,25 @@ typedef struct TransceiverState
 #define DSP_MNOTCH_ENABLE		0x10	// Manual Notch enabled
 #define DSP_MPEAK_ENABLE		0x20	// Manual Peak enabled
 
-    uchar	dsp_active;					// Used to hold various aspects of DSP mode selection
-    uchar	dsp_mode;					// holds the mode chosen in the DSP
-	uchar	temp_nb;
-    uchar 	digital_mode;				// holds actual digital mode
-    uchar	dsp_active_toggle;			// holder used on the press-hold of button G2 to "remember" the previous setting
-    uchar	dsp_nr_strength;			// "Strength" of DSP Noise reduction - to be converted to "Mu" factor
+    uint8_t	dsp_active;					// Used to hold various aspects of DSP mode selection
+    uint8_t	dsp_mode;					// holds the mode chosen in the DSP
+	uint8_t	temp_nb;
+    uint8_t 	digital_mode;				// holds actual digital mode
+    uint8_t	dsp_active_toggle;			// holder used on the press-hold of button G2 to "remember" the previous setting
+    uint8_t	dsp_nr_strength;			// "Strength" of DSP Noise reduction - to be converted to "Mu" factor
     ulong	dsp_nr_delaybuf_len;		// size of DSP noise reduction delay buffer
-    uchar	dsp_nr_numtaps;				// Number of FFT taps on the DSP Noise reduction
-    uchar	dsp_notch_numtaps;
-    uchar	dsp_notch_mu;				// mu adjust of notch DSP LMS
+    uint8_t	dsp_nr_numtaps;				// Number of FFT taps on the DSP Noise reduction
+    uint8_t	dsp_notch_numtaps;
+    uint8_t	dsp_notch_mu;				// mu adjust of notch DSP LMS
     uint8_t	dsp_notch_delaybuf_len;		// size of DSP notch delay buffer
     uint8_t dsp_inhibit;				// if != 0, DSP (NR, Notch) functions are inhibited.  Used during power-up and switching
 
 
-    uchar	lcd_backlight_brightness;	// LCD backlight brightness, 0-3:  0 = full, 3 = dimmest
+    uint8_t	lcd_backlight_brightness;	// LCD backlight brightness, 0-3:  0 = full, 3 = dimmest
 
 #define LCD_BLANKING_ENABLE 0x80
 #define LCD_BLANKING_TIMEMASK 0x0f
-    uchar	lcd_backlight_blanking;		// for controlling backlight auto-off control
+    uint8_t	lcd_backlight_blanking;		// for controlling backlight auto-off control
 
 
 
@@ -731,10 +731,10 @@ typedef struct TransceiverState
 
 
 
-    uchar   low_power_config;        // for voltage colours and auto shutdown
+    uint8_t   low_power_config;        // for voltage colours and auto shutdown
     ulong   low_power_shutdown_time;    // earliest time when auto shutdown can be executed
     //
-    uchar	tune_step;					// Used for press-and-hold tune step adjustment
+    uint8_t	tune_step;					// Used for press-and-hold tune step adjustment
     ulong	tune_step_idx_holder;		// used to hold the original step size index during the press-and-hold
     //
     bool	frequency_lock;				// TRUE if frequency knob is locked
@@ -744,7 +744,7 @@ typedef struct TransceiverState
 #define TX_DISABLE_ALWAYS       1
 #define TX_DISABLE_USER         2
 #define TX_DISABLE_OUTOFRANGE	4
-    uchar	tx_disable;		// >0 if no transmit permitted, use RadioManagement_IsTxDisabled() to get boolean
+    uint8_t	tx_disable;		// >0 if no transmit permitted, use RadioManagement_IsTxDisabled() to get boolean
 
 
     uint16_t	flags1;					// Used to hold individual status flags, stored in EEPROM location "EEPROM_FLAGS1"
@@ -789,11 +789,11 @@ typedef struct TransceiverState
     uint16_t	version_number_minor;		// version number - minor - used to hold version number and detect change
     uint16_t	version_number_major;		// version number - build - used to hold version number and detect change
     uint16_t	version_number_release;		// version number - release - used to hold version number and detect change
-    uchar	nb_agc_time_const;			// used to calculate the AGC time constant
-    uchar	cw_offset_mode;				// CW offset mode (USB, LSB, etc.)
+    uint8_t	nb_agc_time_const;			// used to calculate the AGC time constant
+    uint8_t	cw_offset_mode;				// CW offset mode (USB, LSB, etc.)
     bool	cw_lsb;					// flag used to indicate that CW is to operate in LSB when TRUE
-    uchar	iq_freq_mode;				// used to set/configure the I/Q frequency/conversion mode
-    uchar	lsb_usb_auto_select;			// holds setting of LSB/USB auto-select above/below 10 MHz
+    uint8_t	iq_freq_mode;				// used to set/configure the I/Q frequency/conversion mode
+    uint8_t	lsb_usb_auto_select;			// holds setting of LSB/USB auto-select above/below 10 MHz
     bool	conv_sine_flag;				// FALSE until the sine tables for the frequency conversion have been built (normally zero, force 0 to rebuild)
     ulong	last_tuning;				// this is a timer used to prevent too fast tuning per second
     ulong	lcd_blanking_time;			// this holds the system time after which the LCD is blanked - if blanking is enabled
@@ -807,55 +807,53 @@ typedef struct TransceiverState
     // LSB+7 (0x80): 0 = normal mode, 1 = Split mode (e.g. LSB=0:  RX=A, TX=B;  LSB=1:  RX=B, TX=A)
     ulong	voltmeter_calibrate;			// used to calibrate the voltmeter
 	struct mchf_waterfall waterfall;
-    uchar	spectrum_scheduler;		// timer for scheduling the next update of the spectrum scope update, updated at DMA rate
-    uchar	spectrum_scope_nosig_adjust;		// Adjustment for no signal adjustment conditions for spectrum scope    
-    uchar	spectrum_size;				// size of waterfall display (and other parameters) - size setting is in lower nybble, upper nybble/byte reserved
-    uchar	fft_window_type;			// type of windowing function applied to scope/waterfall.  At the moment, only lower 4 bits are used - upper 4 bits are reserved
+    uint8_t	spectrum_scheduler;		// timer for scheduling the next update of the spectrum scope update, updated at DMA rate
+    uint8_t	spectrum_scope_nosig_adjust;		// Adjustment for no signal adjustment conditions for spectrum scope
+    uint8_t	spectrum_size;				// size of waterfall display (and other parameters) - size setting is in lower nybble, upper nybble/byte reserved
+    uint8_t	fft_window_type;			// type of windowing function applied to scope/waterfall.  At the moment, only lower 4 bits are used - upper 4 bits are reserved
     bool	dvmode;					// TRUE if alternate (stripped-down) RX and TX functions (USB-only) are to be used
-    uchar	txrx_switch_audio_muting_timing;			// timing value used for muting TX audio when keying PTT to suppress "click" or "thump"
+    uint8_t	txrx_switch_audio_muting_timing;			// timing value used for muting TX audio when keying PTT to suppress "click" or "thump"
     uint32_t	audio_dac_muting_timer;			// timer value used for muting TX audio when keying PTT to suppress "click" or "thump"
     uint32_t audio_dac_muting_buffer_count; // the audio dac out will be muted for number of buffers
-    uchar	filter_disp_colour;			// used to hold the current color of the line that indicates the filter passband/bandwidth
+    uint8_t	filter_disp_colour;			// used to hold the current color of the line that indicates the filter passband/bandwidth
     bool	audio_dac_muting_flag;			// when TRUE, audio is to be muted after PTT/keyup
     bool	vfo_mem_flag;				// when TRUE, memory mode is enabled
     bool	mem_disp;				// when TRUE, memory display is enabled
     bool	load_eeprom_defaults;			// when TRUE, load EEPROM defaults into RAM when "UiDriverLoadEepromValues()" is called - MUST be saved by user IF these are to take effect!
     ulong	fm_subaudible_tone_gen_select;		// lookup ("tone number") used to index the table tone generation (0 corresponds to "tone disabled")
-    uchar	fm_tone_burst_mode;			// this is the setting for the tone burst generator
+    uint8_t	fm_tone_burst_mode;			// this is the setting for the tone burst generator
     ulong	fm_tone_burst_timing;			// this is used to time/schedule the duration of a tone burst
-    uchar	fm_sql_threshold;			// squelch threshold "dial" setting
+    uint8_t	fm_sql_threshold;			// squelch threshold "dial" setting
 //	uchar	fm_rx_bandwidth;			// bandwidth setting for FM reception
     ulong	fm_subaudible_tone_det_select;		// lookup ("tone number") used to index the table for tone detection (0 corresponds to "disabled")
     bool	beep_active;				// TRUE if beep is active
     ulong	beep_frequency;				// beep frequency, in Hz
     ulong	beep_timing;				// used to time/schedule the duration of a keyboard beep
-    uchar	beep_loudness;				// loudness of the keyboard/CW sidetone test beep
+    uint8_t	beep_loudness;				// loudness of the keyboard/CW sidetone test beep
     bool	load_freq_mode_defaults;		// when TRUE, load frequency/mode defaults into RAM when "UiDriverLoadEepromValues()" is called - MUST be saved by user IF these are to take effect!
 
 #define EEPROM_SER_NONE 0
 #define EEPROM_SER_WRONG_SIG 1
 #define EEPROM_SER_UNKNOWN 2
-    uchar	ser_eeprom_type;			// serial eeprom type
+    uint8_t	ser_eeprom_type;			// serial eeprom type
 
-#define SER_EEPROM_IN_USE_I2C         0x00
-#define SER_EEPROM_IN_USE_ERROR       0x05
-#define SER_EEPROM_IN_USE_TOO_SMALL   0x10
-// #define SER_EEPROM_IN_USE_DONT_SAVE   0x20
-#define SER_EEPROM_IN_USE_RAMCACHE    0xAA
-#define SER_EEPROM_IN_USE_NO          0xFF
+#define CONFIGSTORE_IN_USE_I2C         0x00
+#define CONFIGSTORE_IN_USE_ERROR       0x05
+#define CONFIGSTORE_IN_USE_RAMCACHE    0xAA
+#define CONFIGSTORE_IN_USE_FLASH       0xFF
 
-    uchar	ser_eeprom_in_use;	    // use to determine non-volatile memory configuration
+    uint8_t	configstore_in_use;	    // use to determine non-volatile memory configuration
 
     mchf_touchscreen_t *tp;
 
     bool	show_tp_coordinates;	// show coordinates on LCD
     bool	rfmod_present;			// 0 = not present
     bool	vhfuhfmod_present;		// 0 = not present
-    uchar	multi;					// actual translate factor
-    uchar	tune_power_level;		// TX power in antenna tuning function
-    uchar	power_temp;				// temporary tx power if tune is different from actual tx power
-    uchar	cat_band_index;			// buffered bandindex before first CAT command arrived
-    uchar	xlat;					// CAT <> IQ-Audio
+    uint8_t	multi;					// actual translate factor
+    uint8_t	tune_power_level;		// TX power in antenna tuning function
+    uint8_t	power_temp;				// temporary tx power if tune is different from actual tx power
+    uint8_t	cat_band_index;			// buffered bandindex before first CAT command arrived
+    uint8_t	xlat;					// CAT <> IQ-Audio
     ulong	notch_frequency;		// frequency of the manual notch filter
     ulong	peak_frequency;			// frequency of the manual peak filter
     int		bass_gain;				// gain of the low shelf EQ filter
@@ -866,11 +864,11 @@ typedef struct TransceiverState
     bool	AM_experiment;			// for AM demodulation experiments, not for "public" use
 //    bool	dBm_Hz_Test;			// for testing only
 //    ulong	dBm_count;				// timer for calculating RX dBm
-    uchar 	display_dbm;			// display dbm or dbm/Hz or OFF
-    uchar	s_meter;				// defines S-Meter style/configuration
+    uint8_t 	display_dbm;			// display dbm or dbm/Hz or OFF
+    uint8_t	s_meter;				// defines S-Meter style/configuration
 	uint8_t	meter_colour_up;
 	uint8_t	meter_colour_down;
-	uchar   iq_auto_correction;     // switch variable for automatic IQ correction
+	uint8_t   iq_auto_correction;     // switch variable for automatic IQ correction
 	bool	display_rx_iq;
 	uint8_t twinpeaks_tested;
 	uint8_t agc_wdsp;
@@ -895,7 +893,7 @@ typedef struct TransceiverState
     #define TX_FILTER_SOPRANO		1
     #define TX_FILTER_TENOR			2
     #define TX_FILTER_BASS			3
-    uchar	tx_filter;				// which TX filter has been chosen?
+    uint8_t	tx_filter;				// which TX filter has been chosen?
 
 
     mchf_display_t*     display;
@@ -903,7 +901,7 @@ typedef struct TransceiverState
     uint32_t audio_int_counter;		// used for encoder timing - test DL2FW
     bool encoder3state;
     int bc_band;
-    uchar c_line;					// position of center line
+    uint8_t c_line;					// position of center line
 
     Si570_ResultCodes last_lo_result;			// used in dynamic tuning to hold frequency color
 

--- a/mchf-eclipse/hardware/uhsdr_hw_i2c.c
+++ b/mchf-eclipse/hardware/uhsdr_hw_i2c.c
@@ -24,9 +24,9 @@ uint16_t MCHF_I2C_WriteRegister(I2C_HandleTypeDef* hi2c, uchar I2CAddr,uint16_t 
     return  i2cRet != HAL_OK?0xFF00:0;
 }
 
-uint16_t MCHF_I2C_WriteBlock(I2C_HandleTypeDef* hi2c, uchar I2CAddr, uint16_t addr, uint16_t addr_size, uint8_t* data, uint32_t size)
+uint16_t MCHF_I2C_WriteBlock(I2C_HandleTypeDef* hi2c, uchar I2CAddr, uint16_t addr, uint16_t addr_size, const uint8_t* data, uint32_t size)
 {
-    HAL_StatusTypeDef i2cRet = HAL_I2C_Mem_Write(hi2c,I2CAddr,addr,addr_size,data,size,100);
+    HAL_StatusTypeDef i2cRet = HAL_I2C_Mem_Write(hi2c,I2CAddr,addr,addr_size,(uint8_t*)data,size,100);
 
     return  i2cRet != HAL_OK?0xFF00:0;
 }

--- a/mchf-eclipse/hardware/uhsdr_hw_i2c.h
+++ b/mchf-eclipse/hardware/uhsdr_hw_i2c.h
@@ -26,7 +26,7 @@
 
 uint16_t MCHF_I2C_StartTransfer(I2C_HandleTypeDef* i2c, uint8_t devaddr, uint8_t* data_ptr, uint16_t data_size, bool isWrite, bool isSingleByteRead);
 uint16_t MCHF_I2C_WriteRegister(I2C_HandleTypeDef* i2c, uchar I2CAddr,uint16_t addr,uint16_t addr_size, uchar RegisterValue);
-uint16_t MCHF_I2C_WriteBlock(I2C_HandleTypeDef* i2c, uchar I2CAddr, uint16_t addr, uint16_t addr_size, uint8_t* data, uint32_t size);
+uint16_t MCHF_I2C_WriteBlock(I2C_HandleTypeDef* i2c, uchar I2CAddr, uint16_t addr, uint16_t addr_size, const uint8_t* data, uint32_t size);
 uint16_t MCHF_I2C_ReadRegister(I2C_HandleTypeDef* i2c, uchar I2CAddr, uint16_t addr, uint16_t addr_size, uint8_t *RegisterValue);
 uint16_t MCHF_I2C_ReadBlock(I2C_HandleTypeDef* i2c, uchar I2CAddr,uint16_t addr, uint16_t addr_size, uint8_t *data, uint32_t size);
 

--- a/mchf-eclipse/misc/serial_eeprom.c
+++ b/mchf-eclipse/misc/serial_eeprom.c
@@ -18,6 +18,18 @@
 
 #include "serial_eeprom.h"
 
+// for MAX_VAR_ADDR only
+#include "ui_configuration.h"
+
+typedef struct SerialEEPROM_Configuration
+{
+    uint8_t device_type;
+    uint8_t use_type;
+    bool    detection;
+} SerialEEPROM_Configuration_t;
+
+// static SerialEEPROM_Configuration_t ser_eeprom_config;
+
 const SerialEEPROM_EEPROMTypeDescriptor SerialEEPROM_eepromTypeDescs[SERIAL_EEPROM_DESC_NUM] = {
         // 0
         {
@@ -285,7 +297,7 @@ uint16_t SerialEEPROM_24Cxx_ReadBulk(uint32_t Addr, uint8_t *buffer, uint16_t le
     return retVal;
 }
 
-uint16_t SerialEEPROM_24Cxx_WriteBulk(uint32_t Addr, uint8_t *buffer, uint16_t length, uint8_t Mem_Type)
+uint16_t SerialEEPROM_24Cxx_WriteBulk(uint32_t Addr, const uint8_t *buffer, uint16_t length, uint8_t Mem_Type)
 {
     uint16_t retVal = 0;
     if (Mem_Type < SERIAL_EEPROM_DESC_NUM) {
@@ -313,42 +325,183 @@ uint16_t SerialEEPROM_24Cxx_WriteBulk(uint32_t Addr, uint8_t *buffer, uint16_t l
     return retVal;
 }
 
-uint8_t SerialEEPROM_24Cxx_Detect() {
-
+/**
+ * @brief in general a non-destructive probing to identify the used EEPROM, in some cases devices are written (and changed data restored)
+ * this code uses hardware properties to identify the connected I2C eeprom, no previously signature etc. used or required
+ * @returns identified eeprom chip type or EEPROM_SER_UNKNOWN
+ */
+static uint8_t SerialEEPROM_24Cxx_DetectProbeHardware()
+{
     uint8_t ser_eeprom_type = EEPROM_SER_UNKNOWN;
 
+    const uint8_t testsignatureA = 0x66;
+    const uint8_t testsignatureB = 0x77; // has to be different from testsignature 1
+
+    const uint16_t testaddr1 = 0x0001;
+    const uint16_t testaddr1plus128 = testaddr1 + 0x80;
+
+    // 8 Bit Test First
+    uint16_t test8Byte1 = SerialEEPROM_24Cxx_Read(testaddr1,8);
+
+
+    // first decide if 8 or 16 bit addressable eeprom by trying to read with 8 or 16 bit algorithm
+    // if an algorithm succeeds we know the address width
+    if(test8Byte1 < 0x100)
+    {
+        // 8 bit addressing
+        uint16_t test8Byte2 = SerialEEPROM_24Cxx_Read(testaddr1plus128,8);
+
+        SerialEEPROM_24Cxx_Write(testaddr1,testsignatureB,8);
+        SerialEEPROM_24Cxx_Write(testaddr1plus128,testsignatureB,8);
+
+        if (SerialEEPROM_24Cxx_Read(testaddr1,8) == testsignatureB)
+        {
+            SerialEEPROM_24Cxx_Write(testaddr1,testsignatureA,8);              // write test signature
+            ser_eeprom_type = 7;             // smallest possible 8 bit EEPROM (128Bytes)
+            if(SerialEEPROM_24Cxx_Read(testaddr1plus128,8) == testsignatureB)
+            {
+                ser_eeprom_type = 8;
+            }
+        }
+        SerialEEPROM_24Cxx_Write(testaddr1,test8Byte1,8);         // write back old data
+        SerialEEPROM_24Cxx_Write(testaddr1plus128,test8Byte2,8);
+    }
+    if (ser_eeprom_type == EEPROM_SER_UNKNOWN)
+    {
+        // 16 bit addressing check
+        // the other banks are mapped to different I2C
+        // device addresses. We simply try to read from them
+        // and if it succeeds we know the device type
+        // We need to check unique addresses for each EEPROM type
+        // 0xA0 + 0x10000: 0xA8
+        if(SerialEEPROM_24Cxx_Read(0x10000,17) < 0x100)
+        {
+            ser_eeprom_type = 17;            // 24LC1025
+        }
+        // 0xA0 + 0x10000: 0xA2
+        if(SerialEEPROM_24Cxx_Read(0x10000,18) < 0x100)
+        {
+            ser_eeprom_type = 18;            // 24LC1026
+        }
+        // 0xA0 + 0x10000: 0xA2 + 0x20000: 0xA4 + 0x30000: 0xA6
+        if(SerialEEPROM_24Cxx_Read(0x20000,19) < 0x100)
+        {
+            ser_eeprom_type = 19;            // 24CM02
+        }
+
+        // it is not a large EEPROM (i.e. >64KB Data)
+        //
+        // the following test requires writing to EEPROM,
+        // we remember content of test locations
+        // and write them back later
+        if(ser_eeprom_type == EEPROM_SER_UNKNOWN)
+        {
+            const uint16_t testaddr1plus256 = 0x0100 + testaddr1; // same as before but 0x100 == 256 byte spacing
+            uint16_t testByte1 = SerialEEPROM_24Cxx_Read(testaddr1,16);         // read old content
+            uint16_t testByte2 = SerialEEPROM_24Cxx_Read(testaddr1plus256,16);     // of test bytes
+
+            if (testByte1 < 0x100 && testByte2 < 0x100) {
+
+                // successful read from both locations, let us start
+                SerialEEPROM_24Cxx_Write(testaddr1, testsignatureA,16);         // write testsignature 1
+                SerialEEPROM_24Cxx_Write(testaddr1plus256, testsignatureB,16);         // write testsignature 2
+                if(SerialEEPROM_24Cxx_Read(testaddr1,16) == testsignatureA && SerialEEPROM_24Cxx_Read(testaddr1plus256,16) == testsignatureB)
+                {
+                    // 16 bit addressing
+                    ser_eeprom_type = 9;         // smallest possible 16 bit EEPROM
+
+                    // we look for the "looping" in data, i.e. we read back 0x66
+                    // which we wrote to address  0x0003
+                    // from a address we did not wrote it to
+                    // once it occurs, we know the  size of the EEPROM
+                    // since all of these EEPROMS  are ignoring the unused bits in  the address
+                    for (int shift = 0; shift < 8; shift++) {
+                        uint16_t shift_test_addr = (0x200 << shift)+testaddr1;
+                        if(SerialEEPROM_24Cxx_Read(shift_test_addr,16) == testsignatureA) {
+                            // now we write test signature 2 to make sure the match was no accident
+                            // i.e. match with same content in EEPROM
+                            SerialEEPROM_24Cxx_Write(shift_test_addr,testsignatureB,16);
+                            if(SerialEEPROM_24Cxx_Read(testaddr1,16) == testsignatureB) {
+                                // we found the looping,
+                                // now stop checking and set EEPROM type
+                                ser_eeprom_type = 9 + shift;
+                                break;
+                            }
+                            else
+                            {
+                                // oops: just an accident, so we write back old content and continue
+                                SerialEEPROM_24Cxx_Write(shift_test_addr,testsignatureA,16);
+                            }
+                        }
+                    }
+
+                }
+                SerialEEPROM_24Cxx_Write(testaddr1,testByte1,16);         // write back old data
+                SerialEEPROM_24Cxx_Write(testaddr1plus256,testByte2,16);
+            }
+        }
+    }
+    return ser_eeprom_type;
+}
+
+static void SerialEEPROM_Read_Signature(uint8_t ser_eeprom_type, uint16_t* type_p, uint16_t* state_p)
+{
+    *type_p = SerialEEPROM_24Cxx_Read(0,ser_eeprom_type);
+    *state_p = SerialEEPROM_24Cxx_Read(1,ser_eeprom_type);
+}
+
+uint16_t SerialEEPROM_Set_UseStateInSignature(uint8_t state)
+{
+    return SerialEEPROM_24Cxx_Write(1,SER_EEPROM_IN_USE,ts.ser_eeprom_type);
+}
+
+uint16_t SerialEEPROM_Get_UseStateInSignature()
+{
+    return SerialEEPROM_24Cxx_Read(1,ts.ser_eeprom_type);
+}
+
+uint8_t SerialEEPROM_Detect() {
+
+    uint16_t ser_eeprom_type = EEPROM_SER_UNKNOWN;
+
     // serial EEPROM init
-    if(SerialEEPROM_24Cxx_DeviceConnected() != HAL_OK || SerialEEPROM_Exists() == false)  // Issue with Ser EEPROM, either not available or other problems
-	{
-		ser_eeprom_type = EEPROM_SER_NONE;             // no serial EEPROM available
-		// mchf_hw_i2c2_reset();
-	}
+    if(SerialEEPROM_24Cxx_DeviceConnected() != HAL_OK || SerialEEPROM_24xx_Exists() == false)  // Issue with Ser EEPROM, either not available or other problems
+    {
+        ser_eeprom_type = EEPROM_SER_NONE;             // no serial EEPROM available
+
+    }
     else
     {
-        if(SerialEEPROM_24Cxx_Read(0,16) != 0xFF)
+
+        // this initial read will bring us the first byte of any eeprom (8 or 16bits)
+        // if we read anything but the 0xff == SER_EERPM_NOT_IN_USE value which indicates empty eeprom
+        // we assume some configuration information tells us what EEPROM we have and how it is used
+        if(SerialEEPROM_24Cxx_Read(0,16) != SER_EEPROM_NOT_IN_USE)
         {
             ser_eeprom_type = EEPROM_SER_WRONG_SIG;
+
             // unless we find a correct signature, we have to assume the EEPROM has incorrect/corrupted data
 
-            uint16_t ser_eeprom_type_read = SerialEEPROM_24Cxx_Read(0,8);
-            uint16_t ser_eeprom_sig = SerialEEPROM_24Cxx_Read(1,8);
+            uint16_t ser_eeprom_type_read;
+            uint16_t ser_eeprom_sig;
+
+            SerialEEPROM_Read_Signature(8, &ser_eeprom_type_read, &ser_eeprom_sig);
 
             // all 8 bit (i.e. 256 or 128 Byte) EEPROMS are marked as "too small" during detection
-            if(ser_eeprom_sig == SER_EEPROM_IN_USE_TOO_SMALL && ser_eeprom_type_read > 6 && ser_eeprom_type_read < 9)
+            if(ser_eeprom_sig == SER_EEPROM_TOO_SMALL && ser_eeprom_type_read >= SERIAL_EEPROM_DESC_REAL && ser_eeprom_type_read < 9)
             {
                 ser_eeprom_type = ser_eeprom_type_read;
             }
             else
             {
-                ser_eeprom_type_read = SerialEEPROM_24Cxx_Read(0,16);
-                ser_eeprom_sig = SerialEEPROM_24Cxx_Read(1,16);
+                SerialEEPROM_Read_Signature(16, &ser_eeprom_type_read, &ser_eeprom_sig);
 
-                // we either have a new EEPROM, just being initialized  ( ser_eeprom_sig = SER_EEPROM_IN_USE_NO && valid type) or
-                // we have an used EEPROM (ser_eeprom_sig = SER_EEPROM_IN_USE_I2C && valid type)
+                // we either have a new EEPROM, just being initialized  ( ser_eeprom_sig = SER_EEPROM_NOT_IN_USE && valid type) or
+                // we have an used EEPROM (ser_eeprom_sig = SER_EEPROM_IN_USE && valid type)
                 // please note, that even though no 16 bit EEPROM gets the "too small" signature written in, these may still be
                 // consider too small by the later code. Only EEPROMS which have the "supported" flag set in the descriptor will
                 // be consider of sufficient size for actual use
-                if((ser_eeprom_sig == SER_EEPROM_IN_USE_I2C || ser_eeprom_sig == SER_EEPROM_IN_USE_NO) && ser_eeprom_type_read < SERIAL_EEPROM_DESC_NUM && ser_eeprom_type_read > 8)
+                if((ser_eeprom_sig == SER_EEPROM_IN_USE || ser_eeprom_sig == SER_EEPROM_NOT_IN_USE) && ser_eeprom_type_read < SERIAL_EEPROM_DESC_NUM && ser_eeprom_type_read > 8)
                 {
                     ser_eeprom_type = ser_eeprom_type_read;
                 }
@@ -356,123 +509,40 @@ uint8_t SerialEEPROM_24Cxx_Detect() {
         }
         else
         {
-            const uint8_t testsignature1 = 0x66;
-            const uint16_t testaddr1 = 0x0001;
+            ser_eeprom_type = SerialEEPROM_24Cxx_DetectProbeHardware();
 
-            const uint8_t testsignature2 = 0x77; // has to be different from testsignature 1
-            const uint16_t testaddr2 = 0x0100 + testaddr1; // same as before but 0x100 == 256 byte spacing
-
-            uint16_t testbyte0 = SerialEEPROM_24Cxx_Read(testaddr1,8);
-            SerialEEPROM_24Cxx_Write(testaddr1,testsignature2,8);
-
-            // first decide if 8 or 16 bit addressable eeprom by trying to read with 8 or 16 bit algorithm
-            // if an algorithm succeeds we know the address width
-            if(testbyte0 < 0x100 && SerialEEPROM_24Cxx_Read(testaddr1,8) == testsignature2)
+            if (ser_eeprom_type >= SERIAL_EEPROM_DESC_REAL && ser_eeprom_type < SERIAL_EEPROM_DESC_NUM)
             {
-                // 8 bit addressing
-                SerialEEPROM_24Cxx_Write(testaddr1,testsignature1,8);              // write test signature
-                ser_eeprom_type = 7;             // smallest possible 8 bit EEPROM (128Bytes)
-                if(SerialEEPROM_24Cxx_Read(testaddr1 + 0x80,8) != testsignature1)
+                SerialEEPROM_24Cxx_Write(0,ser_eeprom_type,ser_eeprom_type);
+                if (SerialEEPROM_eepromTypeDescs[ser_eeprom_type].supported == false)
                 {
-                    ser_eeprom_type = 8;
-                }
-                SerialEEPROM_24Cxx_Write(0,ser_eeprom_type,8);
-                SerialEEPROM_24Cxx_Write(1,SER_EEPROM_IN_USE_TOO_SMALL,8);
-            }
-            else
-            {
-                // 16 bit addressing check
-                // the other banks are mapped to different I2C
-                // device addresses. We simply try to read from them
-                // and if it succeeds we know the device type
-                // We need to check unique addresses for each EEPROM type
-                // 0xA0 + 0x10000: 0xA8
-                if(SerialEEPROM_24Cxx_Read(0x10000,17) < 0x100)
-                {
-                    ser_eeprom_type = 17;            // 24LC1025
-                }
-                // 0xA0 + 0x10000: 0xA2
-                if(SerialEEPROM_24Cxx_Read(0x10000,18) < 0x100)
-                {
-                    ser_eeprom_type = 18;            // 24LC1026
-                }
-                // 0xA0 + 0x10000: 0xA2 + 0x20000: 0xA4 + 0x30000: 0xA6
-                if(SerialEEPROM_24Cxx_Read(0x20000,19) < 0x100)
-                {
-                    ser_eeprom_type = 19;            // 24CM02
-                }
-
-                // it is not a large EEPROM (i.e. >64KB Data)
-                //
-                // the following test requires writing to EEPROM,
-                // we remember content of test locations
-                // and write them back later
-                if(ser_eeprom_type == EEPROM_SER_UNKNOWN)
-                {
-
-                    uint16_t testByte1 = SerialEEPROM_24Cxx_Read(testaddr1,16);         // read old content
-                    uint16_t testByte2 = SerialEEPROM_24Cxx_Read(testaddr2,16);     // of test bytes
-
-                    if (testByte1 < 0x100 && testByte2 < 0x100) {
-
-                        // successful read from both locations, let us start
-                        SerialEEPROM_24Cxx_Write(testaddr1, testsignature1,16);         // write testsignature 1
-                        SerialEEPROM_24Cxx_Write(testaddr2, testsignature2,16);         // write testsignature 2
-                        if(SerialEEPROM_24Cxx_Read(testaddr1,16) == testsignature1 && SerialEEPROM_24Cxx_Read(testaddr2,16) == testsignature2)
-                        {
-                            // 16 bit addressing
-                            ser_eeprom_type = 9;         // smallest possible 16 bit EEPROM
-
-                            // we look for the "looping" in data, i.e. we read back 0x66
-                            // which we wrote to address  0x0003
-                            // from a address we did not wrote it to
-                            // once it occurs, we know the  size of the EEPROM
-                            // since all of these EEPROMS  are ignoring the unused bits in  the address
-                            for (int shift = 0; shift < 8; shift++) {
-                                uint16_t shift_test_addr = (0x200 << shift)+testaddr1;
-                                if(SerialEEPROM_24Cxx_Read(shift_test_addr,16) == testsignature1) {
-                                    // now we write test signature 2 to make sure the match was no accident
-                                    // i.e. match with same content in EEPROM
-                                    SerialEEPROM_24Cxx_Write(shift_test_addr,testsignature2,16);
-                                    if(SerialEEPROM_24Cxx_Read(testaddr1,16) == testsignature2) {
-                                        // we found the looping,
-                                        // now stop checking and set EEPROM type
-                                        ser_eeprom_type = 9 + shift;
-                                        break;
-                                    }
-                                    else
-                                    {
-                                        // oops: just an accident, so we write back old content and continue
-                                        SerialEEPROM_24Cxx_Write(shift_test_addr,testsignature1,16);
-                                    }
-                                }
-                            }
-
-                        }
-                        SerialEEPROM_24Cxx_Write(testaddr1,testByte1,16);         // write back old data
-                        SerialEEPROM_24Cxx_Write(testaddr2,testByte2,16);
-                    }
-                }
-                if (ser_eeprom_type != EEPROM_SER_UNKNOWN) {
-                    SerialEEPROM_24Cxx_Write(0,ser_eeprom_type,ser_eeprom_type);
+                    SerialEEPROM_24Cxx_Write(1,SER_EEPROM_TOO_SMALL,ser_eeprom_type);
                 }
             }
         }
+        // just to be save. Never ever deliver a type id outside the array boundaries.
+        if (ser_eeprom_type >= SERIAL_EEPROM_DESC_NUM)
+        {
+            ser_eeprom_type = EEPROM_SER_UNKNOWN;
+        }
     }
-    // just to be save. Never ever deliver a type id outside the array boundaries.
-    if (ser_eeprom_type >= SERIAL_EEPROM_DESC_NUM)
-    {
-        ser_eeprom_type = EEPROM_SER_UNKNOWN;
-    }
+
     return ser_eeprom_type;
-}
-void  SerialEEPROM_Clear()
-{
-    SerialEEPROM_24Cxx_Write(0,0xFF,16);
-    SerialEEPROM_24Cxx_Write(1,0xFF,16);
+
 }
 
-bool SerialEEPROM_Exists()
+void  SerialEEPROM_Clear_Signature()
+{
+    for(uint16_t count=0; count <= MAX_VAR_ADDR; count++)
+    {
+        const uint8_t empty_var[2] = { 0xff, 0xff };
+        SerialEEPROM_24Cxx_WriteBulk(count*2, empty_var,2, 16);
+    }
+
+}
+
+
+bool SerialEEPROM_24xx_Exists()
 {
     return SerialEEPROM_24Cxx_Read(0,8)  < 0x100;
 }
@@ -483,35 +553,37 @@ bool SerialEEPROM_Exists()
 //
 uint16_t SerialEEPROM_ReadVariable(uint16_t addr, uint16_t *value)      // reference to serial EEPROM read function
 {
-    uint16_t data;
+    uint8_t bytes[2];
 
-    data = (uint16_t)(SerialEEPROM_24Cxx_Read(addr*2, ts.ser_eeprom_type)<<8);
-    data = data + (uint8_t)(SerialEEPROM_24Cxx_Read(addr*2+1, ts.ser_eeprom_type));
-    *value = data;
 
-    return 0;
+    uint16_t retval = SerialEEPROM_24Cxx_ReadBulk(addr*2,bytes, 2, ts.ser_eeprom_type);
+
+    if (retval == HAL_OK)
+    {
+        *value =  ((uint16_t)bytes[0])<<8;
+        *value |= bytes[1];
+    }
+
+    return retval;
 }
 
 uint16_t SerialEEPROM_UpdateVariable(uint16_t addr, uint16_t value)
 {
         uint16_t value_read = 0;
-        uint16_t status = SerialEEPROM_ReadVariable(addr,&value_read);
-        if  (status != 0 || value_read != value )
+        uint16_t retval = SerialEEPROM_ReadVariable(addr,&value_read);
+        if  (retval != 0 || value_read != value )
         {
-            SerialEEPROM_WriteVariable(addr,value);
+            retval = SerialEEPROM_WriteVariable(addr,value);
         }
-        return 0;
+        return retval;
 }
 
 uint16_t SerialEEPROM_WriteVariable(uint16_t addr, uint16_t value)      // reference to serial EEPROM write function, writing unsigned 16 bit
 {
-    uint8_t lowbyte, highbyte;
+    uint8_t bytes[2];
 
-    lowbyte = (uint8_t)(value&(0x00FF));
-    highbyte = (uint8_t)((value&(0xFF00))>>8);
+    bytes[0] = (uint8_t)((value&(0xFF00))>>8);
+    bytes[1] = (uint8_t)(value&(0x00FF));
 
-    SerialEEPROM_24Cxx_Write(addr*2, highbyte, ts.ser_eeprom_type);
-    SerialEEPROM_24Cxx_Write(addr*2+1, lowbyte, ts.ser_eeprom_type);
-
-    return 0;
+    return SerialEEPROM_24Cxx_WriteBulk(addr*2, bytes, 2, ts.ser_eeprom_type);
 }

--- a/mchf-eclipse/misc/serial_eeprom.h
+++ b/mchf-eclipse/misc/serial_eeprom.h
@@ -24,20 +24,34 @@ typedef struct {
 } SerialEEPROM_EEPROMTypeDescriptor;
 
 #define SERIAL_EEPROM_DESC_NUM 20
+#define SERIAL_EEPROM_DESC_REAL 7
+// the first type number not used as pseudo device (24xx128)
+#define SERIAL_EEPROM_MIN_USEABLE_SIZE 32*1024
+
+// WE CANNOT CHANGE THESE CODES AS THIS WILL BREAK EXISTING CONFIGURATIONS STORED IN EEPROM
+#define SER_EEPROM_IN_USE           0x00
+#define SER_EEPROM_NOT_IN_USE       0xFF
+#define SER_EEPROM_TOO_SMALL        0x10
+
+
+
 extern const SerialEEPROM_EEPROMTypeDescriptor SerialEEPROM_eepromTypeDescs[SERIAL_EEPROM_DESC_NUM];
 
-void     SerialEEPROM_Clear();
-bool     SerialEEPROM_Exists();
 
 // low level interface
+bool     SerialEEPROM_24xx_Exists();
 uint16_t SerialEEPROM_24Cxx_Write(uint32_t, uint8_t, uint8_t);
 uint16_t SerialEEPROM_24Cxx_Read(uint32_t, uint8_t);
-uint16_t SerialEEPROM_24Cxx_WriteBulk(uint32_t, uint8_t*, uint16_t, uint8_t);
+uint16_t SerialEEPROM_24Cxx_WriteBulk(uint32_t, const uint8_t*, uint16_t, uint8_t);
 uint16_t SerialEEPROM_24Cxx_ReadBulk(uint32_t, uint8_t*, uint16_t, uint8_t);
-uint8_t  SerialEEPROM_24Cxx_Detect();
 
 uint16_t SerialEEPROM_ReadVariable(uint16_t addr, uint16_t *value);
 uint16_t SerialEEPROM_WriteVariable(uint16_t addr, uint16_t value);
 uint16_t SerialEEPROM_UpdateVariable(uint16_t addr, uint16_t value);
+
+uint8_t  SerialEEPROM_Detect();
+uint16_t SerialEEPROM_Set_UseStateInSignature(uint8_t state);
+uint16_t SerialEEPROM_Get_UseStateInSignature();
+void     SerialEEPROM_Clear_Signature();
 
 #endif

--- a/mchf-eclipse/src/uhsdr_main.c
+++ b/mchf-eclipse/src/uhsdr_main.c
@@ -304,7 +304,7 @@ void TransceiverStateInit(void)
     ts.beep_loudness = DEFAULT_BEEP_LOUDNESS;			// loudness of keyboard/CW sidetone test beep
     ts.load_freq_mode_defaults = 0;					// when TRUE, load frequency defaults into RAM when "UiDriverLoadEepromValues()" is called - MUST be saved by user IF these are to take effect!
     ts.ser_eeprom_type = 0;						// serial eeprom not present
-    ts.ser_eeprom_in_use = SER_EEPROM_IN_USE_NO;					// serial eeprom not in use
+    ts.configstore_in_use = CONFIGSTORE_IN_USE_FLASH;					// serial eeprom not in use
 
     ts.tp = &mchf_touchscreen;
     ts.display = &mchf_display;


### PR DESCRIPTION
Main goal: better and easier overview of what goes on during configration storage
detection.
Slight signature change in EEPROM_WriteBulk (no functional impact).

THIS HAS BEEN TESTED with new EEPROM (i.e. completely erase one) and previously used ones.  
It may report the wrong EEPROM in certain cases (1025 reported as 1026) but this does not impact 
the use of the I2C EEPROM. Backup to and restore from flash are working. 