### PR TITLE
Touch Long Press, Same Speed Zoom

### DIFF
--- a/mchf-eclipse/drivers/ui/lcd/ui_spectrum.h
+++ b/mchf-eclipse/drivers/ui/lcd/ui_spectrum.h
@@ -173,6 +173,7 @@ enum
 typedef struct SpectrumDisplay
 {
     // Samples buffer
+    float32_t   FFT_RingBuffer[FFT_IQ_BUFF_LEN];
     float32_t   FFT_Samples[FFT_IQ_BUFF_LEN];
     float32_t   FFT_MagData[SPEC_BUFF_LEN];
     float32_t   FFT_AVGData[SPEC_BUFF_LEN];     // IIR low-pass filtered FFT buffer data
@@ -182,6 +183,14 @@ typedef struct SpectrumDisplay
 
     // Current data ptr
     ulong   samp_ptr;
+    volatile bool    reading_ringbuffer;
+    // if the user level code wants to read the ring buffer
+    // simply set this, and the audio driver will stop writing
+    // to the buffer.  This means we loose some samples here but this is not a problem I would think.
+    // if we don't want or should do this,
+    // we have to add a little extra space to the ringbuffer (one audio driver sample block), which gives sufficient
+    // space to add data to while we are reading.
+
 
     // Addresses of vertical grid lines on x axis
     ushort  vert_grid_id[SPECTRUM_SCOPE_GRID_VERT_COUNT-1];

--- a/mchf-eclipse/drivers/ui/menu/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu.c
@@ -2121,7 +2121,7 @@ void UiMenu_UpdateItem(uint16_t select, uint16_t mode, int pos, int var, char* o
             txt_ptr = " x1";
             break;
         }
-        UiDriver_SpectrumZoomChangeLevel();
+        UiDriver_SpectrumChangeLayoutParameters();
         break;
     case MENU_SCOPE_AGC_ADJUST: // Spectrum scope AGC adjust
         var_change = UiDriverMenuItemChangeUInt8(var, mode, &ts.spectrum_agc_rate,
@@ -2441,7 +2441,7 @@ void UiMenu_UpdateItem(uint16_t select, uint16_t mode, int pos, int var, char* o
         snprintf(options,32, "  %u", ts.waterfall.nosig_adjust);
         break;
 #endif
-    case MENU_SPECTRUM_SIZE:    // set step size of of waterfall display?
+    case MENU_SPECTRUM_SIZE:    // set view size of of spectrum display (big disables title bar)?
         UiDriverMenuItemChangeUInt8(var, mode, &ts.spectrum_size,
                                     0,
                                     SPECTRUM_BIG,

--- a/mchf-eclipse/drivers/ui/ui_driver.h
+++ b/mchf-eclipse/drivers/ui/ui_driver.h
@@ -184,7 +184,7 @@ void    UiDriver_DrawFButtonLabel(uint8_t button_num, const char* label, uint32_
 void 	UiDriver_DisplayFreqStepSize();
 void 	UiDriver_DisplayDemodMode(void);
 void	UiDriver_LcdBlankingStartTimer(void);
-void    UiDriver_SpectrumZoomChangeLevel();
+void    UiDriver_SpectrumChangeLayoutParameters();
 
 void UiDriver_DebugInfo_DisplayEnable(bool enable);
 


### PR DESCRIPTION
- Long Press Waterfall/Scope title -> switch layout size (no title/title)
- Waterfall and scope speed is the same in all zoom level
  by using a sliding data set
- Small adjustment to waterfall / scope speed

Internal API Changes:
- Touch Long Press support: Touch now supports long press actions