### PR TITLE
SNAP mode implemented: in CW mode, in SAM and in AM

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -2696,7 +2696,7 @@ static void AudioDriver_NoiseReduction(int16_t blockSize)
 
 
 
-#ifdef USE_SNAP
+#if 0
 //
 //*----------------------------------------------------------------------------
 //* Function Name       : audio_snap_carrier [DD4WH, march 2016]
@@ -3490,7 +3490,7 @@ static void AudioDriver_RxProcessor(AudioSample_t * const src, AudioSample_t * c
             adb.q_buffer[i] = (float32_t)src[i].r;
         }
 
-#ifdef USE_SNAP
+#if 0
         if (sc.snap) {
             if (sc.state == 0)
             {

--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -2695,231 +2695,6 @@ static void AudioDriver_NoiseReduction(int16_t blockSize)
 }
 
 
-
-#if 0
-//
-//*----------------------------------------------------------------------------
-//* Function Name       : audio_snap_carrier [DD4WH, march 2016]
-//* Object              :
-//* Object              : when called, it determines the carrier frequency inside the filter bandwidth and tunes RX to that frequency
-//* Input Parameters    : uses the new arm_rfft_fast_f32 for the FFT, that is 10 times (!!!) more accurate than the old arm_rfft_f32
-//* Output Parameters   :
-//* Functions called    :
-//*----------------------------------------------------------------------------
-
-static void AudioDriver_SnapCarrier (void)
-{
-
-    const float32_t buff_len = FFT_IQ_BUFF_LEN2;
-    // the calculation of bin_BW is perfectly right at the moment, but we have to change it, if we switch to using the spectrum display zoom FFT to finetune
-    //    const float32_t bin_BW = (float32_t) (48000.0 * 2.0 / (buff_len * (1 << sd.magnify))); // width of a 1024 tap FFT bin = 46.875Hz, if FFT_IQ_BUFF_LEN2 = 2048 --> 1024 tap FFT
-    const float32_t bin_BW = (float32_t) (IQ_SAMPLE_RATE_F * 2.0 / (buff_len));
-    const int buff_len_int = FFT_IQ_BUFF_LEN2;
-
-    float32_t   FFT_MagData[FFT_IQ_BUFF_LEN2/2];
-
-    float32_t bw_LSB = 0.0;
-    float32_t bw_USB = 0.0;
-
-    float32_t help_freq = (float32_t)df.tune_old / ((float32_t)TUNE_MULT);
-
-    //	determine posbin (where we receive at the moment) from ts.iq_freq_mode
-    const int posbin = buff_len_int/4  - (buff_len_int * (AudioDriver_GetTranslateFreq()/(IQ_SAMPLE_RATE/8)))/16;
-    const float32_t width = FilterInfo[FilterPathInfo[ts.filter_path].id].width;
-    const float32_t centre_f = FilterPathInfo[ts.filter_path].offset;
-    const float32_t offset = centre_f - (width/2.0);
-
-    //	determine Lbin and Ubin from ts.dmod_mode and FilterInfo.width
-    //	= determine bandwith separately for lower and upper sideband
-    switch(ts.dmod_mode)
-    {
-    case DEMOD_LSB:
-    {
-        bw_USB = 1000.0; // also "look" 1kHz away from carrier
-        bw_LSB = width;
-    }
-    break;
-    case DEMOD_USB:
-    {
-        bw_LSB = 1000.0; // also "look" 1kHz away from carrier
-        bw_USB = width;
-    }
-    break;
-    case DEMOD_CW:   // experimental feature for CW - morse code signals
-    {
-        if(ts.cw_offset_mode == CW_OFFSET_USB_SHIFT)  	// Yes - USB?
-        {
-            // set flag for USB-freq-correction
-            // set limits for Lbin and Ubin according to filter_settings: offset = centre frequency!!!
-            // Lbin = posbin + offset from 0Hz
-            // offset = centre_f - (width/2)
-            // Lbin = posbin + round (off/bin_BW)
-            // Ubin = posbin + round((off + width)/bin_BW)
-            bw_LSB = - 1.0 * offset;
-            bw_USB = offset + width;
-            //	        	Lbin = (float32_t)posbin + round (offset / bin_BW);
-            //	        	Ubin = (float32_t)posbin + round ((offset + width)/bin_BW);
-        }
-        else if(ts.cw_offset_mode == CW_OFFSET_LSB_SHIFT) 	// LSB?
-        {
-            bw_USB = - 1.0 * offset;
-            bw_LSB = offset + width;
-            //	        	Ubin = (float32_t)posbin - round (offset / bin_BW);
-            //		        Lbin = (float32_t)posbin - round ((offset + width)/bin_BW);
-        }
-        else if(ts.cw_offset_mode == CW_OFFSET_AUTO_SHIFT)	 	// Auto mode?  Check flag
-        {
-            if(ts.cw_lsb)
-            {
-                bw_USB = - 1.0 * offset;
-                bw_LSB = offset + width;
-                //			        Ubin = (float32_t)posbin - round (offset / bin_BW);
-                //			        Lbin = (float32_t)posbin - round ((offset + width)/bin_BW);
-            }
-            else
-            {
-                bw_LSB = - 1.0 * offset;
-                bw_USB = offset + width;
-                //		        	Lbin = (float32_t)posbin + round (offset / bin_BW);
-                //		        	Ubin = (float32_t)posbin + round ((offset + width)/bin_BW);
-            }
-        }
-    }
-    break;
-    case DEMOD_SAM:
-    case DEMOD_AM:
-    {
-        bw_LSB = width;
-        bw_USB = width;
-    }
-    break;
-    }
-    // calculate upper and lower limit for determination of maximum magnitude
-    const float32_t Lbin = (float32_t)posbin - round(bw_LSB / bin_BW);
-    const float32_t Ubin = (float32_t)posbin + round(bw_USB / bin_BW); // the bin on the upper sideband side
-
-    /* NEVER USE THIS, THIS CAUSES BIG PROBLEMS (but I dunno why . . )
-     *
-     *    if(Lbin < 0)
-    {
-    	Lbin = 0;
-    }
-    if (Ubin > 255)
-    {
-    	Ubin = 255;
-    }
-     */
-    // 	FFT preparation
-    // we do not need to scale for this purpose !
-    // arm_scale_f32((float32_t *)sc.FFT_Samples, (float32_t)((1/ads.codec_gain_calc) * 1000.0), (float32_t *)sc.FFT_Samples, FFT_IQ_BUFF_LEN2);	// scale input according to A/D gain
-    //
-    // do windowing function on input data to get less "Bin Leakage" on FFT data
-    //
-    for(int i = 0; i < buff_len_int; i++)
-    {
-        //	Hanning 1.36
-        //sc.FFT_Windat[i] = 0.5 * (float32_t)((1 - (arm_cos_f32(PI*2 * (float32_t)i / (float32_t)(FFT_IQ_BUFF_LEN2-1)))) * sc.FFT_Samples[i]);
-        // Hamming 1.22
-        //sc.FFT_Windat[i] = (float32_t)((0.53836 - (0.46164 * arm_cos_f32(PI*2 * (float32_t)i / (float32_t)(FFT_IQ_BUFF_LEN2-1)))) * sc.FFT_Samples[i]);
-        // Blackman 1.75
-        float32_t help_sample = (0.42659 - (0.49656*arm_cos_f32((2.0*PI*(float32_t)i)/(buff_len-1.0))) + (0.076849*arm_cos_f32((4.0*PI*(float32_t)i)/(buff_len-1.0)))) * sc.FFT_Samples[i];
-        sc.FFT_Samples[i] = help_sample;
-    }
-
-    // run FFT
-    //		arm_rfft_f32((arm_rfft_instance_f32 *)&sc.S,(float32_t *)(sc.FFT_Windat),(float32_t *)(sc.FFT_Samples));	// Do FFT
-    //		arm_rfft_fast_f32((arm_rfft_fast_instance_f32 *)&sc.S,(float32_t *)(sc.FFT_Windat),(float32_t *)(sc.FFT_Samples),0);	// Do FFT
-    arm_rfft_fast_f32(&sc.S,sc.FFT_Samples,sc.FFT_Samples,0);	// Do FFT
-    //
-    // Calculate magnitude
-    // as I understand this, this takes two samples and calculates ONE magnitude from this --> length is FFT_IQ_BUFF_LEN2 / 2
-    arm_cmplx_mag_f32(sc.FFT_Samples, FFT_MagData,(buff_len_int/2));
-    //
-    // putting the bins in frequency-sequential order!
-    // it puts the Magnitude samples into FFT_Samples again
-    // the samples are centred at FFT_IQ_BUFF_LEN2 / 2, so go from FFT_IQ_BUFF_LEN2 / 2 to the right and fill the buffer sc.FFT_Samples,
-    // when you have come to the end (FFT_IQ_BUFF_LEN2), continue from FFT_IQ_BUFF_LEN2 / 2 to the left until you have reached sample 0
-    //
-    for(int i = 0; i < (buff_len_int/2); i++)
-    {
-        if(i < (buff_len_int/4))	 		// build left half of magnitude data
-        {
-            sc.FFT_Samples[i] = FFT_MagData[i + buff_len_int/4];	// get data
-        }
-        else	 							// build right half of magnitude data
-        {
-            sc.FFT_Samples[i] = FFT_MagData[i - buff_len_int/4];	// get data
-        }
-    }
-    //####################################################################
-    if (sc.FFT_number == 0)
-    {
-        // look for maximum value and save the bin # for frequency delta calculation
-        float32_t maximum = 0.0;
-        float32_t maxbin = 1.0;
-        float32_t delta = 0.0;
-
-        for (int c = (int)Lbin; c <= (int)Ubin; c++)   // search for FFT bin with highest value = carrier and save the no. of the bin in maxbin
-        {
-            if (maximum < sc.FFT_Samples[c])
-            {
-                maximum = sc.FFT_Samples[c];
-                maxbin = c;
-            }
-        }
-
-        // ok, we have found the maximum, now save first delta frequency
-        delta = (maxbin - (float32_t)posbin) * bin_BW;
-
-        help_freq = help_freq + delta;
-
-        //        if(ts.dmod_mode == DEMOD_CW) help_freq = help_freq + centre_f; // tuning in CW mode for passband centre!
-
-        help_freq = help_freq * ((float32_t)TUNE_MULT);
-        // set frequency of Si570 with 4 * dialfrequency
-        df.tune_new = help_freq;
-        // request a retune just by changing the frequency
-
-        //        help_freq = (float32_t)df.tune_new / 4.0;
-        sc.FFT_number = 1;
-        sc.state    = 0;
-        arm_fill_f32(0.0,sc.FFT_Samples,buff_len_int);
-    }
-    else
-    {
-        // ######################################################
-
-        // and now: fine-tuning:
-        //	get amplitude values of the three bins around the carrier
-
-        float32_t bin1 = sc.FFT_Samples[posbin-1];
-        float32_t bin2 = sc.FFT_Samples[posbin];
-        float32_t bin3 = sc.FFT_Samples[posbin+1];
-
-        if (bin1+bin2+bin3 == 0.0) bin1= 0.00000001; // prevent divide by 0
-
-        // estimate frequency of carrier by three-point-interpolation of bins around maxbin
-        // formula by (Jacobsen & Kootsookos 2007) equation (4) P=1.36 for Hanning window FFT function
-
-        float32_t delta = (bin_BW * (1.75 * (bin3 - bin1)) / (bin1 + bin2 + bin3));
-        if(delta > bin_BW) delta = 0.0;
-
-        // set frequency variable with delta2
-        help_freq = help_freq + delta;
-        //       if(ts.dmod_mode == DEMOD_CW) help_freq = help_freq - centre_f; // tuning in CW mode for passband centre!
-
-        help_freq = help_freq * ((float32_t)TUNE_MULT);
-        // set frequency of Si570 with 4 * dialfrequency
-        df.tune_new = help_freq;
-        // request a retune just by changing the frequency
-
-        sc.state = 0; // reset flag for FFT sample collection (used in audio_rx_driver)
-        sc.snap = 0; // reset flag for button press (used in ui_driver)
-        sc.FFT_number = 0; // reset flag to first FFT
-    }
-}
-#endif
-
 static void AudioDriver_Mix(float32_t* src, float32_t* dst, float32_t scaling, const uint16_t blockSize)
 {
     float32_t                   e3_buffer[IQ_BUFSZ+1];
@@ -3491,6 +3266,8 @@ static void AudioDriver_RxProcessor(AudioSample_t * const src, AudioSample_t * c
         }
 
 #if 0
+        // not used any more, the new SNAP mode uses/recycles the data already collected by the spectrum/waterfall FFT
+        // DD4WH Oct 2017
         if (sc.snap) {
             if (sc.state == 0)
             {
@@ -4875,3 +4652,232 @@ void AudioDriver_I2SCallback(int16_t *src, int16_t *dst, int16_t* audioDst, int1
         Board_GreenLed(LED_STATE_OFF);
     }
 }
+
+
+#if 0
+// this version of the snap_carrier algorithm is not used anymore
+// we now use/recycle the data from the spectrum/waterfall FFT and do not use a specific FFT anymore
+// DD4WH Oct 2017
+
+//
+//*----------------------------------------------------------------------------
+//* Function Name       : audio_snap_carrier [DD4WH, march 2016]
+//* Object              :
+//* Object              : when called, it determines the carrier frequency inside the filter bandwidth and tunes RX to that frequency
+//* Input Parameters    : uses the new arm_rfft_fast_f32 for the FFT, that is 10 times (!!!) more accurate than the old arm_rfft_f32
+//* Output Parameters   :
+//* Functions called    :
+//*----------------------------------------------------------------------------
+
+static void AudioDriver_SnapCarrier (void)
+{
+
+    const float32_t buff_len = FFT_IQ_BUFF_LEN2;
+    // the calculation of bin_BW is perfectly right at the moment, but we have to change it, if we switch to using the spectrum display zoom FFT to finetune
+    //    const float32_t bin_BW = (float32_t) (48000.0 * 2.0 / (buff_len * (1 << sd.magnify))); // width of a 1024 tap FFT bin = 46.875Hz, if FFT_IQ_BUFF_LEN2 = 2048 --> 1024 tap FFT
+    const float32_t bin_BW = (float32_t) (IQ_SAMPLE_RATE_F * 2.0 / (buff_len));
+    const int buff_len_int = FFT_IQ_BUFF_LEN2;
+
+    float32_t   FFT_MagData[FFT_IQ_BUFF_LEN2/2];
+
+    float32_t bw_LSB = 0.0;
+    float32_t bw_USB = 0.0;
+
+    float32_t help_freq = (float32_t)df.tune_old / ((float32_t)TUNE_MULT);
+
+    //	determine posbin (where we receive at the moment) from ts.iq_freq_mode
+    const int posbin = buff_len_int/4  - (buff_len_int * (AudioDriver_GetTranslateFreq()/(IQ_SAMPLE_RATE/8)))/16;
+    const float32_t width = FilterInfo[FilterPathInfo[ts.filter_path].id].width;
+    const float32_t centre_f = FilterPathInfo[ts.filter_path].offset;
+    const float32_t offset = centre_f - (width/2.0);
+
+    //	determine Lbin and Ubin from ts.dmod_mode and FilterInfo.width
+    //	= determine bandwith separately for lower and upper sideband
+    switch(ts.dmod_mode)
+    {
+    case DEMOD_LSB:
+    {
+        bw_USB = 1000.0; // also "look" 1kHz away from carrier
+        bw_LSB = width;
+    }
+    break;
+    case DEMOD_USB:
+    {
+        bw_LSB = 1000.0; // also "look" 1kHz away from carrier
+        bw_USB = width;
+    }
+    break;
+    case DEMOD_CW:   // experimental feature for CW - morse code signals
+    {
+        if(ts.cw_offset_mode == CW_OFFSET_USB_SHIFT)  	// Yes - USB?
+        {
+            // set flag for USB-freq-correction
+            // set limits for Lbin and Ubin according to filter_settings: offset = centre frequency!!!
+            // Lbin = posbin + offset from 0Hz
+            // offset = centre_f - (width/2)
+            // Lbin = posbin + round (off/bin_BW)
+            // Ubin = posbin + round((off + width)/bin_BW)
+            bw_LSB = - 1.0 * offset;
+            bw_USB = offset + width;
+            //	        	Lbin = (float32_t)posbin + round (offset / bin_BW);
+            //	        	Ubin = (float32_t)posbin + round ((offset + width)/bin_BW);
+        }
+        else if(ts.cw_offset_mode == CW_OFFSET_LSB_SHIFT) 	// LSB?
+        {
+            bw_USB = - 1.0 * offset;
+            bw_LSB = offset + width;
+            //	        	Ubin = (float32_t)posbin - round (offset / bin_BW);
+            //		        Lbin = (float32_t)posbin - round ((offset + width)/bin_BW);
+        }
+        else if(ts.cw_offset_mode == CW_OFFSET_AUTO_SHIFT)	 	// Auto mode?  Check flag
+        {
+            if(ts.cw_lsb)
+            {
+                bw_USB = - 1.0 * offset;
+                bw_LSB = offset + width;
+                //			        Ubin = (float32_t)posbin - round (offset / bin_BW);
+                //			        Lbin = (float32_t)posbin - round ((offset + width)/bin_BW);
+            }
+            else
+            {
+                bw_LSB = - 1.0 * offset;
+                bw_USB = offset + width;
+                //		        	Lbin = (float32_t)posbin + round (offset / bin_BW);
+                //		        	Ubin = (float32_t)posbin + round ((offset + width)/bin_BW);
+            }
+        }
+    }
+    break;
+    case DEMOD_SAM:
+    case DEMOD_AM:
+    {
+        bw_LSB = width;
+        bw_USB = width;
+    }
+    break;
+    }
+    // calculate upper and lower limit for determination of maximum magnitude
+    const float32_t Lbin = (float32_t)posbin - round(bw_LSB / bin_BW);
+    const float32_t Ubin = (float32_t)posbin + round(bw_USB / bin_BW); // the bin on the upper sideband side
+
+    /* NEVER USE THIS, THIS CAUSES BIG PROBLEMS (but I dunno why . . )
+     *
+     *    if(Lbin < 0)
+    {
+    	Lbin = 0;
+    }
+    if (Ubin > 255)
+    {
+    	Ubin = 255;
+    }
+     */
+    // 	FFT preparation
+    // we do not need to scale for this purpose !
+    // arm_scale_f32((float32_t *)sc.FFT_Samples, (float32_t)((1/ads.codec_gain_calc) * 1000.0), (float32_t *)sc.FFT_Samples, FFT_IQ_BUFF_LEN2);	// scale input according to A/D gain
+    //
+    // do windowing function on input data to get less "Bin Leakage" on FFT data
+    //
+    for(int i = 0; i < buff_len_int; i++)
+    {
+        //	Hanning 1.36
+        //sc.FFT_Windat[i] = 0.5 * (float32_t)((1 - (arm_cos_f32(PI*2 * (float32_t)i / (float32_t)(FFT_IQ_BUFF_LEN2-1)))) * sc.FFT_Samples[i]);
+        // Hamming 1.22
+        //sc.FFT_Windat[i] = (float32_t)((0.53836 - (0.46164 * arm_cos_f32(PI*2 * (float32_t)i / (float32_t)(FFT_IQ_BUFF_LEN2-1)))) * sc.FFT_Samples[i]);
+        // Blackman 1.75
+        float32_t help_sample = (0.42659 - (0.49656*arm_cos_f32((2.0*PI*(float32_t)i)/(buff_len-1.0))) + (0.076849*arm_cos_f32((4.0*PI*(float32_t)i)/(buff_len-1.0)))) * sc.FFT_Samples[i];
+        sc.FFT_Samples[i] = help_sample;
+    }
+
+    // run FFT
+    //		arm_rfft_f32((arm_rfft_instance_f32 *)&sc.S,(float32_t *)(sc.FFT_Windat),(float32_t *)(sc.FFT_Samples));	// Do FFT
+    //		arm_rfft_fast_f32((arm_rfft_fast_instance_f32 *)&sc.S,(float32_t *)(sc.FFT_Windat),(float32_t *)(sc.FFT_Samples),0);	// Do FFT
+    arm_rfft_fast_f32(&sc.S,sc.FFT_Samples,sc.FFT_Samples,0);	// Do FFT
+    //
+    // Calculate magnitude
+    // as I understand this, this takes two samples and calculates ONE magnitude from this --> length is FFT_IQ_BUFF_LEN2 / 2
+    arm_cmplx_mag_f32(sc.FFT_Samples, FFT_MagData,(buff_len_int/2));
+    //
+    // putting the bins in frequency-sequential order!
+    // it puts the Magnitude samples into FFT_Samples again
+    // the samples are centred at FFT_IQ_BUFF_LEN2 / 2, so go from FFT_IQ_BUFF_LEN2 / 2 to the right and fill the buffer sc.FFT_Samples,
+    // when you have come to the end (FFT_IQ_BUFF_LEN2), continue from FFT_IQ_BUFF_LEN2 / 2 to the left until you have reached sample 0
+    //
+    for(int i = 0; i < (buff_len_int/2); i++)
+    {
+        if(i < (buff_len_int/4))	 		// build left half of magnitude data
+        {
+            sc.FFT_Samples[i] = FFT_MagData[i + buff_len_int/4];	// get data
+        }
+        else	 							// build right half of magnitude data
+        {
+            sc.FFT_Samples[i] = FFT_MagData[i - buff_len_int/4];	// get data
+        }
+    }
+    //####################################################################
+    if (sc.FFT_number == 0)
+    {
+        // look for maximum value and save the bin # for frequency delta calculation
+        float32_t maximum = 0.0;
+        float32_t maxbin = 1.0;
+        float32_t delta = 0.0;
+
+        for (int c = (int)Lbin; c <= (int)Ubin; c++)   // search for FFT bin with highest value = carrier and save the no. of the bin in maxbin
+        {
+            if (maximum < sc.FFT_Samples[c])
+            {
+                maximum = sc.FFT_Samples[c];
+                maxbin = c;
+            }
+        }
+
+        // ok, we have found the maximum, now save first delta frequency
+        delta = (maxbin - (float32_t)posbin) * bin_BW;
+
+        help_freq = help_freq + delta;
+
+        //        if(ts.dmod_mode == DEMOD_CW) help_freq = help_freq + centre_f; // tuning in CW mode for passband centre!
+
+        help_freq = help_freq * ((float32_t)TUNE_MULT);
+        // set frequency of Si570 with 4 * dialfrequency
+        df.tune_new = help_freq;
+        // request a retune just by changing the frequency
+
+        //        help_freq = (float32_t)df.tune_new / 4.0;
+        sc.FFT_number = 1;
+        sc.state    = 0;
+        arm_fill_f32(0.0,sc.FFT_Samples,buff_len_int);
+    }
+    else
+    {
+        // ######################################################
+
+        // and now: fine-tuning:
+        //	get amplitude values of the three bins around the carrier
+
+        float32_t bin1 = sc.FFT_Samples[posbin-1];
+        float32_t bin2 = sc.FFT_Samples[posbin];
+        float32_t bin3 = sc.FFT_Samples[posbin+1];
+
+        if (bin1+bin2+bin3 == 0.0) bin1= 0.00000001; // prevent divide by 0
+
+        // estimate frequency of carrier by three-point-interpolation of bins around maxbin
+        // formula by (Jacobsen & Kootsookos 2007) equation (4) P=1.36 for Hanning window FFT function
+
+        float32_t delta = (bin_BW * (1.75 * (bin3 - bin1)) / (bin1 + bin2 + bin3));
+        if(delta > bin_BW) delta = 0.0;
+
+        // set frequency variable with delta2
+        help_freq = help_freq + delta;
+        //       if(ts.dmod_mode == DEMOD_CW) help_freq = help_freq - centre_f; // tuning in CW mode for passband centre!
+
+        help_freq = help_freq * ((float32_t)TUNE_MULT);
+        // set frequency of Si570 with 4 * dialfrequency
+        df.tune_new = help_freq;
+        // request a retune just by changing the frequency
+
+        sc.state = 0; // reset flag for FFT sample collection (used in audio_rx_driver)
+        sc.snap = 0; // reset flag for button press (used in ui_driver)
+        sc.FFT_number = 0; // reset flag to first FFT
+    }
+}
+#endif

--- a/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
@@ -1270,6 +1270,7 @@ void UiSpectrum_CalculateSnap(float32_t Lbin, float32_t Ubin, int posbin, float3
 	if(ads.CW_signal || (ts.dmod_mode == DEMOD_AM || ts.dmod_mode == DEMOD_SAM)) // this is only done, if there has been a pulse from the CW station that exceeds the threshold
 		// in the CW decoder section
 	{
+		static uint8_t snap_counter = 0;
 		static float32_t freq_old = 10000000.0;
 	float32_t help_freq = (float32_t)df.tune_old / ((float32_t)TUNE_MULT);
 	// 1. lowpass filter all the relevant bins over 2 to 20 FFTs (?)
@@ -1335,6 +1336,20 @@ void UiSpectrum_CalculateSnap(float32_t Lbin, float32_t Ubin, int posbin, float3
     //help_freq = help_freq * ((float32_t)TUNE_MULT);
     ads.snap_carrier_freq = (ulong) (help_freq);
     freq_old = help_freq;
+
+    if(sc.snap == true)
+    {
+    	snap_counter++;
+    	if(snap_counter >= 6) // take low pass filtered 6 freq measurements
+    	{
+    		// tune to frequency
+            // set frequency of Si570 with 4 * dialfrequency
+            df.tune_new = (help_freq * ((float32_t)TUNE_MULT));
+    		// reset counter
+    		snap_counter = 0;
+    		sc.snap = false;
+    	}
+    }
 
     // graphical TUNE HELPER display
     UiSpectrum_CwSnapDisplay (delta);

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -1029,7 +1029,7 @@ static void UiDriver_DisplayFButton_F2SnapMeter()
 	}
 	else
 	{
-#ifdef SNAP
+#ifdef USE_SNAP
 		cap = "SNAP";
 		color = White;    // yes - indicate with color
 #else

--- a/mchf-eclipse/hardware/uhsdr_board.h
+++ b/mchf-eclipse/hardware/uhsdr_board.h
@@ -36,12 +36,13 @@
 
 
 
-#define USE_FREEDV //uncomment to use freedv instead of SNAP function
+//#define USE_FREEDV //uncomment to use freedv instead of SNAP function
 // #define DEBUG_FREEDV
 // hardware specific switches
 //#define HY28BHISPEED			true		// uncomment for using new HY28B in SPI with bus speed 50MHz instead of 25MHz
 
-// #define USE_FREEDV_AND_SNAP // experimental!!!
+// should be fine now (Oct 2017), since SNAP now does not use any more memory
+#define USE_FREEDV_AND_SNAP // experimental!!!
 
 
 #ifdef USE_FREEDV_AND_SNAP


### PR DESCRIPTION
A SNAP mode is now available.
- available in CW, SAM and AM 
- adjust CW threshold (in CW menu) carefully, so that red LED is modulated by the carrier (CW, SAM or AM)
- press F2 ("SNAP")
- frequency should be tuned to the carrier
Please test!
Thanks Danilo, DB4PLE for the excellent preparations for button use and ui_driver!!!