### PR TITLE
SPI speed-up for mcHF with ILI9486

### DIFF
--- a/mchf-eclipse/drivers/ui/lcd/ui_lcd_hy28.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_lcd_hy28.c
@@ -1826,7 +1826,7 @@ uint8_t UiLcdHy28_Init()
     {
         UiLcdHy28_ParallelDeInit();
     	mchf_display.use_spi = true;
-        UiLcdHy28_SpiInit(HY28BHISPEED);
+        UiLcdHy28_SpiInit(true);
         UiLcdHy28_Reset();
         mchf_display.DeviceCode=0x9486;
         // the "spi" interface is write-only, so we have to do an educated guess here

--- a/mchf-eclipse/drivers/ui/lcd/ui_lcd_hy28.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_lcd_hy28.c
@@ -543,6 +543,7 @@ void UiLcdHy28_SpiInit(bool hispeed)
 
 	#if defined(STM32F7)
 	  	  hspi2.Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_4;
+	  	  lcd_spi_prescaler=SPI_BAUDRATEPRESCALER_4;
 	#else
 	  	  hspi2.Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_2;
 	#endif


### PR DESCRIPTION
Wrong SPI init function call parameter fixup. After touchpanel transaction (for example detection of presence) there was not proper prescaler value set (division by 4 instead of 2). This will not affect the OVI40 SPI mode.