### PR TITLE
Simple RTTY TX via USB Keyboard now possible

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -4657,8 +4657,11 @@ static void AudioDriver_TxProcessorRtty(AudioSample_t * const dst, uint16_t bloc
     // remove noise if no CW is keyed
     memset(adb.a_buffer,0,sizeof(adb.a_buffer[0])*blockSize);
 
-	CwGen_Process(adb.a_buffer, adb.a_buffer, blockSize);
-	// we just misuse adb.a_buffer, and generate a CW side tone
+    if (ts.cw_keyer_mode != CW_KEYER_MODE_STRAIGHT)
+    {
+    	CwGen_Process(adb.a_buffer, adb.a_buffer, blockSize);
+    	// we just misuse adb.a_buffer, and generate a CW side tone
+    }
 
 }
 

--- a/mchf-eclipse/drivers/audio/cw/cw_gen.c
+++ b/mchf-eclipse/drivers/audio/cw/cw_gen.c
@@ -384,7 +384,7 @@ void CwGen_Init(void)
 	case CW_KEYER_MODE_IAM_B:
 		ps.port_state = CW_IAMBIC_B;
 		break;
-	case CW_MODE_IAM_A:
+	case CW_KEYER_MODE_IAM_A:
 		ps.port_state = CW_IAMBIC_A;
 		break;
 	default:
@@ -514,13 +514,13 @@ bool CwGen_Process(float32_t *i_buffer,float32_t *q_buffer,ulong blockSize)
 	bool retval;
 
 
-	if(ts.cw_keyer_mode == CW_MODE_STRAIGHT || CatDriver_CatPttActive())
+	if(ts.cw_keyer_mode == CW_KEYER_MODE_STRAIGHT || CatDriver_CatPttActive())
 	{
 		// we make sure the remaining code will see the "right" keyer mode
 		// since we are running in an interrupt, none will change that outside
 		// and we can safely restore after we're done
 		uint8_t keyer_mode = ts.cw_keyer_mode;
-		ts.cw_keyer_mode = CW_MODE_STRAIGHT;
+		ts.cw_keyer_mode = CW_KEYER_MODE_STRAIGHT;
 		retval = CwGen_ProcessStraightKey(i_buffer,q_buffer,blockSize);
 		ts.cw_keyer_mode = keyer_mode;
 	}
@@ -805,7 +805,7 @@ static bool CwGen_ProcessIambic(float32_t *i_buffer,float32_t *q_buffer,ulong bl
 					ps.port_state |= CW_END_PROC;
 				}
 
