### PR TITLE
Improved Support for Mode-specific Display Handling

### DIFF
--- a/mchf-eclipse/drivers/audio/cw/cw_decoder.c
+++ b/mchf-eclipse/drivers/audio/cw/cw_decoder.c
@@ -1265,25 +1265,29 @@ void CW_Decode(void)
 	}
 }
 
-void CW_Decoder_WPM_display(bool visible)
+void CwDecoder_WpmDisplayClearOrPrepare(bool prepare)
+{
+    uint16_t color1 = prepare?White:Black;
+    uint16_t color2 = prepare?Green:Black;
+
+    UiLcdHy28_PrintText(POS_CW_DECODER_WPM_X, POS_CW_DECODER_WPM_Y," --",color1,Black,0);
+    UiLcdHy28_PrintText(POS_CW_DECODER_WPM_X + 27, POS_CW_DECODER_WPM_Y, "wpm", color2, Black, 4);
+
+    if (prepare == true)
+    {
+        CwDecoder_WpmDisplayUpdate(true);
+    }
+}
+
+void CwDecoder_WpmDisplayUpdate(bool force_update)
 {
 	static uint8_t old_speed = 0;
 	char WPM_str[10];
-	const char* label;
-	uint16_t color1 = White;
-	uint16_t color2 = Green;
-	if(!visible)
-	{
-		color1 = Black;
-		color2 = Black;
-	}
 
-	if(cw_decoder_config.speed != old_speed)
+	if(cw_decoder_config.speed != old_speed || force_update == true)
 	{
 		snprintf(WPM_str, 10, "%3u", cw_decoder_config.speed);
-		label = "wpm";
-		UiLcdHy28_PrintText(POS_CW_DECODER_WPM_X, POS_CW_DECODER_WPM_Y,WPM_str,color1,Black,0);
-		UiLcdHy28_PrintText(POS_CW_DECODER_WPM_X + 27, POS_CW_DECODER_WPM_Y, label, color2, Black, 4);
+		UiLcdHy28_PrintText(POS_CW_DECODER_WPM_X, POS_CW_DECODER_WPM_Y,WPM_str,White,Black,0);
 	}
 }
 

--- a/mchf-eclipse/drivers/audio/cw/cw_decoder.h
+++ b/mchf-eclipse/drivers/audio/cw/cw_decoder.h
@@ -42,6 +42,7 @@ extern cw_config_t cw_decoder_config;
 void CwDecode_RxProcessor(float32_t * const src, int16_t blockSize);
 void CwDecode_FilterInit();
 //void CW_Decoder_WPM_display_erase();
-void CW_Decoder_WPM_display();
+void CwDecoder_WpmDisplayUpdate(bool force_update);
+void CwDecoder_WpmDisplayClearOrPrepare(bool prepare);
 
 #endif /* AUDIO_CW_CW_DECODER_H_ */

--- a/mchf-eclipse/drivers/audio/freedv_uhsdr.h
+++ b/mchf-eclipse/drivers/audio/freedv_uhsdr.h
@@ -27,12 +27,12 @@
 #define FREEDV_TX_MESSAGE	" CQ CQ CQ UHSDR " TRX_NAME " SDR with integrated FreeDV codec calling!"
 #define FREEDV_TX_DF8OE_MESSAGE	" DF8OE JO42jr using UHSDR " TRX_NAME " SDR with integrated FreeDV codec"
 
-void FreeDV_mcHF_HandleFreeDV();
+void FreeDv_HandleFreeDv();
 void FreeDV_mcHF_init();
 
-void fdv_print_ber();
-void fdv_clear_display();
-void fdv_print_SNR();
+void FreeDv_DisplayClear();
+void FreeDv_DisplayPrepare();
+void FreeDv_DisplayUpdate();
 
 #endif
 

--- a/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
@@ -69,7 +69,6 @@ static const scope_scaling_info_t scope_scaling_factors[SCOPE_SCALE_NUM] =
 
 static void     UiSpectrum_DrawFrequencyBar();
 static void		UiSpectrum_CalculateDBm();
-void ui_spectrum_init_cw_snap_display (uint8_t visible);
 
 // FIXME: This is partially application logic and should be moved to UI and/or radio management
 // instead of monitoring change, changes should trigger update of spectrum configuration (from pull to push)
