### PR TITLE
Implemented  "Keep Signal Option" for CW Shift Offset Mode

### DIFF
--- a/mchf-eclipse/drivers/ui/menu/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu.c
@@ -1747,24 +1747,24 @@ void UiMenu_UpdateItem(uint16_t select, uint16_t mode, int pos, int var, char* o
         const cw_mode_map_entry_t* curr_mode = RadioManagement_CWConfigValueToModeEntry(ts.cw_offset_mode);
         temp_var_u8 = curr_mode->sideband_mode;
 
-                var_change = UiDriverMenuItemChangeUInt8(var, mode, &temp_var_u8,
-                        0,
-                        2,
-                        2,
-                        1
-                );
+        var_change = UiDriverMenuItemChangeUInt8(var, mode, &temp_var_u8,
+                0,
+                2,
+                2,
+                1
+        );
 
-                if(var_change)      // update parameters if changed
-                {
-                    cw_mode_map_entry_t new_mode;
-                    new_mode.dial_mode = curr_mode->dial_mode;
-                    new_mode.sideband_mode = temp_var_u8;
-                    ts.cw_offset_mode = RadioManagement_CWModeEntryToConfigValue(&new_mode);
+        if(var_change)      // update parameters if changed
+        {
+            cw_mode_map_entry_t new_mode;
+            new_mode.dial_mode = curr_mode->dial_mode;
+            new_mode.sideband_mode = temp_var_u8;
+            ts.cw_offset_mode = RadioManagement_CWModeEntryToConfigValue(&new_mode);
 
-                    ts.cw_lsb = RadioManagement_CalculateCWSidebandMode();
-                    UiDriver_DisplayDemodMode();
-                    UiDriver_FrequencyUpdateLOandDisplay(true); // update frequency display and local oscillator
-                }
+            ts.cw_lsb = RadioManagement_CalculateCWSidebandMode();
+            UiDriver_DisplayDemodMode();
+            UiDriver_FrequencyUpdateLOandDisplay(true); // update frequency display and local oscillator
+        }
 
         switch(temp_var_u8)
         {
@@ -1793,7 +1793,7 @@ void UiMenu_UpdateItem(uint16_t select, uint16_t mode, int pos, int var, char* o
         );
 
         if(var_change)      // update parameters if changed
-                {
+        {
             cw_mode_map_entry_t new_mode;
             new_mode.sideband_mode = curr_mode->sideband_mode;
             new_mode.dial_mode = temp_var_u8;
@@ -1802,7 +1802,7 @@ void UiMenu_UpdateItem(uint16_t select, uint16_t mode, int pos, int var, char* o
             ts.cw_lsb = RadioManagement_CalculateCWSidebandMode();
             UiDriver_DisplayDemodMode();
             UiDriver_FrequencyUpdateLOandDisplay(true); // update frequency display and local oscillator
-                }
+        }
 
         switch(temp_var_u8)
         {
@@ -1905,7 +1905,8 @@ void UiMenu_UpdateItem(uint16_t select, uint16_t mode, int pos, int var, char* o
                                                   1
                                                  );
 
-            switch(cw_decoder_config.spikecancel) {
+            switch(cw_decoder_config.spikecancel)
+            {
             case 0:
                 txt_ptr = " OFF";
                 break;
@@ -1937,7 +1938,8 @@ void UiMenu_UpdateItem(uint16_t select, uint16_t mode, int pos, int var, char* o
             UiDriver_CreateTemperatureDisplay();
         }
 
-        switch(temp_var_u8) {
+        switch(temp_var_u8)
+        {
         case TCXO_OFF:
             txt_ptr = " OFF";
             break;
@@ -1958,7 +1960,8 @@ void UiMenu_UpdateItem(uint16_t select, uint16_t mode, int pos, int var, char* o
                                                   1
                                                  );
 
-            switch(ts.iq_auto_correction) {
+            switch(ts.iq_auto_correction)
+            {
             case 0:
                 txt_ptr = " OFF";
                 ts.display_rx_iq = true;
@@ -3634,7 +3637,9 @@ void UiMenu_UpdateItem(uint16_t select, uint16_t mode, int pos, int var, char* o
              Board_RedLed(LED_STATE_OFF);
          }
          break;
-
+     case MENU_DEBUG_CW_OFFSET_SHIFT_KEEP_SIGNAL:
+         var_change = UiDriverMenuItemChangeEnableOnOffBool(var, mode, &ts.cw_offset_shift_keep_signal,0,options,&clr);
+         break;
      case MENU_CW_DECODER_USE_3_GOERTZEL:
          var_change = UiDriverMenuItemChangeEnableOnOffBool(var, mode, &cw_decoder_config.use_3_goertzels,0,options,&clr);
     	 break;

--- a/mchf-eclipse/drivers/ui/menu/ui_menu_internal.h
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu_internal.h
@@ -245,6 +245,7 @@ enum
     CONFIG_RTC_CALIB,
     MENU_DYNAMICTUNE,
     MENU_DIGITAL_MODE_SELECT,
+    MENU_DEBUG_CW_OFFSET_SHIFT_KEEP_SIGNAL,
     MAX_RADIO_CONFIG_ITEM   // Number of radio configuration menu items - This must ALWAYS remain as the LAST item!
 };
 

--- a/mchf-eclipse/drivers/ui/menu/ui_menu_structure.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu_structure.c
@@ -381,11 +381,12 @@ const MenuDescriptor infoGroup[] =
 const MenuDescriptor debugGroup[] =
 {
     { MENU_DEBUG, MENU_ITEM, MENU_DEBUG_ENABLE_INFO, NULL,"Enable Debug Info Display", UiMenuDesc("Enable debug outputs on LCD for testing purposes (touch screen coordinates, load) and audio interrupt duration indication via green led") },
+    { MENU_DEBUG, MENU_ITEM, MENU_DEBUG_CW_OFFSET_SHIFT_KEEP_SIGNAL, NULL,"CW Shift Keeps Signal", UiMenuDesc("Enable automatic sidetone correction for CW OFFSET MODE = SHIFT. If you tuned in SSB to a CW signal around the sidetone frequency, you'll keep that signal when going to CW. Even if you switch from USB to CW-LSB etc.") },
     { MENU_DEBUG, MENU_ITEM, MENU_DEBUG_TX_AUDIO, NULL,"TX Audio via USB", UiMenuDesc("If enabled, send generated audio to PC during TX.") },
     { MENU_DEBUG, MENU_ITEM, MENU_DEBUG_CLONEOUT, NULL,"FT817 Clone Transmit", UiMenuDesc("Will in future send out memory data to an FT817 Clone Info (to be used with CHIRP).") },
     { MENU_DEBUG, MENU_ITEM, MENU_DEBUG_CLONEIN, NULL,"FT817 Clone Receive", UiMenuDesc("Will in future get memory data from an FT817 Clone Info (to be used with CHIRP).") },
     { MENU_DEBUG, MENU_ITEM, MENU_DEBUG_NEW_NB, NULL,"New Noiseblanker", UiMenuDesc("New noiseblanker for testing purposes") },
-    { MENU_DEBUG, MENU_ITEM, MENU_DEBUG_RTTY_ATC, NULL,"RTTY ATC enable", UiMenuDesc("enable automatic threshold correction ATC for RTTY decoding") },
+    { MENU_DEBUG, MENU_ITEM, MENU_DEBUG_RTTY_ATC, NULL,"RTTY ATC Enable", UiMenuDesc("Enable automatic threshold correction ATC for RTTY decoding") },
     { MENU_DEBUG, MENU_STOP, 0, NULL, NULL, UiMenuDesc("") }
 };
 

--- a/mchf-eclipse/hardware/uhsdr_board.h
+++ b/mchf-eclipse/hardware/uhsdr_board.h
@@ -968,6 +968,7 @@ typedef struct TransceiverState
 
 	uint8_t enable_rtty_decode; // new rtty encoder (experimental)
 	bool cw_decoder_enable;
+	bool cw_offset_shift_keep_signal; // experimental flag, shall we move shift by sidetone frequency to keep tuned signal?
 	bool enable_ptt_rts; // disable/enable ptt via virtual serial port rts
 
 	keyer_mode_t keyer_mode; // disable/enable keyer mode for F1-F5 buttons


### PR DESCRIPTION
What it does: Best of both worlds (in a way)
Like in RX or TX, if you are tuned to a signal around the CW sidetone frequency in SSB
you will stay tuned to this signal if going into CW mode.
I.e. if your sidetone is 700 Hz and you are tuned to 7.000.000 Hz and you hear
a CW signal with about 700 Hz, simple switch to CW. You will still hear the signal
and your frequency display will show 7.000.700 Hz, since this will be your TX
frequency.

Unlike CW RX or TX offset modes it works even if you are switching sidebands, e.g. from
SSB LSB to CW-U (USB). Also if you switch between CW-U and CW-L you'll stay
tuned to the signal (as it was in CW Shift Mode). If you switch back to SSB,
you will still be tuned to that signal.

How to operate: In CW menu, set CW Offset to "Shift". In Debug menu, switch on "CW Shift Keeps Signal".
Tune to a CW signal around the sidetone frequency, and switch to CW.

@s53dz: Give this a try and tell what you think. 