### PR TITLE
Fix for #1044 (SSB TX marker in scope not drawn fully) and CW WPM dis…

### DIFF
--- a/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
@@ -130,7 +130,7 @@ static void UiSpectrum_UpdateSpectrumPixelParameters()
             case DigitalMode_FreeDV:
             	// 1500 +/- 625Hz
                 mode_marker[0] = 875;
-                mode_marker[0] = 2125;
+                mode_marker[1] = 2125;
                 sd.marker_num = 2;
                 break;
             case DigitalMode_RTTY:


### PR DESCRIPTION
…play change

- The marker line of next mode after FreeDV is now working
- CW WPM display shows "--" during initialization phase.
In this phase the calculated WPM values are next to useless, since not all information to calculate meaningful WPM with the current formula is available.