@@ -360,10 +359,6 @@ static void UiSpectrum_CreateDrawArea()
                 "   DISABLED   ",
                 Grey,
                 RGB((COL_SPECTRUM_GRAD*2),(COL_SPECTRUM_GRAD*2),(COL_SPECTRUM_GRAD*2)),0);
-    }
-    if(cw_decoder_config.snap_enable && ts.dmod_mode == DEMOD_CW)
-    {
-    	ui_spectrum_init_cw_snap_display(1);
     }
 }
 
@@ -1177,7 +1172,7 @@ static void UiSpectrum_DisplayDbm()
 #define CW_snap_carrier_X	27 // central position of variable freq marker
 #define CW_snap_carrier_Y	122 // position of variable freq marker
 
-void ui_spectrum_init_cw_snap_display (uint8_t visible)
+void ui_spectrum_init_cw_snap_display (bool visible)
 {
 	int color = Green;
 	if(!visible)
@@ -1230,41 +1225,41 @@ void ui_spectrum_init_cw_snap_display (uint8_t visible)
 
 void ui_spectrum_cw_snap_display (float32_t delta)
 {
-	#define max_delta 140.0
-	#define divider 5.0
+#define max_delta 140.0
+#define divider 5.0
 	//    static float32_t old_delta = 0.0;
 
-    static int old_delta_p = 0.0;
-    if(delta > max_delta)
-    {
-    	delta = max_delta;
-    }
-    else if(delta < -max_delta)
-    {
-    	delta = -max_delta;
-    }
+	static int old_delta_p = 0.0;
+	if(delta > max_delta)
+	{
+		delta = max_delta;
+	}
+	else if(delta < -max_delta)
+	{
+		delta = -max_delta;
+	}
 
-    // no lowpass filtering required !?
-//    delta = 0.1 * delta + 0.9 * old_delta;
+	// no lowpass filtering required !?
+	//    delta = 0.1 * delta + 0.9 * old_delta;
 
-    int delta_p = (int)(0.5 + (delta / divider));
+	int delta_p = (int)(0.5 + (delta / divider));
 
-    if(delta_p != old_delta_p)
-    {
-	UiLcdHy28_DrawStraightLineDouble( CW_snap_carrier_X + old_delta_p + 1,
-    		CW_snap_carrier_Y,
-            6,
-            LCD_DIR_VERTICAL,
-            Black);
+	if(delta_p != old_delta_p)
+	{
+	    UiLcdHy28_DrawStraightLineDouble( CW_snap_carrier_X + old_delta_p + 1,
+	            CW_snap_carrier_Y,
+	            6,
+	            LCD_DIR_VERTICAL,
+	            Black);
 
-	UiLcdHy28_DrawStraightLineDouble( CW_snap_carrier_X + delta_p + 1,
-    		CW_snap_carrier_Y,
-            6,
-            LCD_DIR_VERTICAL,
-            Yellow);
-//	old_delta = delta;
-	old_delta_p = delta_p;
-    }
+	    UiLcdHy28_DrawStraightLineDouble( CW_snap_carrier_X + delta_p + 1,
+	            CW_snap_carrier_Y,
+	            6,
+	            LCD_DIR_VERTICAL,
+	            Yellow);
+	    //	old_delta = delta;
+		old_delta_p = delta_p;
+	}
 }
 
 

--- a/mchf-eclipse/drivers/ui/lcd/ui_spectrum.h
+++ b/mchf-eclipse/drivers/ui/lcd/ui_spectrum.h
@@ -24,6 +24,8 @@ void UiSpectrum_Redraw();
 void UiSpectrum_WaterfallClearData();
 void UiSpectrum_DisplayFilterBW();
 
+void ui_spectrum_init_cw_snap_display (bool visible);
+
 
 // Settings for dB/division for spectrum display
 enum

--- a/mchf-eclipse/drivers/ui/menu/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu.c
@@ -3625,10 +3625,13 @@ void UiMenu_UpdateItem(uint16_t select, uint16_t mode, int pos, int var, char* o
 
      case MENU_CW_DECODER:
          var_change = UiDriverMenuItemChangeEnableOnOffBool(var, mode, &ts.cw_decoder_enable,0,options,&clr);
-         if(!ts.cw_decoder_enable)
+         if (var_change)
          {
-				CW_Decoder_WPM_display(0);
-				Board_RedLed(LED_STATE_OFF);
+             if (ts.dmod_mode == DEMOD_CW)
+             {
+                 UiDriver_UpdateDemodSpecificDisplayAfterParamChange();
+             }
+             Board_RedLed(LED_STATE_OFF);
          }
          break;
 
@@ -3638,6 +3641,13 @@ void UiMenu_UpdateItem(uint16_t select, uint16_t mode, int pos, int var, char* o
 
      case MENU_CW_DECODER_SNAP_ENABLE:
          var_change = UiDriverMenuItemChangeEnableOnOffBool(var, mode, &cw_decoder_config.snap_enable,0,options,&clr);
+         if (var_change)
+         {
+             if (ts.dmod_mode == DEMOD_CW)
+             {
+                 UiDriver_UpdateDemodSpecificDisplayAfterParamChange();
+             }
+         }
     	 break;
 
     case MENU_DIGITAL_MODE_SELECT:

--- a/mchf-eclipse/drivers/ui/radio_management.c
+++ b/mchf-eclipse/drivers/ui/radio_management.c
@@ -850,16 +850,11 @@ bool RadioManagement_IsPowerFactorReduce(uint32_t freq)
 
 }
 
-//*----------------------------------------------------------------------------
-//* Function Name       : UiDriverSetBandPowerFactor
-//* Object              : TX chain gain is not const for the 3-30 Mhz range
-//* Input Parameters    : so adjust here
-//* Output Parameters   :
 
-/* Depends on globals: ts.pwr_adj, ts.power_level, df.tune_new, ts.flags2 & FLAGS2_LOW_BAND_BIAS_REDUCE
+/*
+ * Depends on globals: ts.pwr_adj, ts.power_level, df.tune_new, ts.flags2 & FLAGS2_LOW_BAND_BIAS_REDUCE
  * Impacts globals:    ts.tx_power_factor
  */
-
 void RadioManagement_SetBandPowerFactor(uchar band)
 {
     float32_t   pf_bandvalue, pf_levelscale;    // used as a holder for percentage of power output scaling
@@ -937,7 +932,6 @@ void RadioManagement_SetDemodMode(uint8_t new_mode)
     else if (ts.dmod_mode == DEMOD_DIGI)
     {
             RadioManagement_ChangeCodec(ts.digital_mode,0);
-            fdv_clear_display();
     }
 
     if (new_mode == DEMOD_FM && ts.dmod_mode != DEMOD_FM)
@@ -950,18 +944,6 @@ void RadioManagement_SetDemodMode(uint8_t new_mode)
     AudioDriver_TxFilterInit(new_mode);
     AudioManagement_SetSidetoneForDemodMode(new_mode,false);
 
-    if(ts.dmod_mode == DEMOD_CW && ts.cw_decoder_enable)
-    { 	// if old mode == DEMOD_CW and cw decoder is enabled:
-    	// clear WPM display to make room for other modes´ display features
-    	CW_Decoder_WPM_display(0);
-    	// clear tune helper for CW carrier
-    	ui_spectrum_init_cw_snap_display(0);
-    }
-    if(new_mode == DEMOD_CW && ts.cw_decoder_enable && cw_decoder_config.snap_enable)
-    {
-    	// draw init graphical CW carrier tuner helper
-    	ui_spectrum_init_cw_snap_display(1);
-    }    // Finally update public flag
     ts.dmod_mode = new_mode;
 
     if  (ads.af_disabled) { ads.af_disabled--; }

--- a/mchf-eclipse/drivers/ui/ui_driver.h
+++ b/mchf-eclipse/drivers/ui/ui_driver.h
@@ -182,6 +182,7 @@ void UiDriver_DebugInfo_DisplayEnable(bool enable);
 
 void UiDriver_ChangeTuningStep(uchar is_up);
 void UiDriver_UpdateDisplayAfterParamChange();
+void UiDriver_UpdateDemodSpecificDisplayAfterParamChange();
 void UiDriver_SetDemodMode(uint8_t new_mode);
 
 void UiDriver_StartUpScreenInit();


### PR DESCRIPTION
- Implemented a explicit demod mode specific display switch approach.
by first asking the old mode to clear its mode specific ui elements
and then ask the new mode to prepare its new ui elements according to the
mode's configuration.
Used FreeDV, RTTY and CW as the guinea pigs for this approach.
There is room for improvement. General idea is that each mode provides
a set of three functions (prepare, update, clear) to run the mode specific display
elements. This is not entirely implemented, especially for the "update" since this
a more difficult part to really use one approach for all (may not always be suitable)
, but seems to be the general way to go to keep complexity in check.