### PR TITLE
Implementing prosigns for iambic entry

### DIFF
--- a/mchf-eclipse/drivers/audio/cw/cw_gen.c
+++ b/mchf-eclipse/drivers/audio/cw/cw_gen.c
@@ -68,6 +68,8 @@
 // 3 => 8ms, 13 steps
 #define CW_SMOOTH_STEPS		9	// 1 step = 0.6ms; 13 for 8ms, 9 for 5.4 ms, for internal keyer
 
+#define CW_SPACE_CHAR		1
+
 typedef struct PaddleState
 {
 	// State machine and port states
@@ -106,7 +108,7 @@ static void   CwGen_TestFirstPaddle();
 // editors by placing both in vertically split window
 const uint32_t cw_char_codes[] =
 {
-		1,    // 		-> ' '
+		CW_SPACE_CHAR,    // 		-> ' '
 		2,    // . 		-> 'E'
 		3,    // - 		-> 'T'
 		10,   // .. 	-> 'I'
@@ -205,6 +207,33 @@ const char cw_char_chars[CW_CHAR_CODES] =
 		'-',
 		',',
 		':'
+};
+
+const uint32_t cw_sign_codes[] =
+{
+		187, //   <AA>
+		750, //   <AR>
+		746, //   <AS>
+		955, //   <CT>
+		43690, // <HH>
+		958, //   <KN>
+		3775, //  <NJ>
+		2747, //  <SK>
+		686 //    <SN>
+};
+
+#define CW_SIGN_CODES (sizeof(cw_sign_codes)/sizeof(*cw_sign_codes))
+const char* cw_sign_chars[CW_SIGN_CODES] =
+{
+		"AA",
+		"AR",
+		"AS",
+		"CT",
+		"HH",
+		"KN",
+		"NJ",
+		"SK",
+		"SN"
 };
 
 // Blackman-Harris function to keep CW signal bandwidth narrow
@@ -520,6 +549,7 @@ uint32_t CwGen_ReverseCode(uint32_t code)
 static void CwGen_CheckKeyerState(void)
 {
 	uint8_t c;
+	char prosign[2];
 
 	if (CwGen_DahRequested())
 	{
@@ -537,18 +567,44 @@ static void CwGen_CheckKeyerState(void)
 				(! (ps.port_state & CW_END_PROC) && ps.space_timer < ps.space_time - ps.dah_time))
 		{
 			DigiModes_TxBufferRemove(&c);
-			for (int i = 0; i<CW_CHAR_CODES; i++)
+			if (c=='<')
 			{
-				if (cw_char_chars[i] == c)
+				DigiModes_TxBufferRemove(&c);
+				prosign[0] = c;
+				DigiModes_TxBufferRemove(&c);
+				prosign[1] = c;
+				DigiModes_TxBufferRemove(&c);
+				if (c != '>') // Something is wrong - prosign not closed by matching >, better use space then
 				{
-					ps.sending_char = CwGen_ReverseCode(cw_char_codes[i]);
-					break;
+					ps.sending_char = CW_SPACE_CHAR;
+				}
+				else
+				{
+					for (int i = 0; i<CW_SIGN_CODES; i++)
+					{
+						if (cw_sign_chars[i][0] == prosign[0] && cw_sign_chars[i][1] == prosign[1])
+						{
+							ps.sending_char = CwGen_ReverseCode(cw_sign_codes[i]);
+							break;
+						}
+					}
+				}
+
+			}
+			else
+			{
+				for (int i = 0; i<CW_CHAR_CODES; i++)
+				{
+					if (cw_char_chars[i] == c)
+					{
+						ps.sending_char = CwGen_ReverseCode(cw_char_codes[i]);
+						break;
+					}
 				}
 			}
-
 		}
 
-		if (ps.sending_char > 1) // 1 is space
+		if (ps.sending_char > CW_SPACE_CHAR) // 1 is space
 		{
 			if (ps.sending_char % 4 == 3)
 			{
@@ -699,13 +755,42 @@ void CwGen_AddChar(ulong code)
 			{
 				DigiModes_TxBufferPutChar(result);
 			}
+			// HACK END
 
 			break;
 		}
 	}
 
-	// HACK END
-	UiDriver_TextMsgPutChar(result);
+	if (result != '*')
+	{
+		UiDriver_TextMsgPutChar(result);
+	}
+	else
+	{
+		for (int i = 0; i<CW_SIGN_CODES; i++)
+		{
+			if (cw_sign_codes[i] == code) {
+				result = '-';
+
+				UiDriver_TextMsgPutSign(cw_sign_chars[i]);
+
+				// FIXME: HACK HACK FOR RTTY TX TESTING
+				// We can use the same buffer for all digimodes
+				if ((ts.txrx_mode == TRX_MODE_TX && is_demod_rtty()) || ts.cw_text_entry) // Can rtty rely just on cw_text_entry here?
+				{
+					DigiModes_TxBufferPutSign(cw_sign_chars[i]);
+				}
+				// HACK END
+
+				break;
+			}
+		}
+		if (result == '*')
+		{
+			UiDriver_TextMsgPutChar('*');
+		}
+	}
+
 	ps.cw_char = 0;
 }
 
@@ -858,7 +943,7 @@ static bool CwGen_ProcessIambic(float32_t *i_buffer,float32_t *q_buffer,ulong bl
 			ps.key_timer--;
 			if(ps.key_timer == 0)
 			{
-				if(ps.cw_char > 5000)
+				if(ps.cw_char > 50000)
 				{
 					CwGen_AddChar(-1);
 					ps.port_state &= ~CW_END_PROC;

--- a/mchf-eclipse/drivers/audio/cw/cw_gen.c
+++ b/mchf-eclipse/drivers/audio/cw/cw_gen.c
@@ -68,7 +68,6 @@
 // 3 => 8ms, 13 steps
 #define CW_SMOOTH_STEPS		9	// 1 step = 0.6ms; 13 for 8ms, 9 for 5.4 ms, for internal keyer
 
-#define CW_SPACE_CHAR		1
 
 typedef struct PaddleState
 {
@@ -103,6 +102,8 @@ PaddleState  ps;
 static bool   CwGen_ProcessStraightKey(float32_t *i_buffer,float32_t *q_buffer,ulong size);
 static bool   CwGen_ProcessIambic(float32_t *i_buffer,float32_t *q_buffer,ulong size);
 static void   CwGen_TestFirstPaddle();
+
+#define CW_SPACE_CHAR		1
 
 // The vertical listing permits easier direct comparison of code vs. character in
 // editors by placing both in vertically split window
@@ -214,6 +215,7 @@ const uint32_t cw_sign_codes[] =
 		187, //   <AA>
 		750, //   <AR>
 		746, //   <AS>
+		61114, // <CL>
 		955, //   <CT>
 		43690, // <HH>
 		958, //   <KN>
@@ -228,6 +230,7 @@ const char* cw_sign_chars[CW_SIGN_CODES] =
 		"AA",
 		"AR",
 		"AS",
+		"CL",
 		"CT",
 		"HH",
 		"KN",
@@ -235,6 +238,21 @@ const char* cw_sign_chars[CW_SIGN_CODES] =
 		"SK",
 		"SN"
 };
+
+const char cw_sign_onechar[CW_SIGN_CODES] =
+{
+		'^', // AA
+		'+', // AR
+		'&', // AS
+		'{', // CL
+		'}', // CT
+		0x7f, // HH
+		'(', // KN
+		'%', // NJ
+		'>', // SK
+		'~' // SN
+};
+
 
 // Blackman-Harris function to keep CW signal bandwidth narrow
 #define CW_SMOOTH_TBL_SIZE  128
@@ -735,6 +753,48 @@ static bool CwGen_ProcessStraightKey(float32_t *i_buffer,float32_t *q_buffer,ulo
 	}
 	return retval;
 }
+
+//------------------------------------------------------------------
+//
+// The Character Identification Function applies dot/dash pattern
+// recognition to identify the received character.
+//
+// The function returns the ASCII code for the character received,
+// or 0xff if pattern was not recognized.
+//
+//------------------------------------------------------------------
+uint8_t CwGen_CharacterIdFunc(uint32_t code)
+{
+	uint8_t out = 0xff; // 0xff selected to indicate ERROR
+	// Should never happen - Empty, spike suppression or similar
+	if (code == 0)
+	{
+		out = 0xfe;
+	}
+
+	for (int i = 0; i<CW_CHAR_CODES; i++)
+	{
+		if (cw_char_codes[i] == code) {
+			out = cw_char_chars[i];
+			break;
+		}
+	}
+
+	if (out == 0xff)
+	{
+		for (int i = 0; i<CW_SIGN_CODES; i++)
+		{
+			if (cw_sign_codes[i] == code) {
+				out = cw_sign_onechar[i];
+
+				break;
+			}
+		}
+	}
+
+	return out;
+}
+
 
 // FIXME: HACK RTTY
 #include "radio_management.h"

--- a/mchf-eclipse/drivers/audio/cw/cw_gen.h
+++ b/mchf-eclipse/drivers/audio/cw/cw_gen.h
@@ -27,4 +27,6 @@ bool	CwGen_Process(float32_t *i_buffer,float32_t *q_buffer,ulong size);
 void 	CwGen_DahIRQ();
 void 	CwGen_DitIRQ();
 
+uint8_t CwGen_CharacterIdFunc(uint32_t);
+
 #endif

--- a/mchf-eclipse/drivers/audio/rtty.c
+++ b/mchf-eclipse/drivers/audio/rtty.c
@@ -717,6 +717,14 @@ int DigiModes_TxBufferPutChar(uint8_t c)
     return ret;
 }
 
+void DigiModes_TxBufferPutSign(const char* s)
+{
+	DigiModes_TxBufferPutChar('<');
+	DigiModes_TxBufferPutChar(s[0]);
+	DigiModes_TxBufferPutChar(s[1]);
+	DigiModes_TxBufferPutChar('>');
+}
+
 void DigiModes_TxBufferReset()
 {
     digimodes_tx_tail = digimodes_tx_buffer_head;

--- a/mchf-eclipse/drivers/audio/rtty.h
+++ b/mchf-eclipse/drivers/audio/rtty.h
@@ -77,6 +77,7 @@ void RttyDecoder_ProcessSample(float32_t sample);
 int16_t Rtty_Modulator_GenSample();
 
 int DigiModes_TxBufferPutChar(uint8_t c);
+void DigiModes_TxBufferPutSign(const char* s);
 uint8_t DigiModes_TxBufferHasData();
 int DigiModes_TxBufferRemove(uint8_t* c_ptr);
 void DigiModes_TxBufferReset();

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -641,6 +641,13 @@ void UiDriver_TextMsgPutChar(char ch)
     ui_txt_msg_update = true;
 }
 
+void UiDriver_TextMsgPutSign(char *s)
+{
+	UiDriver_TextMsgPutChar('<');
+	UiDriver_TextMsgPutChar(s[0]);
+	UiDriver_TextMsgPutChar(s[1]);
+	UiDriver_TextMsgPutChar('>');
+}
 
 static void UiDriver_LeftBoxDisplay(const uint8_t row, const char *label, bool encoder_active,
 		const char* text, uint32_t color, uint32_t clr_val, bool text_is_value)

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -641,7 +641,7 @@ void UiDriver_TextMsgPutChar(char ch)
     ui_txt_msg_update = true;
 }
 
-void UiDriver_TextMsgPutSign(char *s)
+void UiDriver_TextMsgPutSign(const char *s)
 {
 	UiDriver_TextMsgPutChar('<');
 	UiDriver_TextMsgPutChar(s[0]);

--- a/mchf-eclipse/drivers/ui/ui_driver.h
+++ b/mchf-eclipse/drivers/ui/ui_driver.h
@@ -198,7 +198,7 @@ void UiDriver_StartupScreen_LogIfProblem(bool isError, const char* txt);
 void UiDriver_BacklightDimHandler();
 
 void UiDriver_TextMsgPutChar(char ch);
-void UiDriver_TextMsgPutSign(char *s);
+void UiDriver_TextMsgPutSign(const char *s);
 void UiDriver_TextMsgDisplay();
 void UiDriver_TextMsgClear();
 

--- a/mchf-eclipse/drivers/ui/ui_driver.h
+++ b/mchf-eclipse/drivers/ui/ui_driver.h
@@ -198,6 +198,7 @@ void UiDriver_StartupScreen_LogIfProblem(bool isError, const char* txt);
 void UiDriver_BacklightDimHandler();
 
 void UiDriver_TextMsgPutChar(char ch);
+void UiDriver_TextMsgPutSign(char *s);
 void UiDriver_TextMsgDisplay();
 void UiDriver_TextMsgClear();
 


### PR DESCRIPTION
This extends iambic decoding and cw keyer to include prosigns. This can be basis to further add international characters.
This is, also, part of planned rework of cw decoder to use existing code in cw_gen for cw character decoding. In turn it will result in less used memory.

@db4ple I would be happy if you removed and/or explained more your plans regarding the hack in CwGen_AddChar. Adding prosigns made it a little more complicating. The prosign is enclosed in < and > and you should process it if it is not what you would want in rtty code. I am now using part of your hackcode myself for storing keyer macro memory. Please, see if just relying on ts.cw_text_entry would be enough for you. Intention of the variable is to indicate that iambic input should be processed as inputed text (like if from keyboard). One current issue is that there is no side tone if radio is not in CW mode. 