### PR TITLE
CW graphical tuning helper ready for alpha test 

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -2298,6 +2298,10 @@ static void AudioDriver_DemodFM(int16_t blockSize)
 			x = (i_prev * adb.i_buffer[i]) + (adb.q_buffer[i] * q_prev);
 
 			/*        //
+			  we do not use this approximation any more, because it does not contribute significantly to saving processor cycles,
+			  and does not deliver as clean audio as we would expect.
+			  with atan2f the audio (and especially the hissing noise!) is much cleaner, DD4WH
+
 			 // What follows is adapted from "Fixed-Point Atan2 With Self Normalization", public domain code by "Jim Shima".
 			 // The result is "approximate" - but plenty good enough for speech-grade communications!
 			 //

--- a/mchf-eclipse/drivers/audio/cw/cw_decoder.h
+++ b/mchf-eclipse/drivers/audio/cw/cw_decoder.h
@@ -9,7 +9,7 @@
 #define AUDIO_CW_CW_DECODER_H_
 
 #define POS_CW_DECODER_WPM_X 	0
-#define POS_CW_DECODER_WPM_Y 	116 //79 --> this collides with the RTC!
+#define POS_CW_DECODER_WPM_Y 	104 // 116 --> above DSP box //79 --> this collides with the RTC!
 
 
 

--- a/mchf-eclipse/drivers/audio/cw/cw_decoder.h
+++ b/mchf-eclipse/drivers/audio/cw/cw_decoder.h
@@ -9,7 +9,7 @@
 #define AUDIO_CW_CW_DECODER_H_
 
 #define POS_CW_DECODER_WPM_X 	0
-#define POS_CW_DECODER_WPM_Y 	104 // 116 --> above DSP box //79 --> this collides with the RTC!
+#define POS_CW_DECODER_WPM_Y 	108 // 116 --> above DSP box //79 --> this collides with the RTC!
 
 
 

--- a/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
@@ -1230,7 +1230,9 @@ void ui_spectrum_init_cw_snap_display (uint8_t visible)
 
 void ui_spectrum_cw_snap_display (float32_t delta)
 {
-//    static float32_t old_delta = 0.0;
+	#define max_delta 140.0
+	#define divider 5.0
+	//    static float32_t old_delta = 0.0;
 	// delta is the offset from the carrier freq
 	// now we have to account for CW sidetones etc.
 
@@ -1246,17 +1248,17 @@ void ui_spectrum_cw_snap_display (float32_t delta)
     }
 
     static int old_delta_p = 0.0;
-    if(delta > 280.0)
+    if(delta > max_delta)
     {
-    	delta = 280.0;
+    	delta = max_delta;
     }
-    else if(delta < -280.0)
+    else if(delta < -max_delta)
     {
-    	delta = -280.0;
+    	delta = -max_delta;
     }
 //    delta = 0.1 * delta + 0.9 * old_delta;
 
-    int delta_p = (int)(0.5 + (delta / 10.0));
+    int delta_p = (int)(0.5 + (delta / divider));
 
     if(delta_p != old_delta_p)
     {

--- a/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
@@ -69,6 +69,7 @@ static const scope_scaling_info_t scope_scaling_factors[SCOPE_SCALE_NUM] =
 
 static void     UiSpectrum_DrawFrequencyBar();
 static void		UiSpectrum_CalculateDBm();
+void ui_spectrum_init_cw_snap_display (uint8_t visible);
 
 // FIXME: This is partially application logic and should be moved to UI and/or radio management
 // instead of monitoring change, changes should trigger update of spectrum configuration (from pull to push)
@@ -360,7 +361,10 @@ static void UiSpectrum_CreateDrawArea()
                 Grey,
                 RGB((COL_SPECTRUM_GRAD*2),(COL_SPECTRUM_GRAD*2),(COL_SPECTRUM_GRAD*2)),0);
     }
-
+    if(cw_decoder_config.snap_enable && ts.dmod_mode == DEMOD_CW)
+    {
+    	ui_spectrum_init_cw_snap_display(1);
+    }
 }
 
 void UiSpectrum_Clear()
@@ -1170,11 +1174,50 @@ static void UiSpectrum_DisplayDbm()
 }
 
 
-#define CW_snap_carrier_X	29 // central position of variable freq marker
-#define CW_snap_carrier_Y	116 // position of variable freq marker
+#define CW_snap_carrier_X	27 // central position of variable freq marker
+#define CW_snap_carrier_Y	122 // position of variable freq marker
 
-void ui_spectrum_init_cw_snap_display (void)
+void ui_spectrum_init_cw_snap_display (uint8_t visible)
 {
+	int color = Green;
+	if(!visible)
+	{
+		color = Black;
+		// also erase yellow indicator
+        UiLcdHy28_DrawFullRect(0, CW_snap_carrier_Y, 6, 57, Black);
+	}
+	//Horizontal lines of box
+	UiLcdHy28_DrawStraightLine(0,
+    		CW_snap_carrier_Y + 6,
+            27,
+            LCD_DIR_HORIZONTAL,
+            color);
+	UiLcdHy28_DrawStraightLine(32,
+    		CW_snap_carrier_Y + 6,
+            27,
+            LCD_DIR_HORIZONTAL,
+            color);
+	UiLcdHy28_DrawStraightLine(0,
+    		CW_snap_carrier_Y - 1,
+            27,
+            LCD_DIR_HORIZONTAL,
+            color);
+	UiLcdHy28_DrawStraightLine(32,
+    		CW_snap_carrier_Y - 1,
+            27,
+            LCD_DIR_HORIZONTAL,
+            color);
+	// vertical lines of box
+	UiLcdHy28_DrawStraightLine(0,
+    		CW_snap_carrier_Y - 1,
+            8,
+            LCD_DIR_VERTICAL,
+            color);
+	UiLcdHy28_DrawStraightLine(58,
+    		CW_snap_carrier_Y - 1,
+            8,
+            LCD_DIR_VERTICAL,
+            color);
 #if 0
     UiLcdHy28_DrawStraightLineDouble(((float32_t)POS_SPECTRUM_IND_X + roundf(left_filter_border_pos)), (POS_SPECTRUM_IND_Y + POS_SPECTRUM_FILTER_WIDTH_BAR_Y), roundf(width_pixel), LCD_DIR_HORIZONTAL, clr);
     UiLcdHy28_DrawStraightLine( marker_line_pos[idx],
@@ -1187,16 +1230,29 @@ void ui_spectrum_init_cw_snap_display (void)
 
 void ui_spectrum_cw_snap_display (float32_t delta)
 {
-    static float32_t old_delta = 0.0;
-    delta = delta - (float32_t)(ts.cw_sidetone_freq);
-	static int old_delta_p = 0.0;
-    if(delta > 300.0)
+//    static float32_t old_delta = 0.0;
+	// delta is the offset from the carrier freq
+	// now we have to account for CW sidetones etc.
+
+//	delta = RadioManagement_GetTXDialFrequency()/TUNE_MULT;
+//	delta = RadioManagement_GetRXDialFrequency()/TUNE_MULT;
+    if(ts.cw_lsb)
     {
-    	delta = 300.0;
+    	delta = delta + (float32_t)(ts.cw_sidetone_freq);
     }
-    else if(delta < -300.0)
+    else
     {
-    	delta = -300.0;
+    	delta = delta - (float32_t)(ts.cw_sidetone_freq);
+    }
+
+    static int old_delta_p = 0.0;
+    if(delta > 280.0)
+    {
+    	delta = 280.0;
+    }
+    else if(delta < -280.0)
+    {
+    	delta = -280.0;
     }
 //    delta = 0.1 * delta + 0.9 * old_delta;
 
@@ -1204,18 +1260,18 @@ void ui_spectrum_cw_snap_display (float32_t delta)
 
     if(delta_p != old_delta_p)
     {
-	UiLcdHy28_DrawStraightLineDouble( CW_snap_carrier_X + old_delta_p,
+	UiLcdHy28_DrawStraightLineDouble( CW_snap_carrier_X + old_delta_p + 1,
     		CW_snap_carrier_Y,
-            8,
+            6,
             LCD_DIR_VERTICAL,
             Black);
 
-	UiLcdHy28_DrawStraightLineDouble( CW_snap_carrier_X + delta_p,
+	UiLcdHy28_DrawStraightLineDouble( CW_snap_carrier_X + delta_p + 1,
     		CW_snap_carrier_Y,
-            8,
+            6,
             LCD_DIR_VERTICAL,
             Yellow);
-	old_delta = delta;
+//	old_delta = delta;
 	old_delta_p = delta_p;
     }
 }
@@ -1416,7 +1472,7 @@ static void UiSpectrum_CalculateDBm()
             }
 
             // here would be the right place to start with the SNAP mode!
-            if(cw_decoder_config.snap_enable)
+            if(cw_decoder_config.snap_enable && ts.dmod_mode == DEMOD_CW)
             {
             	 UiSpectrum_Calculate_snap(Lbin, Ubin, posbin, bin_BW);
 

--- a/mchf-eclipse/drivers/ui/radio_management.c
+++ b/mchf-eclipse/drivers/ui/radio_management.c
@@ -33,6 +33,7 @@
 #include "audio_management.h"
 
 #include "cat_driver.h"
+#include "ui_spectrum.h"
 
 
 #include "ui_configuration.h"
@@ -904,6 +905,7 @@ void RadioManagement_SetDemodMode(uint8_t new_mode)
     else if (ts.dmod_mode == DEMOD_DIGI)
     {
             RadioManagement_ChangeCodec(ts.digital_mode,0);
+            fdv_clear_display();
     }
 
     if (new_mode == DEMOD_FM && ts.dmod_mode != DEMOD_FM)
@@ -920,8 +922,14 @@ void RadioManagement_SetDemodMode(uint8_t new_mode)
     { 	// if old mode == DEMOD_CW and cw decoder is enabled:
     	// clear WPM display to make room for other modes´ display features
     	CW_Decoder_WPM_display(0);
+    	// clear tune helper for CW carrier
+    	ui_spectrum_init_cw_snap_display(0);
     }
-    // Finally update public flag
+    if(new_mode == DEMOD_CW && ts.cw_decoder_enable && cw_decoder_config.snap_enable)
+    {
+    	// draw init graphical CW carrier tuner helper
+    	ui_spectrum_init_cw_snap_display(1);
+    }    // Finally update public flag
     ts.dmod_mode = new_mode;
 
     if  (ads.af_disabled) { ads.af_disabled--; }

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -6373,7 +6373,7 @@ void UiDriver_MainHandler()
 				}
 				else if (ts.dmod_mode == DEMOD_CW && cw_decoder_config.snap_enable)
 				{
-					UiDriver_UpdateLcdFreq(ads.snap_carrier_freq, Green, UFM_SECONDARY);
+					//UiDriver_UpdateLcdFreq(ads.snap_carrier_freq, Green, UFM_SECONDARY);
 				}
 		// display AGC box and AGC state
 				const char* txt = "   ";

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -4068,7 +4068,7 @@ static void UiDriver_DisplayDigitalMode()
 	UiLcdHy28_DrawStraightLine(POS_DIGMODE_IND_X,(POS_DIGMODE_IND_Y - 1),LEFTBOX_WIDTH,LCD_DIR_HORIZONTAL,bgclr);
 	UiLcdHy28_PrintTextCentered((POS_DIGMODE_IND_X),(POS_DIGMODE_IND_Y),LEFTBOX_WIDTH,txt,color,bgclr,0);
 
-	fdv_clear_display();
+	//fdv_clear_display();
 }
 
 static void UiDriver_DisplayPowerLevel()

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -1358,8 +1358,8 @@ void UiDriver_DisplayFreqStepSize()
 
 	if(step_line)	 	// Remove underline indicating step size if one had been drawn
 	{
-		UiLcdHy28_DrawStraightLineDouble((POS_TUNE_FREQ_X + (LARGE_FONT_WIDTH * 3)),(POS_TUNE_FREQ_Y + 24),(LARGE_FONT_WIDTH*7),LCD_DIR_HORIZONTAL,Black);
-		UiLcdHy28_DrawStraightLineDouble((POS_TUNE_SPLIT_FREQ_X + (SMALL_FONT_WIDTH * 3)),(POS_TUNE_FREQ_Y + 24),(SMALL_FONT_WIDTH*7),LCD_DIR_HORIZONTAL,Black);
+		UiLcdHy28_DrawStraightLineDouble((POS_TUNE_FREQ_X + (LARGE_FONT_WIDTH * 3)),(POS_TUNE_FREQ_Y + 20),(LARGE_FONT_WIDTH*7),LCD_DIR_HORIZONTAL,Black);
+		UiLcdHy28_DrawStraightLineDouble((POS_TUNE_SPLIT_FREQ_X + (SMALL_FONT_WIDTH * 3)),(POS_TUNE_FREQ_Y + 20),(SMALL_FONT_WIDTH*7),LCD_DIR_HORIZONTAL,Black);
 	}
 
 	// Blank old step size
@@ -1388,11 +1388,11 @@ void UiDriver_DisplayFreqStepSize()
 	{
 		if(is_splitmode())
 		{
-			UiLcdHy28_DrawStraightLineDouble((POS_TUNE_SPLIT_FREQ_X + (SMALL_FONT_WIDTH * line_loc)),(POS_TUNE_FREQ_Y + 24),(SMALL_FONT_WIDTH),LCD_DIR_HORIZONTAL,White);
+			UiLcdHy28_DrawStraightLineDouble((POS_TUNE_SPLIT_FREQ_X + (SMALL_FONT_WIDTH * line_loc)),(POS_TUNE_FREQ_Y + 20),(SMALL_FONT_WIDTH),LCD_DIR_HORIZONTAL,White);
 		}
 		else
 		{
-			UiLcdHy28_DrawStraightLineDouble((POS_TUNE_FREQ_X + (LARGE_FONT_WIDTH * line_loc)),(POS_TUNE_FREQ_Y + 24),(LARGE_FONT_WIDTH),LCD_DIR_HORIZONTAL,White);
+			UiLcdHy28_DrawStraightLineDouble((POS_TUNE_FREQ_X + (LARGE_FONT_WIDTH * line_loc)),(POS_TUNE_FREQ_Y + 20),(LARGE_FONT_WIDTH),LCD_DIR_HORIZONTAL,White);
 		}
 		step_line = 1;	// indicate that a line under the step size had been drawn
 	}


### PR DESCRIPTION
- enable "carrier snap" in Debug menu: entry "Do not use: cs" [only use, if you are brave ;-)]
- enable CW decoder in CW menu
- adjust CW decoder threshold, so that CW station modulates the red LED
- change Demod_mode to CW
- adjust frequency of a CW carrier to match your sidetone by graphically matching yellow mark to centre of green box (above the DSP box)

The green small frequency display has been abandoned (was present in last pull request only for pre-alpha testing)

Also fixed freedv display bug (hopefully ;-))