### PR TITLE
CW Decoder Hang and other fixes.

### DIFF
--- a/mchf-eclipse/drivers/audio/cw/cw_decoder.h
+++ b/mchf-eclipse/drivers/audio/cw/cw_decoder.h
@@ -8,6 +8,16 @@
 #ifndef AUDIO_CW_CW_DECODER_H_
 #define AUDIO_CW_CW_DECODER_H_
 
+typedef struct
+{
+	float32_t sampling_freq;
+	float32_t target_freq;
+	float32_t speed;
+} cw_config_t;
+
+extern cw_config_t cw_decoder_config;
+
+
 void CwDecode_RxProcessor(float32_t * const src, int16_t blockSize);
 void CwDecode_FilterInit();
 

--- a/mchf-eclipse/drivers/audio/freedv_uhsdr.c
+++ b/mchf-eclipse/drivers/audio/freedv_uhsdr.c
@@ -240,31 +240,24 @@ typedef struct {
 } flex_buffer;
 
 static char ui_txt_msg_buffer[ui_txt_msg_buffer_max+1]; // we need to be able store the '\0' as well.
-static const char fdv_rx_empty_line[ui_txt_msg_buffer_max+1] = "                                             ";
+static const char ui_txt_empty_line[ui_txt_msg_buffer_max+1] = "                                             ";
 static int ui_txt_msg_idx= 0;
 static bool ui_txt_msg_update = false;
 
 
 void UiDriver_TextMsgClear()
 {
-    UiLcdHy28_PrintText(5,92, fdv_rx_empty_line,Yellow,Black,4);
+    UiLcdHy28_PrintText(5,92, ui_txt_empty_line,Yellow,Black,4);
     ui_txt_msg_idx = 0;
     ui_txt_msg_update = true;
 }
-void fdv_clear_display()
-{
-    UiLcdHy28_PrintText(5,116,"            ",Yellow,Black,4);
-    UiLcdHy28_PrintText(5,104,"            ",Yellow,Black,4);
-    UiDriver_TextMsgClear();
-}
-
 
 void UiDriver_TextMsgDisplay()
 {
     if (ui_txt_msg_update == true)
     {
         ui_txt_msg_update = false;
-        const char* txt_ptr = ui_txt_msg_idx == 0? fdv_rx_empty_line:ui_txt_msg_buffer;
+        const char* txt_ptr = ui_txt_msg_idx == 0? ui_txt_empty_line:ui_txt_msg_buffer;
         UiLcdHy28_PrintText(5,92,txt_ptr,Yellow,Black,4);
     }
 }
@@ -274,11 +267,13 @@ void UiDriver_TextMsgPutChar(char ch)
     if (ch=='\n' || ch == '\r')
     {
         ui_txt_msg_idx=0;
+    	ui_txt_msg_buffer[ui_txt_msg_idx] = '\0';
     }
     else if (ui_txt_msg_idx < (ui_txt_msg_buffer_max))
     {
-        ui_txt_msg_buffer[ui_txt_msg_idx]=ch; //fill from left to right
         ui_txt_msg_idx++;
+    	ui_txt_msg_buffer[ui_txt_msg_idx] = '\0'; // set the line end before we add the character prevents unterminated strings
+        ui_txt_msg_buffer[ui_txt_msg_idx-1]=ch; //fill from left to right
     }
     else
     {
@@ -288,8 +283,14 @@ void UiDriver_TextMsgPutChar(char ch)
         }
         ui_txt_msg_buffer[ui_txt_msg_buffer_max-1]=ch;
     }
-    ui_txt_msg_buffer[ui_txt_msg_idx] = '\0'; // this is the end of the string
     ui_txt_msg_update = true;
+}
+
+void fdv_clear_display()
+{
+    UiLcdHy28_PrintText(5,116,"            ",Yellow,Black,4);
+    UiLcdHy28_PrintText(5,104,"            ",Yellow,Black,4);
+    UiDriver_TextMsgClear();
 }
 
 


### PR DESCRIPTION
GO AHEAD: I had an funny issue now but, not a real problem: In RTTY Mode and with CW reception  CW Decoder and RTTY decoder are active and both send characters to the display. Nothing to worry about, we'll fix that.

- Refactored the CW decoder a little as part of the problem seeking mission
- Found a minor bug in the original implementation arduino code (non-fatal, minor)
- Found the problem with the endless loop caused by DataRecognition
not announcing the final processing correctly. Now DataRecognition should
never cause an endless loop in ErrorCorrection, and we are safe to use it
even in the interrupt, since the number of iterations is bound by CW_SIG_BUFSIZE.