### PR TITLE
Fix for #1079 CW Offset Mode Shift shows wrong freq if used sideband …

### DIFF
--- a/mchf-eclipse/drivers/ui/radio_management.c
+++ b/mchf-eclipse/drivers/ui/radio_management.c
@@ -236,13 +236,7 @@ int32_t RadioManagement_GetCWDialOffset()
     switch(ts.cw_offset_mode)
     {
     case CW_OFFSET_USB_SHIFT:    // Yes - USB?
-        retval -= ts.cw_sidetone_freq;
-        // lower LO by sidetone amount
-        break;
     case CW_OFFSET_LSB_SHIFT:   // LSB?
-        retval += ts.cw_sidetone_freq;
-        // raise LO by sidetone amount
-        break;
     case CW_OFFSET_AUTO_SHIFT:  // Auto mode?  Check flag
         if(ts.cw_lsb)
         {


### PR DESCRIPTION
…does not match configured default sideband

Same issue we fixed for RX two days ago. Same solution.