### PR TITLE
Replaced a number of double float functions with their single precision float counterparts

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -673,17 +673,17 @@ void AudioDriver_SetSamPllParameters()
     //pll
     adb.omega_min = - (2.0 * PI * adb.pll_fmax * adb.DF / IQ_SAMPLE_RATE_F); //-0.5235987756; //
     adb.omega_max = (2.0 * PI * adb.pll_fmax * adb.DF / IQ_SAMPLE_RATE_F); //0.5235987756; //
-    adb.g1 = (1.0 - exp(-2.0 * adb.omegaN * adb.zeta * adb.DF / IQ_SAMPLE_RATE_F)); //0.0082987073611; //
-    adb.g2 = (- adb.g1 + 2.0 * (1 - exp(- adb.omegaN * adb.zeta * adb.DF / IQ_SAMPLE_RATE_F)
+    adb.g1 = (1.0 - expf(-2.0 * adb.omegaN * adb.zeta * adb.DF / IQ_SAMPLE_RATE_F)); //0.0082987073611; //
+    adb.g2 = (- adb.g1 + 2.0 * (1 - expf(- adb.omegaN * adb.zeta * adb.DF / IQ_SAMPLE_RATE_F)
             * cosf(adb.omegaN * adb.DF / IQ_SAMPLE_RATE_F * sqrtf(1.0 - adb.zeta * adb.zeta)))); //0.01036367597097734813032783691644; //
     //fade leveler
     //    ads.tauR_int = 20; // -->  / 1000 = 0.02
     //    ads.tauI_int = 140; // --> / 100 = 1.4
     adb.tauR = 0.02; // ((float32_t)ads.tauR_int) / 1000.0; //0.02; // original 0.02;
     adb.tauI = 1.4; // ((float32_t)ads.tauI_int) / 100.0; //1.4; // original 1.4;
-    adb.mtauR = (exp(- adb.DF / (IQ_SAMPLE_RATE_F * adb.tauR))); //0.99948;
+    adb.mtauR = (expf(- adb.DF / (IQ_SAMPLE_RATE_F * adb.tauR))); //0.99948;
     adb.onem_mtauR = (1.0 - adb.mtauR);
-    adb.mtauI = (exp(- adb.DF / (IQ_SAMPLE_RATE_F * adb.tauI))); //0.99999255955;
+    adb.mtauI = (expf(- adb.DF / (IQ_SAMPLE_RATE_F * adb.tauI))); //0.99999255955;
     adb.onem_mtauI = (1.0 - adb.mtauI);
 }
 
@@ -736,10 +736,10 @@ void AudioDriver_SetBiquadCoeffs(float32_t* coeffsTo,const float32_t* coeffsFrom
 void AudioDriver_CalcHighShelf(float32_t coeffs[6], float32_t f0, float32_t S, float32_t gain, float32_t FS)
 {
     float32_t w0 = 2 * PI * f0 / FS;
-    float32_t A = powf(10.0,gain/40.0); // gain ranges from -20 to 5
-    float32_t alpha = sin(w0) / 2 * sqrt( (A + 1/A) * (1/S - 1) + 2 );
-    float32_t cosw0 = cos(w0);
-    float32_t twoAa = 2 * sqrt(A) * alpha;
+    float32_t A = pow10f(gain/40.0); // gain ranges from -20 to 5
+    float32_t alpha = sinf(w0) / 2 * sqrtf( (A + 1/A) * (1/S - 1) + 2 );
+    float32_t cosw0 = cosf(w0);
+    float32_t twoAa = 2 * sqrtf(A) * alpha;
     // highShelf
     //
     coeffs[B0] = A *        ( (A + 1) + (A - 1) * cosw0 + twoAa );
@@ -764,11 +764,11 @@ void AudioDriver_CalcLowShelf(float32_t coeffs[6], float32_t f0, float32_t S, fl
 {
 
     float32_t w0 = 2 * PI * f0 / FS;
-    float32_t A = powf(10.0,gain/40.0); // gain ranges from -20 to 5
+    float32_t A = pow10f(gain/40.0); // gain ranges from -20 to 5
 
-    float32_t alpha = sin(w0) / 2 * sqrt( (A + 1/A) * (1/S - 1) + 2 );
-    float32_t cosw0 = cos(w0);
-    float32_t twoAa = 2 * sqrt(A) * alpha;
+    float32_t alpha = sinf(w0) / 2 * sqrtf( (A + 1/A) * (1/S - 1) + 2 );
+    float32_t cosw0 = cosf(w0);
+    float32_t twoAa = 2 * sqrtf(A) * alpha;
 
     // lowShelf
     coeffs[B0] = A *        ( (A + 1) - (A - 1) * cosw0 + twoAa );
@@ -841,13 +841,13 @@ void AudioDriver_SetRxTxAudioProcessingAudioFilters(uint8_t dmod_mode)
         float32_t f0 = ts.notch_frequency;
         float32_t Q = 10; // larger Q gives narrower notch
         float32_t w0 = 2 * PI * f0 / FSdec;
-        float32_t alpha = sin(w0) / (2 * Q);
+        float32_t alpha = sinf(w0) / (2 * Q);
 
         coeffs[B0] = 1;
-        coeffs[B1] = - 2 * cos(w0);
+        coeffs[B1] = - 2 * cosf(w0);
         coeffs[B2] = 1;
         coeffs[A0] = 1 + alpha;
-        coeffs[A1] = 2 * cos(w0); // already negated!
+        coeffs[A1] = 2 * cosf(w0); // already negated!
         coeffs[A2] = alpha - 1; // already negated!
 
         AudioDriver_SetBiquadCoeffs(&IIR_biquad_1.pCoeffs[0],coeffs,coeffs[A0]);
@@ -899,13 +899,13 @@ void AudioDriver_SetRxTxAudioProcessingAudioFilters(uint8_t dmod_mode)
         float32_t Q = 4; //
         float32_t BW = 0.03;
         float32_t w0 = 2 * PI * f0 / FSdec;
-        float32_t alpha = sin (w0) * sinh( log(2) / 2 * BW * w0 / sin(w0) ); //
+        float32_t alpha = sinf (w0) * sinhf( log(2) / 2 * BW * w0 / sinf(w0) ); //
 
         coeffs[B0] = Q * alpha;
         coeffs[B1] = 0;
         coeffs[B2] = - Q * alpha;
         coeffs[A0] = 1 + alpha;
-        coeffs[A1] = 2 * cos(w0); // already negated!
+        coeffs[A1] = 2 * cosf(w0); // already negated!
         coeffs[A2] = alpha - 1; // already negated!
 
         AudioDriver_SetBiquadCoeffs(&IIR_biquad_1.pCoeffs[5],coeffs,coeffs[A0]);

--- a/mchf-eclipse/drivers/cat/cat_driver.c
+++ b/mchf-eclipse/drivers/cat/cat_driver.c
@@ -1243,7 +1243,7 @@ static void CatDriver_HandleCommands()
             else
             {
                 // PWR / SWR
-                resp[0] =(limit_4bits(round(swrm.fwd_pwr))<<4)+limit_4bits(round(swrm.vswr_dampened));
+                resp[0] =(limit_4bits(roundf(swrm.fwd_pwr))<<4)+limit_4bits(roundf(swrm.vswr_dampened));
                 // ALC / MOD
                 resp[1] = (limit_4bits(0)<<4)+limit_4bits(0);
                 bc = 2;
@@ -1251,7 +1251,7 @@ static void CatDriver_HandleCommands()
 
             break;
         case FT817_READ_RX_STATE: /* E7 */
-            resp[0] = (uint8_t)round(sm.s_count*0.5);   //S-Meter signal
+            resp[0] = (uint8_t)roundf(sm.s_count*0.5);   //S-Meter signal
             bc = 1;
             break;
         case FT817_PTT_STATE:

--- a/mchf-eclipse/drivers/freedv/cohpsk.c
+++ b/mchf-eclipse/drivers/freedv/cohpsk.c
@@ -139,7 +139,7 @@ struct COHPSK *cohpsk_create(void)
 
         /* note non-linear carrier spacing to help PAPR, works v well in conjunction with CLIP */
 
-        freq_hz = fdmdv->fsep*( -(COHPSK_NC*ND)/2 - 0.5 + pow(c + 1.0, 0.98) );
+        freq_hz = fdmdv->fsep*( -(COHPSK_NC*ND)/2 - 0.5 + powf(c + 1.0, 0.98) );
 
 	fdmdv->freq[c].real = cosf(2.0*M_PI*freq_hz/COHPSK_FS);
  	fdmdv->freq[c].imag = sinf(2.0*M_PI*freq_hz/COHPSK_FS);

--- a/mchf-eclipse/drivers/ui/radio_management.c
+++ b/mchf-eclipse/drivers/ui/radio_management.c
@@ -1243,11 +1243,11 @@ static void RadioManagement_PowerFromADCValue(float val, float sensor_null, floa
 
     if(val <= LOW_POWER_CALC_THRESHOLD)     // is this low power as evidenced by low voltage from the sensor?
     {
-        pwr = LOW_RF_PWR_COEFF_A + (LOW_RF_PWR_COEFF_B * val) + (LOW_RF_PWR_COEFF_C * pow(val,2 )) + (LOW_RF_PWR_COEFF_D * pow(val, 3));
+        pwr = LOW_RF_PWR_COEFF_A + (LOW_RF_PWR_COEFF_B * val) + (LOW_RF_PWR_COEFF_C * powf(val,2 )) + (LOW_RF_PWR_COEFF_D * powf(val, 3));
     }
     else            // it is high power
     {
-        pwr = HIGH_RF_PWR_COEFF_A + (HIGH_RF_PWR_COEFF_B * val) + (HIGH_RF_PWR_COEFF_C * pow(val, 2));
+        pwr = HIGH_RF_PWR_COEFF_A + (HIGH_RF_PWR_COEFF_B * val) + (HIGH_RF_PWR_COEFF_C * powf(val, 2));
     }
     // calculate forward and reverse RF power in watts (p = a + bx + cx^2) for high power (above 50-60
 
@@ -1256,8 +1256,8 @@ static void RadioManagement_PowerFromADCValue(float val, float sensor_null, floa
         pwr = 0;
     }
 
-    dbm = (10 * (log10(pwr))) + 30 + coupling_calc;
-    pwr = pow10(dbm/10)/1000;
+    dbm = (10 * (log10f(pwr))) + 30 + coupling_calc;
+    pwr = pow10f(dbm/10)/1000;
     *pwr_ptr = pwr;
     *dbm_ptr = dbm;
 }

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -1523,7 +1523,7 @@ void UiDriver_DisplayFreqStepSize()
 		// ever. But it does the job of display any freq step somewhat reasonable.
 		// khz/Mhz only whole  khz/Mhz is shown, no fraction
 		// showing fractions would require some more coding, which is not yet necessary
-		const uint32_t pow10 = log10(df.tuning_step);
+		const uint32_t pow10 = log10f(df.tuning_step);
 		line_loc = 9 - pow10 - pow10/3;
 		if (line_loc < 0)
 		{
@@ -5288,8 +5288,8 @@ static bool UiDriver_TouchscreenCalibration()
 
 			UiDriver_DoCrossCheck(cross5, x_corr, y_corr);
 
-			diffx = round(*x_corr / 15);
-			diffy = round(*y_corr / 15);
+			diffx = roundf(*x_corr / 15);
+			diffy = roundf(*y_corr / 15);
 			*x_corr = diffx;
 			*y_corr = diffy;
 


### PR DESCRIPTION
I did this only in places where only float32_t seems to be involved.
Should not change a thing. Reason for change: code size reduction (a few kBytes).
Speed improvements (marginal at best).

I used fw-mchf.map to identify which double functions are still in use. 