-				if (ts.cw_keyer_mode == CW_MODE_IAM_A || ts.cw_keyer_mode == CW_KEYER_MODE_IAM_B)
+				if (ts.cw_keyer_mode == CW_KEYER_MODE_IAM_A || ts.cw_keyer_mode == CW_KEYER_MODE_IAM_B)
 				{
 					if (ps.port_state & CW_DIT_PROC)
 					{
@@ -850,7 +850,7 @@ static bool CwGen_ProcessIambic(float32_t *i_buffer,float32_t *q_buffer,ulong bl
 
 static void CwGen_TestFirstPaddle()
 {
-	if(ts.cw_keyer_mode == CW_MODE_ULTIMATE)
+	if(ts.cw_keyer_mode == CW_KEYER_MODE_ULTIMATE)
 	{
 		if(!CwGen_DitRequested() && CwGen_DahRequested())
 		{
@@ -870,7 +870,7 @@ static void CwGen_TestFirstPaddle()
  */
 void CwGen_DahIRQ(void)
 {
-	if(ts.cw_keyer_mode == CW_MODE_STRAIGHT)
+	if(ts.cw_keyer_mode == CW_KEYER_MODE_STRAIGHT)
 	{
 		// Reset publics, but only when previous is sent
 		if(ps.key_timer == 0)
@@ -892,7 +892,7 @@ void CwGen_DahIRQ(void)
 void CwGen_DitIRQ(void)
 {
 	// CW mode handler - no dit interrupt in straight key mode
-	if(ts.cw_keyer_mode != CW_MODE_STRAIGHT)
+	if(ts.cw_keyer_mode != CW_KEYER_MODE_STRAIGHT)
 	{
 		CwGen_TestFirstPaddle();
 	}

--- a/mchf-eclipse/drivers/audio/rtty.c
+++ b/mchf-eclipse/drivers/audio/rtty.c
@@ -157,8 +157,8 @@ const uint8_t Ascii2Baudot[128] =
 		0,
 };
 
-#define RTTY_SYMBOL_CODE (0b11011)
-#define RTTY_LETTER_CODE (0b11111)
+#define RTTY_SYMBOL_CODE (0b011011)
+#define RTTY_LETTER_CODE (0b111111)
 
 // RTTY Experiment based on code from the DSP Tutorial at http://dp.nonoo.hu/projects/ham-dsp-tutorial/18-rtty-decoder-using-iir-filters/
 // Used with permission from Norbert Varga, HA2NON under GPLv3 license

--- a/mchf-eclipse/drivers/ui/menu/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu.c
@@ -1641,7 +1641,7 @@ void UiMenu_UpdateItem(uint16_t select, uint16_t mode, int pos, int var, char* o
     case MENU_KEYER_MODE:   // Keyer mode
         var_change = UiDriverMenuItemChangeUInt8(var, mode, &ts.cw_keyer_mode,
                                               0,
-                                              CW_MODE_ULTIMATE,
+                                              CW_KEYER_MODE_ULTIMATE,
                                               CW_KEYER_MODE_IAM_B,
                                               1
                                              );
@@ -1651,13 +1651,13 @@ void UiMenu_UpdateItem(uint16_t select, uint16_t mode, int pos, int var, char* o
         case CW_KEYER_MODE_IAM_B:
             txt_ptr = "IAM_B";
             break;
-        case CW_MODE_IAM_A:
+        case CW_KEYER_MODE_IAM_A:
             txt_ptr = "IAM_A";
             break;
-        case CW_MODE_STRAIGHT:
+        case CW_KEYER_MODE_STRAIGHT:
             txt_ptr = "STR_K";
             break;
-        case CW_MODE_ULTIMATE:
+        case CW_KEYER_MODE_ULTIMATE:
             txt_ptr = "ULTIM";
             break;
         }

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -5940,24 +5940,31 @@ void UiDriver_MainHandler()
 	if(USBH_HID_GetDeviceType(&hUsbHostHS) == HID_KEYBOARD)
 	{
 
-		// hid_demo.keyboard_state = HID_KEYBOARD_IDLE;
-		// hid_demo.state = HID_DEMO_KEYBOARD;
-		//HID_KeyboardMenuProcess();
-
 		HID_KEYBD_Info_TypeDef *k_pinfo;
-		char c;
+		char kbdChar;
 		k_pinfo = USBH_HID_GetKeybdInfo(&hUsbHostHS);
 
 		if(k_pinfo != NULL)
 		{
-
-			c = USBH_HID_GetASCIICode(k_pinfo);
-			if (c != '\0')
+			kbdChar = USBH_HID_GetASCIICode(k_pinfo);
+			switch(k_pinfo->keys[0])
 			{
-				UiDriver_TextMsgPutChar(c);
+			case KEY_F1:
+				ts.ptt_req = true;
+				break;
+			case KEY_F2:
+				ts.tx_stop_req = true;
+				break;
+			}
+			if (kbdChar != '\0')
+			{
+				if (is_demod_rtty())
+				{
+					DigiModes_TxBufferPutChar(kbdChar);
+				}
+				UiDriver_TextMsgPutChar(kbdChar);
 			}
 		}
-
 	}
 #endif
 #endif

--- a/mchf-eclipse/hardware/uhsdr_board.h
+++ b/mchf-eclipse/hardware/uhsdr_board.h
@@ -328,13 +328,12 @@ typedef enum {
     ENC_THREE_NUM_MODES
 } EncoderThreeModes;
 
-//
-//
+
 #define CW_KEYER_MODE_IAM_B				0
-#define CW_MODE_IAM_A				1
-#define CW_MODE_STRAIGHT			2
-#define CW_MODE_ULTIMATE			3
-#define CW_KEYER_MAX_MODE					3
+#define CW_KEYER_MODE_IAM_A				1
+#define CW_KEYER_MODE_STRAIGHT			2
+#define CW_KEYER_MODE_ULTIMATE			3
+#define CW_KEYER_MAX_MODE				3
 
 // PA power level setting enumeration
 typedef enum


### PR DESCRIPTION
- Switch CW Keyer Mode to Straight (disables RTTY CW Keyer Input)
- Now select desired RTTY mode
- Hit F1 on keyboard to start TX (or press PTT)
- Enter text, text is immediately sent out
- Hit F2 on keyboard to stop TX (or press Tune twice)
- You can also enter text before you press F1, it is stored and sent when you start TX.