### PR TITLE
spectral noise reduction: voice activity detector work

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_nr.c
+++ b/mchf-eclipse/drivers/audio/audio_nr.c
@@ -381,7 +381,7 @@ void spectral_noise_reduction (float* in_buffer)
 
                   for(int bindx = VAD_low; bindx < VAD_high + 1; bindx++) // try 128:
                   {
-                      float32_t D_squared = NR_Nest[bindx][0] * NR_Nest[bindx][0]; //
+                      float32_t D_squared = NR_Nest[bindx][0] * NR_Nest[bindx][0];
 //                      NR_temp_sum += (NR_X[bindx][0]/ (D_squared) ) - logf((NR_X[bindx][0] / (D_squared) )) - 1.0; // unpredictable behaviour
 //                      NR_temp_sum += (NR_X[bindx][0] * NR_X[bindx][0]/ (D_squared) ) - logf((NR_X[bindx][0] * NR_X[bindx][0] / (D_squared) )) - 1.0; //nice behaviour
                       NR_temp_sum += (NR_X[bindx][0] * NR_X[bindx][0]/ (D_squared) ); // try without log

--- a/mchf-eclipse/drivers/audio/audio_nr.c
+++ b/mchf-eclipse/drivers/audio/audio_nr.c
@@ -538,7 +538,8 @@ void spectral_noise_reduction (float* in_buffer)
               }
               #if 1
         // FINAL SPECTRAL WEIGHTING: Multiply current FFT results with NR_FFT_buffer for 128 bins with the 128 bin-specific gain factors G
-              for(int bindx = 0; bindx < NR_FFT_L / 2; bindx++) // try 128:
+//              for(int bindx = 0; bindx < NR_FFT_L / 2; bindx++) // try 128:
+                for(int bindx = VAD_low; bindx < VAD_high; bindx++) // try 128:
               {
                   NR_FFT_buffer[bindx * 2] = NR_FFT_buffer [bindx * 2] * NR_Hk[bindx] * NR_long_tone_gain[bindx]; // real part
                   NR_FFT_buffer[bindx * 2 + 1] = NR_FFT_buffer [bindx * 2 + 1] * NR_Hk[bindx] * NR_long_tone_gain[bindx]; // imag part

--- a/mchf-eclipse/drivers/audio/audio_nr.c
+++ b/mchf-eclipse/drivers/audio/audio_nr.c
@@ -236,8 +236,8 @@ static uint8_t NR_first_time = 1; // FIXME: don't put in CCM on F4, we don't ini
 static float32_t NR_long_tone[NR_FFT_L / 2][2];
 //static uint32_t NR_long_tone_counter[NR_FFT_L / 2];
 static float32_t NR_long_tone_gain[NR_FFT_L / 2];
-static uint8_t NR_VAD_delay=0;
-static uint8_t NR_VAD_duration=0; //takes the duration of the last vowel
+static int NR_VAD_delay = 0;
+static int NR_VAD_duration = 0; //takes the duration of the last vowel
 
 
 #define NR_LONG_TONE_ROUNDS 1
@@ -351,35 +351,35 @@ void spectral_noise_reduction (float* in_buffer)
                   NR_VAD = NR_temp_sum / (NR_FFT_L / 2);
                       if((NR_VAD < ts.nr_vad_thresh) || NR_first_time == 2)
                       {
-                          // noise estimation with exponential averager
-                         NR_VAD_duration=0;
+							  // noise estimation with exponential averager
+							 NR_VAD_duration=0;
 
-                	 if (NR_VAD_delay == 0) //update noise level after Speech is really over
-                	   {
-                	     for(int bindx = 0; bindx < NR_FFT_L / 2; bindx++)
-                                {   // exponential averager for current noise estimate
-                                      NR_Nest[bindx][0] = (1.0 - ts.nr_beta) * NR_X[bindx][0] + ts.nr_beta * NR_Nest[bindx][1]; //
-                                      NR_Nest[bindx][1] = NR_Nest[bindx][0];
-                                }
-                	     NR_first_time = 0;
-                	     Board_RedLed(LED_STATE_OFF);
-                	   }
-                	 else // we wait a little until the last vowel has vanished
-                	   {
+						 if (NR_VAD_delay == 0) //update noise level after Speech is really over
+						   {
+							 for(int bindx = 0; bindx < NR_FFT_L / 2; bindx++)
+									{   // exponential averager for current noise estimate
+										  NR_Nest[bindx][0] = (1.0 - ts.nr_beta) * NR_X[bindx][0] + ts.nr_beta * NR_Nest[bindx][1]; //
+										  NR_Nest[bindx][1] = NR_Nest[bindx][0];
+									}
+							 NR_first_time = 0;
+							 Board_RedLed(LED_STATE_OFF);
+						   }
+						 else // we wait a little until the last vowel has vanished
+						   {
 
-                	     if (NR_VAD_delay > 0) NR_VAD_delay--;
+							 if (NR_VAD_delay > 0) NR_VAD_delay--;
 
-                	   }
+						   }
                       }
                       else
-                	{
+                	  {
                     		Board_RedLed(LED_STATE_ON);
                     		NR_VAD_duration++;
                     		if (NR_VAD_duration > 1) //a vowel should be longer than app. 20ms
                     		  {
-                    		   NR_VAD_delay=1; // we wait 1 times app.  10ms before we start updating the noisefloor
+                    		     NR_VAD_delay = 1; // we wait 1 times app.  10ms before we start updating the noisefloor
                     		  }
-                	}
+                	  }
 
 
 

--- a/mchf-eclipse/drivers/audio/audio_nr.c
+++ b/mchf-eclipse/drivers/audio/audio_nr.c
@@ -379,7 +379,7 @@ void spectral_noise_reduction (float* in_buffer)
                 	  }
 
 
