### PR TITLE
snap for BPSK RX: reference to global BPSK variables

### DIFF
--- a/mchf-eclipse/drivers/audio/psk.h
+++ b/mchf-eclipse/drivers/audio/psk.h
@@ -15,6 +15,7 @@
 #include "softdds.h"
 
 #define PSK_OFFSET 1000
+#define PSK_SNAP_RANGE 100 // defines the range within the SNAP algorithm in spectrum.c searches for the PSK carrier
 #define PSK_SAMPLE_RATE 12000 // TODO This should come from elsewhere, to be fixed
 #define PSK_BND_FLT_LEN 5
 #define PSK_BUF_LEN (PSK_SAMPLE_RATE / PSK_OFFSET)

--- a/mchf-eclipse/hardware/uhsdr_board.h
+++ b/mchf-eclipse/hardware/uhsdr_board.h
@@ -36,7 +36,7 @@
 // 3 RA8875 @800x600
 
 //for manual setting adjust following #define
-//#define LCD_TYPE 1
+#define LCD_TYPE 1
 
 // ALTERNATIVE GROUP START USE_GFX
 

--- a/mchf-eclipse/hardware/uhsdr_board.h
+++ b/mchf-eclipse/hardware/uhsdr_board.h
@@ -36,7 +36,7 @@
 // 3 RA8875 @800x600
 
 //for manual setting adjust following #define
-#define LCD_TYPE 1
+//#define LCD_TYPE 1
 
 // ALTERNATIVE GROUP START USE_GFX
 


### PR DESCRIPTION
- hard coded BPSK offset and SNAP range in spectrum.c have now been referenced to global variables in psk.h
- no functional change