### PR TITLE
bugfix CW decoder

### DIFF
--- a/mchf-eclipse/drivers/audio/cw/cw_decoder.c
+++ b/mchf-eclipse/drivers/audio/cw/cw_decoder.c
@@ -325,7 +325,7 @@ static void CW_Decode_exe(void)
 		float32_t speed_ms_per_word = spdcalc * 1000.0 / (cw_decoder_config.sampling_freq / (float32_t)cw_decoder_config.blocksize);
 
 		float32_t speed_wpm_raw = (0.5 + 60000.0 / speed_ms_per_word); // calculate words per minute
-		speed_wpm_avg = speed_wpm_raw * 0.1 + 0.9 * speed_wpm_avg; // a little lowpass filtering
+		speed_wpm_avg = speed_wpm_raw * 0.3 + 0.7 * speed_wpm_avg; // a little lowpass filtering
 		cw_decoder_config.speed = speed_wpm_avg; // convert to integer
 	}
 }

--- a/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
@@ -1331,7 +1331,10 @@ void UiSpectrum_Calculate_snap(float32_t Lbin, float32_t Ubin, int posbin, float
     delta2 = (bin_BW * (1.36 * (bin3 - bin1)) / (bin1 + bin2 + bin3));
     if(delta2 > bin_BW) delta2 = 0.0;
     delta = delta1 + delta2;
-
+    if(delta > 300.0)
+    {
+    	delta = 0.0;
+    }
     help_freq = help_freq + delta;
     help_freq = 0.2 * help_freq + 0.8 * freq_old;
     //help_freq = help_freq * ((float32_t)TUNE_MULT);

--- a/mchf-eclipse/drivers/ui/menu/ui_menu_structure.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu_structure.c
@@ -245,6 +245,7 @@ const MenuDescriptor cwGroup[] =
     { MENU_CW, MENU_ITEM, MENU_CW_AUTO_MODE_SELECT, NULL, "CW LSB/USB Select", UiMenuDesc("Set appropriate sideband mode for CW. If AUTO, sideband is chosen for bands by its frequency. A long press on Mode button gets the other sideband mode")},
     { MENU_CW, MENU_ITEM, MENU_CW_DECODER, NULL,"CW decoder enable", UiMenuDesc("enable experimental CW decoding") },
     { MENU_CW, MENU_ITEM, MENU_CW_DECODER_THRESH, NULL,"Signal threshold", UiMenuDesc("All signals above this threshold are intepreted as a dit or daah") },
+    { MENU_CW, MENU_ITEM, MENU_CW_DECODER_SNAP_ENABLE, NULL,"Tune helper", UiMenuDesc("graphical tune helper: adjust frequency until yellow vertical line is in centre of green box --> right on CW carrier frequency") },
 //    { MENU_CW, MENU_ITEM, MENU_CW_DECODER_AVERAGE, NULL,"Goertzel averager", UiMenuDesc("The CW tone is averaged over N Goertzel values") },
     { MENU_CW, MENU_ITEM, MENU_CW_DECODER_BLOCKSIZE, NULL,"Blocksize for Goertzel", UiMenuDesc("How many samples are taken for the signal detection with the Goertzel algorithm?") },
 //    { MENU_CW, MENU_ITEM, MENU_CW_DECODER_AGC, NULL,"AGC for decoder", UiMenuDesc("Enable/disable AGC for CW decoder") },
@@ -385,7 +386,6 @@ const MenuDescriptor debugGroup[] =
     { MENU_DEBUG, MENU_ITEM, MENU_DEBUG_CLONEIN, NULL,"FT817 Clone Receive", UiMenuDesc("Will in future get memory data from an FT817 Clone Info (to be used with CHIRP).") },
     { MENU_DEBUG, MENU_ITEM, MENU_DEBUG_NEW_NB, NULL,"New Noiseblanker", UiMenuDesc("New noiseblanker for testing purposes") },
     { MENU_DEBUG, MENU_ITEM, MENU_DEBUG_RTTY_ATC, NULL,"RTTY ATC enable", UiMenuDesc("enable automatic threshold correction ATC for RTTY decoding") },
-    { MENU_CW, MENU_ITEM, MENU_CW_DECODER_SNAP_ENABLE, NULL,"Do not use: cs", UiMenuDesc("activate small green frequency display with CW carrier frequency") },
     { MENU_DEBUG, MENU_STOP, 0, NULL, NULL, UiMenuDesc("") }
 };
 

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -2280,7 +2280,6 @@ static void UiDriver_UpdateLcdFreq(ulong dial_freq,ushort color, ushort mode)
 			color = Yellow;
 	}
 
-#if 0
 	// Handle frequency display offset in "CW RX" modes
 	if(ts.dmod_mode == DEMOD_CW)	 		// In CW mode?
 	{
@@ -2306,7 +2305,7 @@ static void UiDriver_UpdateLcdFreq(ulong dial_freq,ushort color, ushort mode)
 			break;
 		}
 	}
-#endif
+
 	switch(mode)
 	{
 	case UFM_SMALL_RX:


### PR DESCRIPTION
- fixed a bug I introduced (thanks Danilo for finding my bug!!!)
- faster lowpass filter for WPM display
- restrict delta frequency of the TUNE HELPER to max. 300Hz (does not seem to help much . . .)
- pushed TUNE HELPER menu entry from debug menu to CW menu