### PR TITLE
bugfix for red LED during TX

### DIFF
--- a/mchf-eclipse/.settings/org.eclipse.cdt.managedbuilder.core.prefs
+++ b/mchf-eclipse/.settings/org.eclipse.cdt.managedbuilder.core.prefs
@@ -1,0 +1,13 @@
+eclipse.preferences.version=1
+environment/buildEnvironmentInclude/ilg.gnuarmeclipse.managedbuild.cross.config.elf.debug.433341838.1123244320/CPATH/delimiter=;
+environment/buildEnvironmentInclude/ilg.gnuarmeclipse.managedbuild.cross.config.elf.debug.433341838.1123244320/CPATH/operation=remove
+environment/buildEnvironmentInclude/ilg.gnuarmeclipse.managedbuild.cross.config.elf.debug.433341838.1123244320/CPLUS_INCLUDE_PATH/delimiter=;
+environment/buildEnvironmentInclude/ilg.gnuarmeclipse.managedbuild.cross.config.elf.debug.433341838.1123244320/CPLUS_INCLUDE_PATH/operation=remove
+environment/buildEnvironmentInclude/ilg.gnuarmeclipse.managedbuild.cross.config.elf.debug.433341838.1123244320/C_INCLUDE_PATH/delimiter=;
+environment/buildEnvironmentInclude/ilg.gnuarmeclipse.managedbuild.cross.config.elf.debug.433341838.1123244320/C_INCLUDE_PATH/operation=remove
+environment/buildEnvironmentInclude/ilg.gnuarmeclipse.managedbuild.cross.config.elf.debug.433341838.1123244320/append=true
+environment/buildEnvironmentInclude/ilg.gnuarmeclipse.managedbuild.cross.config.elf.debug.433341838.1123244320/appendContributed=true
+environment/buildEnvironmentLibrary/ilg.gnuarmeclipse.managedbuild.cross.config.elf.debug.433341838.1123244320/LIBRARY_PATH/delimiter=;
+environment/buildEnvironmentLibrary/ilg.gnuarmeclipse.managedbuild.cross.config.elf.debug.433341838.1123244320/LIBRARY_PATH/operation=remove
+environment/buildEnvironmentLibrary/ilg.gnuarmeclipse.managedbuild.cross.config.elf.debug.433341838.1123244320/append=true
+environment/buildEnvironmentLibrary/ilg.gnuarmeclipse.managedbuild.cross.config.elf.debug.433341838.1123244320/appendContributed=true

--- a/mchf-eclipse/drivers/audio/cw/cw_decoder.c
+++ b/mchf-eclipse/drivers/audio/cw/cw_decoder.c
@@ -328,7 +328,6 @@ static void CW_Decode_exe(void)
 			Board_RedLed(cw_state == true? LED_STATE_ON : LED_STATE_OFF);
 		}
 
-
 	//    6.) fill into circular buffer
 	//----------------
 	// Record state changes and durations onto circular buffer
@@ -379,6 +378,11 @@ static void CW_Decode_exe(void)
 	}
 
 	cw_decoder_config.speed = speed_wpm_avg; // for external use, 0 indicates no signal condition
+
+	if(ts.txrx_mode == TRX_MODE_TX)
+	{	// just to ensure that during RX/TX switching the red LED remains lit in TX_mode
+		Board_RedLed(LED_STATE_ON);
+	}
 }
 
 void CwDecode_RxProcessor(float32_t * const src, int16_t blockSize)


### PR DESCRIPTION
Red LED is switched to ON during TX in CW_decoder, because of potential race condition between CW decoder in the Audio interrupt and TX_RX switching in the ui_driver.