### PR TITLE
snap for BPSK decoder first attempt

### DIFF
--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -1275,6 +1275,7 @@ void UiDriver_ModeSpecificDisplayClear(uint8_t dmod_mode, uint8_t digital_mode)
 		case DigitalMode_RTTY:
 		case DigitalMode_BPSK:
 			UiDriver_TextMsgClear();
+			UiSpectrum_InitCwSnapDisplay(false);
 			break;
 		default:
 			break;
@@ -1320,6 +1321,10 @@ void UiDriver_ModeSpecificDisplayPrepare(uint8_t dmod_mode, uint8_t digital_mode
 		case DigitalMode_RTTY:
 		case DigitalMode_BPSK:
 			UiDriver_TextMsgClear();
+		    if(cw_decoder_config.snap_enable == true)
+		    {
+		    	UiSpectrum_InitCwSnapDisplay(true);
+		    }
 			break;
 		default:
 			break;

--- a/mchf-eclipse/hardware/uhsdr_board.h
+++ b/mchf-eclipse/hardware/uhsdr_board.h
@@ -36,7 +36,7 @@
 // 3 RA8875 @800x600
 
 //for manual setting adjust following #define
-//#define LCD_TYPE 1
+#define LCD_TYPE 1
 
 // ALTERNATIVE GROUP START USE_GFX
 


### PR DESCRIPTION
- coarse tune to a BPSK carrier 1000Hz +- 100Hz
- during BPSK decoding press SNAP button
- frequency will be adjusted to frequency of the BPSK carrier
- at the moment not so precise as I would like to have it
