### PR TITLE
RTTY: added ATC = automatic threshold correction

### DIFF
--- a/mchf-eclipse/.settings/language.settings.xml
+++ b/mchf-eclipse/.settings/language.settings.xml
@@ -5,7 +5,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-700819820320302421" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings Cross ARM" parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="111743357592321234" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings Cross ARM" parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>
@@ -16,7 +16,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-702268907814884299" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings Cross ARM" parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="177772813756081672" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings Cross ARM" parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>
@@ -27,7 +27,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-728784944115861749" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings Cross ARM" parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="126911469821072498" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings Cross ARM" parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>
@@ -38,7 +38,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-751384996759147307" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings Cross ARM" parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="175670720889180520" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings Cross ARM" parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>
@@ -49,7 +49,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-756605493531545429" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings Cross ARM" parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="79220502755665618" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings Cross ARM" parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>
@@ -60,7 +60,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-723419872963587979" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings Cross ARM" parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="160498481196857800" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings Cross ARM" parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>

--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -3966,7 +3966,7 @@ static void AudioDriver_RxProcessor(AudioSample_t * const src, AudioSample_t * c
                 arm_biquad_cascade_df1_f32 (&IIR_biquad_1, adb.a_buffer,adb.a_buffer, blockSizeDecim);
 
 #ifdef USE_RTTY_PROCESSOR
-                if (ts.dvmode == true && ts.digital_mode == DigitalMode_RTTY && blockSizeDecim == 8) // only works when decimation rate is 4 --> sample rate == 12ksps
+                if (ts.dvmode == true && (ts.digital_mode == DigitalMode_RTTY || ts.digital_mode == DigitalMode_RTTY_NEW) && blockSizeDecim == 8) // only works when decimation rate is 4 --> sample rate == 12ksps
                 {
                     AudioDriver_RxProcessor_Rtty(adb.a_buffer, blockSizeDecim);
                 }

--- a/mchf-eclipse/drivers/audio/rtty.c
+++ b/mchf-eclipse/drivers/audio/rtty.c
@@ -331,7 +331,6 @@ static int RttyDecoder_demodulator(float32_t sample) {
 		v1 = RttyDecoder_lowPass(v1, rttyDecoderData.lpfConfig, &rttyDecoderData.lpfData);
 
 		// MchfBoard_GreenLed((line0 > 0)? LED_STATE_OFF:LED_STATE_ON);
-		return (v1 > 0)?0:1;
     }
     else
     {   // RTTY without ATC, which works very well too!
@@ -344,9 +343,9 @@ static int RttyDecoder_demodulator(float32_t sample) {
 		// lowpass filtering the summed line
 			v1 = RttyDecoder_lowPass(v1, rttyDecoderData.lpfConfig, &rttyDecoderData.lpfData);
 		// MchfBoard_GreenLed((line0 > 0)? LED_STATE_OFF:LED_STATE_ON);
-		return (v1 > 0)?0:1;
     }
 
+    return (v1 > 0)?0:1;
 }
 
 // this function returns true once at the half of a bit with the bit's value

--- a/mchf-eclipse/drivers/audio/rtty.c
+++ b/mchf-eclipse/drivers/audio/rtty.c
@@ -268,7 +268,9 @@ static int RttyDecoder_demodulator(float32_t sample) {
 
     if(ts.digital_mode == DigitalMode_RTTY_NEW)
     {   // RTTY decoding with ATC = automatic threshold correction
-		float32_t helper = space_mag;
+		// FIXME: space & mark seem to be swapped in the following code
+    	// dirty fix
+    	float32_t helper = space_mag;
 		space_mag = mark_mag;
 		mark_mag = helper;
     	static float32_t mark_env = 0.0;
@@ -299,8 +301,14 @@ static int RttyDecoder_demodulator(float32_t sample) {
 					float32_t mclipped = 0.0, sclipped = 0.0;
 					mclipped = mark_mag > mark_env ? mark_env : mark_mag;
 					sclipped = space_mag > space_env ? space_env : space_mag;
-					if (mclipped < noise_floor) mclipped = noise_floor;
-					if (sclipped < noise_floor) sclipped = noise_floor;
+					if (mclipped < noise_floor)
+						{
+						    mclipped = noise_floor;
+						}
+					if (sclipped < noise_floor)
+						{
+						    sclipped = noise_floor;
+						}
 
 		// we could add options for mark-only or space-only decoding
 		// however, the current implementation with ATC already works quite well with mark-only/space-only
@@ -316,8 +324,8 @@ static int RttyDecoder_demodulator(float32_t sample) {
 
 		// Optimal ATC (Section 6 of of www.w7ay.net/site/Technical/ATC)
 		v1  = (mclipped - noise_floor) * (mark_env - noise_floor) -
-							(sclipped - noise_floor) * (space_env - noise_floor) - 0.25 * (
-							(mark_env - noise_floor) * (mark_env - noise_floor) -
+							(sclipped - noise_floor) * (space_env - noise_floor) -
+					0.25 *  ((mark_env - noise_floor) * (mark_env - noise_floor) -
 		                    (space_env - noise_floor) * (space_env - noise_floor));
 
 		v1 = RttyDecoder_lowPass(v1, rttyDecoderData.lpfConfig, &rttyDecoderData.lpfData);

--- a/mchf-eclipse/drivers/audio/rtty.c
+++ b/mchf-eclipse/drivers/audio/rtty.c
@@ -241,7 +241,7 @@ void RttyDecoder_Init()
 }
 
 static float32_t decayavg(float32_t average, float32_t input, int weight)
-{
+{ // adapted from https://github.com/ukhas/dl-fldigi/blob/master/src/include/misc.h
 	float32_t retval;
 	if (weight <= 1)
     {
@@ -277,6 +277,7 @@ static int RttyDecoder_demodulator(float32_t sample) {
 	    static float32_t space_noise = 0.0;
 	    // experiment to implement an ATC (Automatic threshold correction), DD4WH, 2017_08_24
 		// everything taken from FlDigi, licensed by GNU GPLv2 or later
+	    // https://github.com/ukhas/dl-fldigi/blob/master/src/cw_rtty/rtty.cxx
 		// calculate envelope of the mark and space signals
 		// uses fast attack and slow decay
 		mark_env = decayavg (mark_env, mark_mag,

--- a/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
@@ -131,6 +131,7 @@ static void UiSpectrum_UpdateSpectrumPixelParameters()
                 sd.marker_num = 2;
                 break;
             case DigitalMode_RTTY:
+            case DigitalMode_RTTY_NEW:
                 mode_marker[0] = 915; // Mark Frequency
                 mode_marker[1] = mode_marker[0] + rtty_shifts[rtty_ctrl_config.shift_idx].value;
                 sd.marker_num = 2;

--- a/mchf-eclipse/drivers/ui/radio_management.c
+++ b/mchf-eclipse/drivers/ui/radio_management.c
@@ -106,6 +106,7 @@ const digital_mode_desc_t digimodes[DigitalMode_Num_Modes] =
     { "DIGITAL" , true },
     { "FreeDV"  , true },
     { "RTTY"    , true },
+	{ "RTTY_NEW", true },
     { "FREEDV2" , false },
     { "PSK"     , false },
     { "SSTV"    , false },

--- a/mchf-eclipse/drivers/ui/radio_management.c
+++ b/mchf-eclipse/drivers/ui/radio_management.c
@@ -106,7 +106,7 @@ const digital_mode_desc_t digimodes[DigitalMode_Num_Modes] =
     { "DIGITAL" , true },
     { "FreeDV"  , true },
     { "RTTY"    , true },
-	{ "RTTY_NEW", true },
+	{ "RTTYATC", true },
     { "FREEDV2" , false },
     { "PSK"     , false },
     { "SSTV"    , false },

--- a/mchf-eclipse/drivers/ui/radio_management.c
+++ b/mchf-eclipse/drivers/ui/radio_management.c
@@ -106,7 +106,7 @@ const digital_mode_desc_t digimodes[DigitalMode_Num_Modes] =
     { "DIGITAL" , true },
     { "FreeDV"  , true },
     { "RTTY"    , true },
-	{ "RTTYATC", true },
+	{ "RTTYATC" , true },
     { "FREEDV2" , false },
     { "PSK"     , false },
     { "SSTV"    , false },

--- a/mchf-eclipse/drivers/ui/radio_management.h
+++ b/mchf-eclipse/drivers/ui/radio_management.h
@@ -159,6 +159,7 @@ typedef enum
     DigitalMode_None = 0,
     DigitalMode_FreeDV,
     DigitalMode_RTTY,
+	DigitalMode_RTTY_NEW,
     DigitalMode_FreeDV2,
     DigitalMode_BPSK31,
     DigitalMode_SSTV,

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -770,7 +770,7 @@ void UiDriver_HandleTouchScreen()
         }
         if(UiDriver_CheckTouchCoordinates(0,7,10,13))			// toggle digital modes
         {
-            incr_wrap_uint8(&ts.digital_mode,0,DigitalMode_RTTY);
+            incr_wrap_uint8(&ts.digital_mode,0,DigitalMode_RTTY_NEW);
             // We limit the reachable modes to the ones truly available
             // which is FreeDV1 for now
             UiDriver_ToggleDigitalMode();
@@ -1792,6 +1792,7 @@ void UiDriver_DisplayDemodMode()
         switch(ts.digital_mode)
         {
         case DigitalMode_RTTY:
+        case DigitalMode_RTTY_NEW:
             txt = ts.digi_lsb?"RT-L":"RT-U";
             break;
         default:
@@ -3333,6 +3334,7 @@ void UiDriver_SetDemodMode(uint8_t new_mode)
         switch(ts.digital_mode)
         {
         case DigitalMode_RTTY:
+        case DigitalMode_RTTY_NEW:
             if (ts.enc_one_mode != ENC_ONE_MODE_AUDIO_GAIN)
             {
                 ts.enc_one_mode = ENC_ONE_MODE_RTTY_SPEED;
@@ -3982,7 +3984,7 @@ static bool UiDriver_IsApplicableEncoderOneMode(uint8_t mode)
     {
     case ENC_ONE_MODE_RTTY_SPEED:
         // only switch to rtty adjustment, if rtty enabled!
-        retval = ts.digital_mode == DigitalMode_RTTY && ts.dmod_mode == DEMOD_DIGI;
+        retval = (ts.digital_mode == DigitalMode_RTTY || ts.digital_mode == DigitalMode_RTTY_NEW) && ts.dmod_mode == DEMOD_DIGI;
         break;
     case ENC_ONE_MODE_ST_GAIN:
         retval = ts.dmod_mode == DEMOD_CW;
@@ -4014,7 +4016,7 @@ static void UiDriver_DisplayEncoderOneMode()
         break;
     default:
         // what to display if lower box is not active
-        if (ts.digital_mode == DigitalMode_RTTY && ts.dmod_mode == DEMOD_DIGI)
+        if ((ts.digital_mode == DigitalMode_RTTY || ts.digital_mode == DigitalMode_RTTY_NEW) && ts.dmod_mode == DEMOD_DIGI)
         {
             UiDriver_DisplayRttySpeed(0);
         }
@@ -4036,7 +4038,7 @@ static bool UiDriver_IsApplicableEncoderTwoMode(uint8_t mode)
     {
     case ENC_TWO_MODE_RTTY_SHIFT:
         // only switch to rtty adjustment, if rtty enabled!
-        retval = ts.digital_mode == DigitalMode_RTTY && ts.dmod_mode == DEMOD_DIGI;
+        retval = (ts.digital_mode == DigitalMode_RTTY || ts.digital_mode == DigitalMode_RTTY_NEW) && ts.dmod_mode == DEMOD_DIGI;
         break;
     case ENC_TWO_MODE_NOTCH_F:
         retval = is_dsp_mnotch();


### PR DESCRIPTION
ATC should lead to more robust decoding of RTTY under fading conditions. See this page for more information: http://www.w7ay.net/site/Technical/ATC/
I have simply taken code bits from FlDigi source code and adapted them to UHSDR code.
For comparison, we now temporarily have two digital modes: "RTTY" and "RTTY ATC", so we can compare the performance of RTTY without ATC ("RTTY") and RTTY with ATC ("RTTYATC").

Tested:
DWD weather report decoding in RT-U. No significant differences with 1k4 BPF. But try to switch to  500Hz/950Hz filter (which leads to space being OUT of the filter passband): then RTTYATC has a huge advantage over RTTY. The latter is not able to decode anything when only mark is present, whereas RTTYATC even pulls out some content when only mark is present . . .
Not tested:
Ham Radio RTTY