### PR TITLE
Spectral noise reduction clean up 

### DIFF
--- a/mchf-eclipse/drivers/audio/freedv_uhsdr.c
+++ b/mchf-eclipse/drivers/audio/freedv_uhsdr.c
@@ -740,6 +740,7 @@ void do_alternate_NR(float32_t* inputsamples, float32_t* outputsamples )
     {
         spectral_noise_reduction(inputsamples);
     }
+
     for (int k=0; k < NR_FFT_SIZE;  k++)
     {
         outputsamples[k] = inputsamples[k];

--- a/mchf-eclipse/drivers/audio/freedv_uhsdr.c
+++ b/mchf-eclipse/drivers/audio/freedv_uhsdr.c
@@ -769,7 +769,13 @@ static uint8_t NR_first_time = 1;
 
 void spectral_noise_reduction (float* in_buffer)
 {
-// half-overlapping input buffers (= overlap 50%)
+// Frank DD4WH & Michael DL2FW, November 2017
+// detailed technical description of the implemented algorithm
+// following Romanin et al. 2009 on the basis of Ephraim & Malah 1984 and Hu et al. 2001
+// can be found in our WIKI
+// https://github.com/df8oe/UHSDR/wiki/Noise-reduction
+//
+//	half-overlapping input buffers (= overlap 50%)
 // Hann window on 128 samples
 // FFT128 - inverse FFT128
 // overlap-add


### PR DESCRIPTION
* deleted code related to minimum search algorithm
* only VAD algorithm now active
* deleted unused variables
* small fixes
* now RAM usage is at about 3kbytes
* thus it should run on all hardware platforms now
Please test.

