### PR TITLE
Add cw_decoder.c

### DIFF
--- a/mchf-embitz/uhsdr.ebp
+++ b/mchf-embitz/uhsdr.ebp
@@ -232,6 +232,9 @@
 		<Unit filename="..\mchf-eclipse\basesw\mcHF\Middlewares\ST\STM32_USB_Host_Library\Core\Src\usbh_pipes.c">
 			<Option compilerVar="CC" />
 		</Unit>
+		<Unit filename="..\mchf-eclipse\basesw\mcHF\Middlewares\Third_Party\FatFs\src\ff.c">
+			<Option compilerVar="CC" />
+		</Unit>
 		<Unit filename="..\mchf-eclipse\basesw\mcHF\Src\adc.c">
 			<Option compilerVar="CC" />
 		</Unit>
@@ -296,6 +299,9 @@
 			<Option compilerVar="CC" />
 		</Unit>
 		<Unit filename="..\mchf-eclipse\drivers\audio\codec\uhsdr_hw_i2s.c">
+			<Option compilerVar="CC" />
+		</Unit>
+		<Unit filename="..\mchf-eclipse\drivers\audio\cw\cw_decoder.c">
 			<Option compilerVar="CC" />
 		</Unit>
 		<Unit filename="..\mchf-eclipse\drivers\audio\cw\cw_gen.c">

--- a/mchf-embitz/uhsdr_f7.ebp
+++ b/mchf-embitz/uhsdr_f7.ebp
@@ -283,6 +283,9 @@
 		<Unit filename="..\mchf-eclipse\drivers\audio\codec\uhsdr_hw_i2s.c">
 			<Option compilerVar="CC" />
 		</Unit>
+		<Unit filename="..\mchf-eclipse\drivers\audio\cw\cw_decoder.c">
+			<Option compilerVar="CC" />
+		</Unit>
 		<Unit filename="..\mchf-eclipse\drivers\audio\cw\cw_gen.c">
 			<Option compilerVar="CC" />
 		</Unit>


### PR DESCRIPTION
Add cw_decoder.c for building both version.

Had to add ff.c (FATFs) since the mcHF's usb_host.c call f_mount() "unmount" !?
The ovi40's usb_host.c don't call "unmount". 
