### PR TITLE
Refactored display init code / OVI40 display fix

### DIFF
--- a/mchf-eclipse/drivers/ui/lcd/ui_lcd_hy28.h
+++ b/mchf-eclipse/drivers/ui/lcd/ui_lcd_hy28.h
@@ -106,10 +106,37 @@
 typedef enum
 {
     DISPLAY_NONE = 0,
+#ifdef USE_GFX_ILI932x
     DISPLAY_HY28A_SPI,
     DISPLAY_HY28B_SPI,
-    DISPLAY_HY28B_PARALLEL
+    DISPLAY_HY28B_PARALLEL,
+#endif
+#ifdef USE_GFX_RA8875
+    DISPLAY_RA8875_SPI,
+    DISPLAY_RA8875_PARALLEL,
+
+#endif
+#ifdef USE_GFX_ILI9486
+    DISPLAY_ILI9486_PARALLEL,
+    // ATTENTION: SINCE WE HAVE NO WAY OF CHECKING IF THE DISPLAY IS REALLY THERE
+    // THIS NEEDS TO BE LAST IN THE LIST OF CHECKS AND WILL, IF ENABLED, ALWAYS "SUCCEED"
+    DISPLAY_RPI_SPI,
+#endif
+	// keep this always at the end of the enum
+	DISPLAY_NUM
 } mchf_display_types_t;
+
+typedef struct
+{
+    mchf_display_types_t display_type;
+    const char* name;
+    GPIO_TypeDef* spi_cs_port;
+    uint16_t      spi_cs_pin;
+    uint16_t      is_spi:1;
+    uint16_t      spi_speed:1;
+} uhsdr_display_info_t;
+
+extern const uhsdr_display_info_t display_infos[];
 
 
 typedef struct

--- a/mchf-eclipse/drivers/ui/menu/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu.c
@@ -478,14 +478,6 @@ void __attribute__ ((noinline)) UiDriverMenuMapStrings(char* output, uint32_t va
 }
 
 
-
-static const char* display_types[] = {
-     "No Display",
-     "HY28A SPI",
-     "HY28B SPI",
-     "HY28A/B Para."
- };
-
 /**
  * @returns: information for requested item as string. Do not write to this string.
  */
@@ -501,7 +493,7 @@ const char* UiMenu_GetSystemInfo(uint32_t* m_clr_ptr, int info_item)
     {
     case INFO_DISPLAY:
     {
-        outs = display_types[ts.display->display_type];
+        outs = display_infos[ts.display->display_type].name;
         break;
     }
     case INFO_DISPLAY_CTRL:

--- a/mchf-eclipse/drivers/usb/app/usbd_desc.c
+++ b/mchf-eclipse/drivers/usb/app/usbd_desc.c
@@ -46,6 +46,7 @@
 #include "usbd_core.h"
 #include "usbd_desc.h"
 #include "usbd_conf.h"
+
 #include "hardware/uhsdr_board.h"
 
 /** @addtogroup STM32_USB_OTG_DEVICE_LIBRARY

--- a/mchf-eclipse/hardware/uhsdr_board.c
+++ b/mchf-eclipse/hardware/uhsdr_board.c
@@ -399,21 +399,22 @@ void Board_InitMinimal()
 void Board_InitFull()
 {
 
-#ifdef STM32F4
-    // on a STM32F4 we can have the internal RTC only if there is an SPI display.
-    if (ts.display->display_type == DISPLAY_HY28A_SPI || ts.display->display_type == DISPLAY_HY28B_SPI)
+#ifdef UI_BRD_MCHF
+    // on a STM32F4 MCHF UI we can have the internal RTC only if there is an SPI display.
+    if (ts.display->use_spi == true)
 #endif
     {
         ts.rtc_present = MchfRtc_enabled();
     }
+#ifdef UI_BRD_MCHF
     // we need to find out which keyboard layout before we init the GPIOs to use it.
     // at this point we have to have called the display init and the rtc init
     // in order to know which one to use.
-    // parallel display never has a STM32 based rtc, so we do not need to check for RTC
-    if ((ts.display->display_type == DISPLAY_HY28A_SPI || ts.display->display_type == DISPLAY_HY28B_SPI) && ts.rtc_present)
+    if (ts.rtc_present)
     {
         buttons.map = &bm_sets[1][0];
     }
+#endif
 
     // Init keypad hw based on button map bm
     mchf_board_keypad_init(buttons.map);

--- a/mchf-eclipse/hardware/uhsdr_board.h
+++ b/mchf-eclipse/hardware/uhsdr_board.h
@@ -56,8 +56,11 @@
   #define USE_GFX_ILI9486
   #define USE_DISP_320_240
 #elif LCD_TYPE == 3
-  #define USE_DRIVER_RA8875
+  #define USE_GFX_RA8875
   #define USE_DISP_800_480
+  #define USE_FFT_1024
+#else
+  #error "Unsupported LCD_TYPE"
 #endif
 
 // OPTION


### PR DESCRIPTION
- more streamlined init code, using a data structures to read configuration
- fixed regression with OVI40 white screen in last few commits
- Should work for OVI40/mcHF ILI932x and ILI9486 displays
Tested OVI40/ILI932x par, mcHF ILI932x SPI, mcHF ILI9486 SPI

I noticed a broken OVI40 parallel display after rebase. Need to check that.