### PR TITLE
SNR: playground for automatic notch filter evaluation

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_nr.h
+++ b/mchf-eclipse/drivers/audio/audio_nr.h
@@ -20,7 +20,8 @@
 #ifdef USE_ALTERNATE_NR
 #include "freedv_uhsdr.h"
 
-#define NR_FFT_L NR_FFT_SIZE
+#define NR_FFT_L (NR_FFT_SIZE) // for NR FFT size 128
+//#define NR_FFT_L (NR_FFT_SIZE * 2) // for NR FFT size 256
 
 typedef struct NoiseReduction // declaration
 {


### PR DESCRIPTION
* no functional change
* only for testing purposes for the automatic notch filtering
* never use a 256-point-FFT in the noise reduction on the small RAM mcHF