### PR TITLE
Suppress warning strict aliasing warning when building dsp lib object files

### DIFF
--- a/mchf-eclipse/Makefile
+++ b/mchf-eclipse/Makefile
@@ -123,6 +123,7 @@ $(FIRMWARE).elf : LDFLAGS = ${LDFLAGS_F4} -T$(ROOTLOC)/arm-gcc-link.ld
 
 	include $(ROOTLOC)/bootloader.mak
 
+
 endif
 ifeq ($(BUILDFOR),F7)
 
@@ -183,16 +184,19 @@ endif
 
 # how to compile individual object files
 OBJS := $(patsubst %.S,%.o,$(patsubst %.c,%.o,$(SRC:.cpp=.o)))
+DSPLIB_OBJS := $(patsubst %.S,%.o,$(patsubst %.c,%.o,$(DSPLIB_SRC:.cpp=.o)))
 BLOBJS := $(patsubst %.S,%.o,$(patsubst %.cpp,%.o,$(BLSRC:.c=.o)))
+
+$(DSPLIB_OBJS): EXTRA_CFLAGS:= -Wno-strict-aliasing
 
 .S.o:
 	$(ECHO) "  [CC] $@"
 	@mkdir -p $(subst $(ROOTLOC)/,,$(shell dirname $<))
-	$(CC) $(CFLAGS) -std=gnu11 -c ${INC_DIRS} $< -o $@
+	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) -std=gnu11 -c ${INC_DIRS} $< -o $@
 .c.o:
 	$(ECHO) "  [CC] $@"
 	@mkdir -p $(subst $(ROOTLOC)/,,$(shell dirname $<))
-	$(CC) $(CFLAGS) -std=gnu11 -c ${INC_DIRS} $< -o $@
+	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) -std=gnu11 -c ${INC_DIRS} $< -o $@
 
 .cxx.o:
 	$(ECHO) "  [CXX] $@"
@@ -254,9 +258,9 @@ $(BOOTLOADER):  $(BOOTLOADER).bin $(BOOTLOADER).dfu
 	# compile the bootloader ARM-executables .bin / .elf and .dfu for mcHF SDR TRx, generate .map and .dmp
 
 # compilation
-$(FIRMWARE).elf:  $(OBJS) 
+$(FIRMWARE).elf:  $(OBJS) $(DSPLIB_OBJS)
 	$(ECHO) "  [LD] $@"
-	$(CXX) $(LDFLAGS)  -Xlinker --gc-sections -Llibs -Wl,-Map,$(FIRMWARE).map -o$@ $(OBJS) $(LIBS)
+	$(CXX) $(LDFLAGS)  -Xlinker --gc-sections -Llibs -Wl,-Map,$(FIRMWARE).map -o$@ $(OBJS) $(DSPLIB_OBJS) $(LIBS)
 
 # compilation
 $(BOOTLOADER).elf:  $(BLOBJS) 

--- a/mchf-eclipse/f7-files.mak
+++ b/mchf-eclipse/f7-files.mak
@@ -249,6 +249,8 @@ basesw/ovi40/Drivers/STM32F7xx_HAL_Driver/Src/stm32f7xx_ll_usb.c \
 basesw/ovi40/Drivers/STM32F7xx_HAL_Driver/Src/stm32f7xx_ll_utils.c \
 basesw/ovi40/Drivers/CMSIS/Device/ST/STM32F7xx/Source/Templates/gcc/startup_stm32f767xx.S \
 basesw/ovi40/Drivers/CMSIS/Device/ST/STM32F7xx/Source/Templates/system_stm32f7xx.c \
+
+DSPLIB_SRC:=\
 basesw/ovi40/Drivers/CMSIS/DSP_Lib/Source/TransformFunctions/arm_bitreversal2.S \
 basesw/ovi40/Drivers/CMSIS/DSP_Lib/Source/TransformFunctions/arm_bitreversal.c \
 basesw/ovi40/Drivers/CMSIS/DSP_Lib/Source/TransformFunctions/arm_cfft_f32.c \

--- a/mchf-eclipse/files.mak
+++ b/mchf-eclipse/files.mak
@@ -235,6 +235,9 @@ basesw/mcHF/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_sdmmc.c \
 basesw/mcHF/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_usb.c \
 basesw/mcHF/Drivers/CMSIS/Device/ST/STM32F4xx/Source/Templates/gcc/startup_stm32f407xx.S \
 basesw/mcHF/Drivers/CMSIS/Device/ST/STM32F4xx/Source/Templates/system_stm32f4xx.c \
+
+
+DSPLIB_SRC:=\
 basesw/mcHF/Drivers/CMSIS/DSP_Lib/Source/TransformFunctions/arm_bitreversal.c \
 basesw/mcHF/Drivers/CMSIS/DSP_Lib/Source/TransformFunctions/arm_cfft_f32.c \
 basesw/mcHF/Drivers/CMSIS/DSP_Lib/Source/TransformFunctions/arm_cfft_q15.c \


### PR DESCRIPTION
STM should fix the code, but we just suppress this warning here and only here.