-                  for(int bindx = VAD_low; bindx < VAD_high + 1; bindx++) // try 128:
+                  for(int bindx = VAD_low; bindx < VAD_high; bindx++) // try 128:
                   {
                       float32_t D_squared = NR_Nest[bindx][0] * NR_Nest[bindx][0];
 //                      NR_temp_sum += (NR_X[bindx][0]/ (D_squared) ) - logf((NR_X[bindx][0] / (D_squared) )) - 1.0; // unpredictable behaviour

--- a/mchf-eclipse/drivers/ui/radio_management.c
+++ b/mchf-eclipse/drivers/ui/radio_management.c
@@ -978,6 +978,7 @@ void RadioManagement_SetDemodMode(uint8_t new_mode)
 
     if  (ads.af_disabled) { ads.af_disabled--; }
     if (ts.dsp_inhibit) { ts.dsp_inhibit--; }
+    ts.nr_first_time = 1; // re-initialize spectral noise reduction, when dmod_mode was changed
 
 }
 

--- a/mchf-eclipse/hardware/uhsdr_board.h
+++ b/mchf-eclipse/hardware/uhsdr_board.h
@@ -1060,6 +1060,7 @@ typedef struct TransceiverState
 	float32_t nr_vad_thresh; // threshold for voice activity detector in spectral noise reduction
 	uint32_t nr_vad_thresh_int;
 	bool nr_enable; // enable spectral noise reduction
+	uint8_t nr_first_time; // set to 1 for initialization of the NR variables
 	bool nr_gain_smooth_enable; // enable gain smoothing
 	float32_t nr_gain_smooth_alpha; // smoothing constant for gain smoothing in the spectral noise reduction
 	int16_t nr_gain_smooth_alpha_int;

--- a/mchf-eclipse/src/uhsdr_main.c
+++ b/mchf-eclipse/src/uhsdr_main.c
@@ -353,6 +353,7 @@ void TransceiverStateInit(void)
 	ts.nr_long_tone_alpha = 0.999;
 	ts.nr_long_tone_thresh = 15000;
 	ts.nr_long_tone_reset = true;
+	ts.nr_first_time = 1;
 
     // development setting for DF8OE
     if( *(__IO uint32_t*)(SRAM2_BASE+5) == 0x29)


### PR DESCRIPTION
* VAD is now without the log-part --> see here for the reason why:
citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.455.8638&rep=rep1&type=pdf
page 2, just before paragraph 3 --> equation (9).

* spectral noise reduction variables are freshly initialized when switching dmod_modes
* VAD takes only the bins in the filter bandwidth as the basis for calculating the VAD
* only the bins in the filter passband are being multiplied with the bin gains calculated by the algorithm

Problem that remains: 
* when changing from a low signal to sudden large signals (when noise estimate is low) subsequently the VAD gets too high, so that it never reaches the VAD thresh again --> no more noise estimate is done.
--> solution? could be that we clamp the decrease of the noise estimator ???