### PR TITLE
Keyer implementation WIP2

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -4723,7 +4723,7 @@ static void AudioDriver_TxProcessor(AudioSample_t * const srcCodec, AudioSample_
     	break;
     	}
     }
-    else if(dmod_mode == DEMOD_CW)
+    else if(dmod_mode == DEMOD_CW || ts.cw_text_entry)
     {
         if (tune)
         {

--- a/mchf-eclipse/drivers/audio/cw/cw_gen.c
+++ b/mchf-eclipse/drivers/audio/cw/cw_gen.c
@@ -639,7 +639,7 @@ void CwGen_AddChar(ulong code)
 
 			// FIXME: HACK HACK FOR RTTY TX TESTING
 			// We can use the same buffer for all digimodes
-			if (ts.txrx_mode == TRX_MODE_TX && is_demod_rtty())
+			if (ts.txrx_mode == TRX_MODE_TX && is_demod_rtty() || ts.cw_text_entry) // Can rtty rely just on cw_text_entry here?
 			{
 				DigiModes_TxBufferPutChar(result);
 			}

--- a/mchf-eclipse/drivers/ui/radio_management.c
+++ b/mchf-eclipse/drivers/ui/radio_management.c
@@ -541,9 +541,9 @@ void RadioManagement_SwitchTxRx(uint8_t txrx_mode, bool tune_mode)
         // this code handles the ts.tx_disable
         // even if ts.tx_disble is set in CW and only in CW we still switch to TX
         // but leave the PA disabled. This is for support of CW training right with the mcHF.
-        if (RadioManagement_IsTxDisabled())
+        if (RadioManagement_IsTxDisabled() || ts.cw_text_entry)
         {
-            if (tx_ok == true && ts.dmod_mode == DEMOD_CW)
+            if ((tx_ok == true && ts.dmod_mode == DEMOD_CW) || ts.cw_text_entry)
             {
                 tx_pa_disabled = true;
             }
@@ -984,7 +984,7 @@ void RadioManagement_HandlePttOnOff()
         // we are asked to start TX
         if(ts.ptt_req)
         {
-            if(ts.txrx_mode == TRX_MODE_RX && (RadioManagement_IsTxDisabled() == false || ts.dmod_mode == DEMOD_CW))
+            if(ts.txrx_mode == TRX_MODE_RX && (RadioManagement_IsTxDisabled() == false || ts.dmod_mode == DEMOD_CW)) // FIXME cw_text_entry situation is not correctly processed
             {
                 RadioManagement_SwitchTxRx(TRX_MODE_TX,false);
             }

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -940,11 +940,11 @@ static inline void UiDriver_FButton_F5Tune()
 	{
 		if (ts.buffered_tx)
 		{
-			cap = "UNBUF";
+			cap = "TX/RX";
 		}
 		else
 		{
-			cap = "TX/RX";
+			cap = "UNBUF";
 		}
 	}
 	else
@@ -5670,6 +5670,12 @@ static void UiAction_ToggleTuneMode()
 	UiDriver_FButton_F5Tune();
 }
 
+static void UiAction_ToggleBufferedTXMode()
+{
+	ts.buffered_tx = ! ts.buffered_tx;
+	UiDriver_FButton_F5Tune();
+}
+
 static void UiAction_ToggleSplitModeOrToggleMemMode()
 {
 	if(!ts.vfo_mem_flag)	 		// update screen if in VFO (not memory) mode
@@ -5915,7 +5921,7 @@ static const keyaction_descr_t keyactions_keyer[] =
 		{ BUTTON_F2_PRESSED, 	KEYACTION_NOP, 		KEYACTION_NOP },
 		{ BUTTON_F3_PRESSED, 	KEYACTION_NOP, 		KEYACTION_NOP },
 		{ BUTTON_F4_PRESSED, 	KEYACTION_NOP, 		KEYACTION_NOP },
-		{ BUTTON_F5_PRESSED, 	KEYACTION_NOP,		KEYACTION_NOP },
+		{ BUTTON_F5_PRESSED, 	KEYACTION_NOP,		UiAction_ToggleBufferedTXMode },
 };
 
 static const keyaction_list_descr_t key_sets[] =

--- a/mchf-eclipse/hardware/uhsdr_board.h
+++ b/mchf-eclipse/hardware/uhsdr_board.h
@@ -477,6 +477,18 @@ typedef struct {
 }
 iq_balance_data_t;
 
+#define KEYER_BUTTONS 3
+#define KEYER_BUTTON_NONE 0
+#define KEYER_BUTTON_1 1
+#define KEYER_BUTTON_2 2
+#define KEYER_BUTTON_3 3
+#define KEYER_MACRO_LEN 200
+typedef struct {
+	bool active;
+	uint8_t button_recording;
+	uint8_t macro[KEYER_BUTTONS][KEYER_MACRO_LEN];
+}
+keyer_mode_t;
 
 //
 // Bands tuning values - WORKING registers - used "live" during transceiver operation
@@ -636,6 +648,7 @@ typedef struct TransceiverState
     uint8_t	cw_keyer_mode;
     uint8_t	cw_keyer_speed;
     uint8_t	cw_paddle_reverse;
+    bool cw_text_entry;
 
     uint8_t cw_keyer_weight;   // cw dit/pause ratio 100 = 1.00 -> dit == pause == dah / 3
 #define CW_KEYER_WEIGHT_DEFAULT (100)
@@ -956,7 +969,7 @@ typedef struct TransceiverState
 	uint8_t enable_rtty_decode; // new rtty encoder (experimental)
 	bool enable_ptt_rts; // disable/enable ptt via virtual serial port rts
 
-	bool keyer_mode; // disable/enable keyer mode for F1-F5 buttons
+	keyer_mode_t keyer_mode; // disable/enable keyer mode for F1-F5 buttons
 	bool buffered_tx; // disable/enable buffered sending for CW and digital modes
 } TransceiverState;
 //

--- a/mchf-eclipse/src/uhsdr_main.c
+++ b/mchf-eclipse/src/uhsdr_main.c
@@ -65,14 +65,14 @@ void HAL_GPIO_EXTI_Callback (uint16_t GPIO_Pin)
     	if (mchf_ptt_dah_line_pressed() && ts.dmod_mode != DEMOD_SAM)
     	{  // was PTT line low? Not in a RX Only Mode?
     		ts.ptt_req = true;     // yes - ONLY then do we activate PTT!  (e.g. prevent hardware bug from keying PTT!)
-    		if(ts.dmod_mode == DEMOD_CW || is_demod_rtty())
+    		if(ts.dmod_mode == DEMOD_CW || is_demod_rtty() || ts.cw_text_entry)
     		{
     			CwGen_DahIRQ();     // Yes - go to CW state machine
     		}
     	}
     	break;
     case PADDLE_DIT:
-        if((ts.dmod_mode == DEMOD_CW || is_demod_rtty()) && mchf_dit_line_pressed())
+        if((ts.dmod_mode == DEMOD_CW || is_demod_rtty() || ts.cw_text_entry) && mchf_dit_line_pressed())
         {
             ts.ptt_req = true;
             CwGen_DitIRQ();
@@ -345,8 +345,14 @@ void TransceiverStateInit(void)
     ts.i2c_speed[I2C_BUS_2] = I2C2_SPEED_DEFAULT; // Codec, EEPROM
 
     ts.rtty_atc_enable = true;
-    ts.keyer_mode = false;
+    ts.keyer_mode.active = false;
+    ts.keyer_mode.button_recording = KEYER_BUTTON_NONE;
+    for (int idx = 0; idx<KEYER_BUTTONS; idx++)
+    {
+    	ts.keyer_mode.macro[idx][0] = '\0';
+    }
     ts.buffered_tx = false;
+    ts.cw_text_entry = false;
 }
 
 void MiscInit(void)


### PR DESCRIPTION
First, sorry @db4ple I messed up with merging/rebasing, but I will try to improve for the next PR. I am using Windows GUI interface to GitHub, I should switch to git shell instead. At least I tried harder to follow style guidelines this time :)

This PR:
1. adjusts keyer functions to recent ui_driver button processing changes.
2. implements label/color changes of the button when recording macro
3. implements possibility to record a macro with limitations (works only in CW mode currently using paddle in iambic B; should work in any mode)
4. for debugging purposes macro can be replayed on the text screen without any actual sending
Buffered operation, deleting characters, saving macro text to eeprom - not implemented yet.

To try it out - connect a paddle and change setting to iambic B; switch to CW mode; long press M1 to get into keyer mode; long press BTN1 and enter some characters (e.g. "CQCQ"); short press BTN1 (now showing REC) to save; press BTN1 to simulate playing back of your recorded string (without actual sendign).

@db4ple , please, see cw_gen file if you could remove the hack and use cw_text_entry instead. The idea is to have it for any general entry of text via paddle not necessarily related to the keyer.

Next steps would be:
1. fixing cw_text_entry to work in any mode the same way (RadioManagement_HandlePttOnOff likely should be adjusted as a minimum).
2. implementing actual sending of signal in CW mode (to be used the same way in digital modes, but useful by itself)
3. a space cannot be recorded as it leaves cw state machine too early if txrx is short.
