### PR TITLE
Improved RIT and SPLIT handling, fixed issues in this area, menu code…

### DIFF
--- a/mchf-eclipse/drivers/ui/menu/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu.c
@@ -302,7 +302,7 @@ bool UiDriverMenuItemChangeEnableOnOffBool(int var, uint8_t mode, volatile bool*
 {
     uint8_t temp = *val_ptr;
 
-    bool res = UiDriverMenuItemChangeOnOff(var, mode, &temp, val_default);
+    bool res = UiDriverMenuItemChangeEnableOnOff(var, mode, &temp, val_default, options, clr_ptr);
     *val_ptr = temp;
     return res;
 }
@@ -310,7 +310,7 @@ bool UiDriverMenuItemChangeEnableOnOffFlag(int var, uint8_t mode, volatile uint1
 {
     uint8_t temp = (*val_ptr & mask)?1:0;
 
-    bool res = UiDriverMenuItemChangeOnOff(var, mode, &temp, val_default);
+    bool res = UiDriverMenuItemChangeEnableOnOff(var, mode, &temp, val_default, options, clr_ptr);
 
     CLR_OR_SET_BITMASK(temp,*val_ptr,mask);
 

--- a/mchf-eclipse/drivers/ui/radio_management.h
+++ b/mchf-eclipse/drivers/ui/radio_management.h
@@ -181,7 +181,7 @@ uint8_t RadioManagement_GetBand(ulong freq);
 bool RadioManagement_PowerLevelChange(uint8_t band, uint8_t power_level);
 bool RadioManagement_Tune(bool tune);
 bool RadioManagement_UpdatePowerAndVSWR();
-void    RadioManagement_SetHWFiltersForFrequency(ulong freq);
+void RadioManagement_SetHWFiltersForFrequency(ulong freq);
 void RadioManagement_ChangeCodec(uint32_t codec, bool enableCodec);
 bool RadioManagement_ChangeFrequency(bool force_update, uint32_t dial_freq,uint8_t txrx_mode);
 void RadioManagement_HandlePttOnOff();
@@ -206,6 +206,10 @@ void RadioManagement_ToggleVfoAB();
 
 bool RadioManagement_FmDevIs5khz();
 void RadioManagement_FmDevSet5khz(bool is5khz);
+
+uint32_t RadioManagement_GetTXDialFrequency();
+uint32_t RadioManagement_GetRXDialFrequency();
+
 
 inline void RadioManagement_ToggleVfoMem()
 {


### PR DESCRIPTION
… refactor.

Frequency bar below display now correctly updates if RIT is used
TX carrier now correctly indicates TX carrier even with SPLIT and/or RIT
Found (old) issue that XVERTER settings do not influence the frequency bar
below scope (Carrier marker and filter are okay)
THESE CHANGES ABOVE NEED MORE TESTING TO SEE IF EVERYTHING HAS BEEN COVERED!!!


Menu code now more compact.