### PR TITLE
Stereo SAM implemented

### DIFF
--- a/mchf-eclipse/drivers/ui/radio_management.c
+++ b/mchf-eclipse/drivers/ui/radio_management.c
@@ -1178,7 +1178,12 @@ uint32_t RadioManagement_NextAlternativeDemodMode(uint32_t loc_mode)
         break;
     case DEMOD_SAM:
         ads.sam_sideband ++;
-        if (ads.sam_sideband > SAM_SIDEBAND_MAX)
+        // stereo SAM is only switchable if you have stereo modes enabled
+        uint8_t minus = 0;
+#ifdef USE_TWO_CHANNEL_AUDIO
+        minus = !ts.stereo_enable;
+#endif
+        if (ads.sam_sideband > (SAM_SIDEBAND_MAX - minus))
         {
             ads.sam_sideband = SAM_SIDEBAND_BOTH;
             retval = DEMOD_AM;


### PR DESCRIPTION
* added Stereo SAM to stereo demodulation modes
* stereo demodulation: prevent SAM stereo from being selected when stereo mode is disabled.

So, by now, we have three stereo demodulation modes (with hardware other than the mcHF):

* IQ: listen directly to I and Q without any demodulation
* Stereo SSB: listen to LSB on the right ear and USB on the left ear
* Stereo SAM: same as Stereo SSB, but with a PLL which locks to the carrier of a broadcast station