### PR TITLE
Support for gcc 2017 Q4 GCC 7 and more clean targets in makefile

### DIFF
--- a/mchf-eclipse/Makefile
+++ b/mchf-eclipse/Makefile
@@ -257,7 +257,9 @@ help:
 .PHONY: all clean docs docs-clean help
 
 
-all:  $(FIRMWARE) $(TRX_ID).handbook
+all: firmware $(TRX_ID).handbook
+
+firmware:  $(FIRMWARE) 
 	# compile the ARM-executables .bin / .elf and .dfu for mcHF SDR TRx, generate .map 
 	@echo "using \c"
 	$(CC) --version | grep gcc
@@ -291,21 +293,28 @@ $(TRX_ID).version:
 	@printf "Version %s.%s.%s%s\n" $(UHSDR_VER_MAJOR) $(UHSDR_VER_MINOR) $(UHSDR_VER_RELEASE) $(UHSDR_VER_TAINT)
 
 # cleaning rule
-clean:  
-	# remove the executables, map, dmp and all object files (.o)
-	$(RM) $(call FixPath,$(OBJS))
-	$(RM) $(call FixPath,$(DSPLIB_OBJS))
-	$(RM) $(call FixPath,$(HAL_OBJS))
-	$(RM) $(call FixPath,$(BL_OBJS))
-	$(RM) $(call FixPath,$(BL_HAL_OBJS))
+clean-firmware:
+	$(RM) $(call FixPath,$(OBJS))	
 	$(RM) $(call FixPath,$(FIRMWARE).elf)
 	$(RM) $(call FixPath,$(FIRMWARE).dfu)
 	$(RM) $(call FixPath,$(FIRMWARE).bin)
 	$(RM) $(call FixPath,$(FIRMWARE).map)
+
+clean-bootloader:
+	$(RM) $(call FixPath,$(BL_OBJS))
+	$(RM) $(call FixPath,$(BL_HAL_OBJS))
 	$(RM) $(call FixPath,$(BOOTLOADER).elf)
 	$(RM) $(call FixPath,$(BOOTLOADER).dfu)
 	$(RM) $(call FixPath,$(BOOTLOADER).bin)
 	$(RM) $(call FixPath,$(BOOTLOADER).map)
+
+clean-libs:
+	$(RM) $(call FixPath,$(DSPLIB_OBJS))
+	$(RM) $(call FixPath,$(HAL_OBJS))
+	
+
+clean:  clean-firmware clean-bootloader clean-libs
+	# remove the executables, map, dmp and all object files (.o)
 	$(RM) $(call FixPath,*~)
 
 docs:  

--- a/mchf-eclipse/drivers/ui/lcd/ui_lcd_hy28.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_lcd_hy28.c
@@ -669,7 +669,7 @@ void UiLcdHy28_GpioInit(mchf_display_types_t display_type)
 DMA_HandleTypeDef DMA_Handle;
 
 
-inline void UiLcdHy28_SpiDmaStop()
+static inline void UiLcdHy28_SpiDmaStop()
 {
     while (DMA1_Stream4->CR & DMA_SxCR_EN) { asm(""); }
 }
@@ -714,7 +714,7 @@ inline void UiLcdHy28_SpiLcdCsDisable()
 {
     GPIO_SetBits(mchf_display.lcd_cs_pio, mchf_display.lcd_cs);
 }
-inline void UiLcdHy28_SpiLcdCsEnable()
+static inline void UiLcdHy28_SpiLcdCsEnable()
 {
     GPIO_ResetBits(mchf_display.lcd_cs_pio, mchf_display.lcd_cs);
 }

--- a/mchf-eclipse/src/bootloader/flash_if.h
+++ b/mchf-eclipse/src/bootloader/flash_if.h
@@ -53,7 +53,7 @@ extern const char* author; */
  * @brief real user flash size of microprocessor (flash size - bootloader/config flash size)
  * @returns size of user flash in bytes
  */
-inline uint32_t flashIf_userFlashSize()  {  return ((STM32_GetFlashSize() - MCHF_FLASHRESERVED)*1024); }
+static inline uint32_t flashIf_userFlashSize()  {  return ((STM32_GetFlashSize() - MCHF_FLASHRESERVED)*1024); }
 
 
 /* Exported macros -----------------------------------------------------------*/

--- a/mchf-eclipse/src/bootloader/uhsdr_boot_hw.h
+++ b/mchf-eclipse/src/bootloader/uhsdr_boot_hw.h
@@ -90,12 +90,12 @@ void mcHF_PowerOff();
 /*
  * Just toggles the PowerHold Pin, but does not stop execution
  */
-inline void mcHF_PowerHoldOff()
+static inline void mcHF_PowerHoldOff()
 {
     mchfBl_PinOn(PWR_HOLD);
 }
 
-inline void mcHF_PowerHoldOn()
+static inline void mcHF_PowerHoldOn()
 {
     mchfBl_PinOff(PWR_HOLD);
 }


### PR DESCRIPTION
Created more clean targets to support selective cleaning 
Fixed bootloader compile fail for 2017 Q4 gcc 7

