### PR TITLE
cleanup & eliminate old school S-meter

### DIFF
--- a/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
@@ -1443,10 +1443,10 @@ static void UiSpectrum_CalculateDBm()
     // the dBm/Hz display gives an absolute measure of the signal strength of the sum of all signals inside the passband of the filter
     // we take the FFT-magnitude values of the spectrum display FFT for this purpose (which are already calculated for the spectrum display),
     // so the additional processor load and additional RAM usage should be close to zero
-    // this code also calculates the basis for the S-Meter (in sm.dbm and sm.dbmhz), if not in old school S-Meter mode
+    // this code also calculates the basis for the S-Meter (in sm.dbm and sm.dbmhz)
     //
     {
-        if( ts.txrx_mode == TRX_MODE_RX && ((ts.s_meter != DISPLAY_S_METER_STD) || (ts.display_dbm != DISPLAY_S_METER_STD )))
+        if( ts.txrx_mode == TRX_MODE_RX)
         {
             const float32_t slope = 19.8; // 19.6; --> empirical values derived from measurements by DL8MBY, 2016/06/30, Thanks!
             const float32_t cons = ts.dbm_constant - 225; // -225; //- 227.0;

--- a/mchf-eclipse/drivers/ui/menu/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu.c
@@ -1214,11 +1214,7 @@ void UiMenu_UpdateItem(uint16_t select, uint16_t mode, int pos, int var, char* o
             {
             case 1:       //
                 txt_ptr = "    WDSP AGC";        //
-                if(ts.s_meter == 0) // old school S-Meter does not work with WDSP AGC, so we switch to dBm S-Meter in that case!
-                    {
-                        ts.s_meter = 1;
-                    }
-                break;
+            break;
             default:
                 txt_ptr = "Standard AGC";        //
             }
@@ -2232,27 +2228,6 @@ void UiMenu_UpdateItem(uint16_t select, uint16_t mode, int pos, int var, char* o
         }
         break;
 
-       case    MENU_S_METER:
-           var_change = UiDriverMenuItemChangeUInt8(var, mode, &ts.s_meter,
-                                                 0,
-                                                 2,
-                                                 0,
-                                                 1
-                                                );
-
-          switch(ts.s_meter)
-           {
-           case DISPLAY_S_METER_DBM:        //
-               txt_ptr = "    based on dBm";        // dbm S-Meter
-               break;
-           case DISPLAY_S_METER_DBMHZ:  //
-               txt_ptr = " based on dBm/Hz";        // dbm/Hz display and old school S-Meter
-               break;
-           default:
-           txt_ptr =  "old school style";       // oldschool S-Meter
-            break;
-           }
-           break;
     case MENU_METER_COLOUR_UP:              // upper meter colour
         var_change = UiDriverMenuItemChangeUInt8(var, mode, &ts.meter_colour_up,
                                               0,

--- a/mchf-eclipse/drivers/ui/menu/ui_menu_structure.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu_structure.c
@@ -227,7 +227,6 @@ const MenuDescriptor displayGroup[] =
     { MENU_DISPLAY, MENU_ITEM, MENU_METER_COLOUR_DOWN, NULL, "Lower Meter Colour", UiMenuDesc("Set the colour of the scale of combined SWR/AUD/ALC-Meter") },
     { MENU_DISPLAY, MENU_ITEM, MENU_DBM_DISPLAY, NULL, "dBm display", UiMenuDesc("RX signal power (measured within the filter bandwidth) can be displayed in dBm or normalized as dBm/Hz. This value is supposed to be quite accurate to +-3dB. Preferably use low spectrum display magnify settings. Accuracy is lower for very very weak and very very strong signals.")},
     { MENU_DISPLAY, MENU_ITEM, MENU_DBM_CALIBRATE, NULL, "dBm calibrate", UiMenuDesc("dBm display calibration. Just an offset (in dB) that is added to the internally calculated dBm or dBm/Hz value.")},
-    { MENU_DISPLAY, MENU_ITEM, MENU_S_METER, NULL, "S-Meter", UiMenuDesc("Select the S-Meter measurement style. In old school mode, the RF Gain influences the displayed S-Meter value, higher RFG values increase the S-Meter value. In all other settings, the S-Meter is based on the dBm measurement and is thus a more accurate and objective reflection of the signal strength.")},
     { MENU_DISPLAY, MENU_STOP, 0, NULL, NULL, UiMenuDesc("") }
 };
 

--- a/mchf-eclipse/drivers/ui/ui_configuration.c
+++ b/mchf-eclipse/drivers/ui/ui_configuration.c
@@ -169,7 +169,7 @@ const ConfigEntryDescriptor ConfigEntryInfo[] =
     { ConfigEntry_UInt32_16, EEPROM_MANUAL_PEAK,&ts.peak_frequency,750,200,5000},
     { ConfigEntry_UInt8, EEPROM_DISPLAY_DBM,&ts.display_dbm,0,0,2},
     { ConfigEntry_Int32_16, EEPROM_DBM_CALIBRATE,&ts.dbm_constant,0,-100,100},
-    { ConfigEntry_UInt8, EEPROM_S_METER,&ts.s_meter,0,0,2},
+//    { ConfigEntry_UInt8, EEPROM_S_METER,&ts.s_meter,0,0,2},
     { ConfigEntry_UInt8, EEPROM_DIGI_MODE_CONF,&ts.digital_mode,0,0,DigitalMode_Num_Modes-1},
 	{ ConfigEntry_Int32_16, EEPROM_BASS_GAIN,&ts.bass_gain,2,-20,20},
     { ConfigEntry_Int32_16, EEPROM_TREBLE_GAIN,&ts.treble_gain,0,-20,20},

--- a/mchf-eclipse/drivers/ui/ui_configuration.h
+++ b/mchf-eclipse/drivers/ui/ui_configuration.h
@@ -526,7 +526,7 @@ uint16_t    UiConfiguration_SaveEepromValues(void);
 #define EEPROM_DISPLAY_DBM					359		// dbm display
 #define EEPROM_BASS_GAIN					360		// bass gain lowShelf filter
 #define EEPROM_TREBLE_GAIN					361		// treble gain highShelf filter
-#define	EEPROM_S_METER						362		// S-Meter configuration
+//#define	EEPROM_S_METER						362		// S-Meter configuration
 #define EEPROM_TX_FILTER					363		// TX_Filter configuration
 #define EEPROM_TX_BASS_GAIN					364		// TX bass gain lowShelf filter
 #define EEPROM_TX_TREBLE_GAIN				365		// TX treble gain highShelf filter

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -4343,21 +4343,9 @@ static void UiDriver_HandleSMeter()
 		{
 			static bool         clip_indicate = 0;
 
-			if (ts.s_meter == DISPLAY_S_METER_STD) // oldschool (os) S-meter scheme
-			{
-				sm.gain_calc = AGC_GAIN_CAL/(ads.agc_val * ads.codec_gain_calc);
-				// AGC gain calibration factor divided by (AGC loop gain setting * known A/D gain setting)
-			}
-			else if (ts.s_meter == DISPLAY_S_METER_DBM) // based on dBm calculation
-			{
-				sm.gain_calc = sm.dbm;
-			}
-			else // based on dBm/Hz calculation
-			{
-				sm.gain_calc = sm.dbmhz;
-			}
+			sm.gain_calc = sm.dbm;
 
-			const float *S_Meter_Cal_Ptr = (ts.s_meter == DISPLAY_S_METER_STD)?  S_Meter_Cal : S_Meter_Cal_dbm;
+			const float *S_Meter_Cal_Ptr = S_Meter_Cal_dbm;
 
 			// find corresponding signal level
 			for (

--- a/mchf-eclipse/hardware/uhsdr_board.h
+++ b/mchf-eclipse/hardware/uhsdr_board.h
@@ -970,7 +970,7 @@ typedef struct TransceiverState
 	int agc_wdsp_tau_decay[6];
 	int agc_wdsp_tau_hang_decay;
 
-#define DISPLAY_S_METER_STD   0
+//#define DISPLAY_S_METER_STD   0
 #define DISPLAY_S_METER_DBM   1
 #define DISPLAY_S_METER_DBMHZ 2
 


### PR DESCRIPTION
old school S-meter has no longer any functional value.
It is therefore eliminated.
Menu entry "S-Meter style" has been deleted, S-meter now is ALWAYS showing signal strength (in dBm) of the signal inside the filter passband.
