### PR TITLE
added RTTY shifts - please test

### DIFF
--- a/mchf-eclipse/.settings/language.settings.xml
+++ b/mchf-eclipse/.settings/language.settings.xml
@@ -5,7 +5,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-5833061428390205" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT ARM Cross GCC Built-in Compiler Settings " parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="111743357592321234" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT ARM Cross GCC Built-in Compiler Settings " parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>
@@ -16,7 +16,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-61845140010475419" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT ARM Cross GCC Built-in Compiler Settings " parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="137903589417528688" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT ARM Cross GCC Built-in Compiler Settings " parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>
@@ -27,7 +27,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="39285439015840547" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT ARM Cross GCC Built-in Compiler Settings " parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="126911469821072498" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT ARM Cross GCC Built-in Compiler Settings " parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>
@@ -38,7 +38,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-46672881174317715" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT ARM Cross GCC Built-in Compiler Settings " parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="175670720889180520" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT ARM Cross GCC Built-in Compiler Settings " parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>
@@ -49,7 +49,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-57694483941597141" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT ARM Cross GCC Built-in Compiler Settings " parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="104149044429641834" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT ARM Cross GCC Built-in Compiler Settings " parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>
@@ -60,7 +60,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="31169885638697229" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT ARM Cross GCC Built-in Compiler Settings " parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="160498481196857800" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT ARM Cross GCC Built-in Compiler Settings " parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>
@@ -71,7 +71,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-57694483941597141" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT ARM Cross GCC Built-in Compiler Settings " parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="104149044429641834" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT ARM Cross GCC Built-in Compiler Settings " parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>
@@ -82,7 +82,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="31169885638697229" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT ARM Cross GCC Built-in Compiler Settings " parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="160498481196857800" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT ARM Cross GCC Built-in Compiler Settings " parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>

--- a/mchf-eclipse/drivers/audio/psk.h
+++ b/mchf-eclipse/drivers/audio/psk.h
@@ -15,7 +15,7 @@
 #include "softdds.h"
 
 #define PSK_OFFSET 1000
-#define PSK_SNAP_RANGE 100 // defines the range within the SNAP algorithm in spectrum.c searches for the PSK carrier
+#define PSK_SNAP_RANGE 100 // defines the range within which the SNAP algorithm in spectrum.c searches for the PSK carrier
 #define PSK_SAMPLE_RATE 12000 // TODO This should come from elsewhere, to be fixed
 #define PSK_BND_FLT_LEN 5
 #define PSK_BUF_LEN (PSK_SAMPLE_RATE / PSK_OFFSET)

--- a/mchf-eclipse/drivers/audio/rtty.c
+++ b/mchf-eclipse/drivers/audio/rtty.c
@@ -177,9 +177,12 @@ const rtty_speed_item_t rtty_speeds[RTTY_SPEED_NUM] =
 
 const rtty_shift_item_t rtty_shifts[RTTY_SHIFT_NUM] =
 {
+		{ RTTY_SHIFT_85, 85, " 85" },
 		{ RTTY_SHIFT_170, 170, "170" },
 		{ RTTY_SHIFT_200, 200, "200" },
+		{ RTTY_SHIFT_425, 425, "425" },
 		{ RTTY_SHIFT_450, 450, "450" },
+		{ RTTY_SHIFT_850, 850, "850" },
 };
 
 rtty_ctrl_t rtty_ctrl_config =
@@ -333,12 +336,44 @@ static rtty_bpf_config_t rtty_bp_12khz_1085 =
 		.freq = 1085
 };
 // order 2 Butterworth, freqs: 1065-1165 Hz, centre: 1115Hz
+// for 200Hz shift
 static rtty_bpf_config_t rtty_bp_12khz_1115 =
 {
 		.gain = 1.513364944e+03,
 		.coeffs = { -0.9286270861, 3.1576917276, -4.6112830458, 3.2768349860 },
-		.freq = 1085
+		.freq = 1115
 };
+
+// for 85Hz shift --> 915 + 85Hz = space = 1000Hz
+// 3dB bandwidth 50Hz
+// order 2 Butterworth, freqs: 975-1025 Hz, centre: 1000Hz
+static rtty_bpf_config_t rtty_bp_12khz_1000 =
+{
+		.gain = 5.944465260e+03,
+		.coeffs = { -0.9636529842, 3.3693752166, -4.9084595657, 3.4323354886 },
+		.freq = 1000
+};
+
+// for 425Hz shift --> 915 + 425Hz = space = 1340Hz
+// 3dB bandwidth 100Hz
+// order 2 Butterworth, freqs: 1290 - 1390 Hz, centre: 1340Hz
+static rtty_bpf_config_t rtty_bp_12khz_1340 =
+{
+		.gain = 1.513365018e+03,
+		.coeffs = { -0.9286270862, 2.8906128091, -4.1762457780, 2.9996788796 },
+		.freq = 1340
+};
+
+// for 850Hz shift --> 915 + 850Hz = space = 1765Hz
+// 3dB bandwidth 100Hz
+// order 2 Butterworth, freqs: 1715 - 1815 Hz, centre: 1765Hz
+static rtty_bpf_config_t rtty_bp_12khz_1765 =
+{
+		.gain = 1.513365057e+03,
+		.coeffs = { -0.9286270862, 2.1190223173, -3.1352567157, 2.1989754113 },
+		.freq = 1765
+};
+
 
 static rtty_lpf_config_t rtty_lp_12khz_50 =
 {
@@ -371,11 +406,20 @@ void RttyDecoder_Init()
 	// now we handled the specifics
 	switch (rttyDecoderData.config_p->shift)
 	{
-	case 450:
-		rttyDecoderData.bpfSpaceConfig = &rtty_bp_12khz_1365; // this is space or '0'
+	case 85:
+		rttyDecoderData.bpfSpaceConfig = &rtty_bp_12khz_1000;
 		break;
 	case 200:
 		rttyDecoderData.bpfSpaceConfig = &rtty_bp_12khz_1115;
+		break;
+	case 425:
+		rttyDecoderData.bpfSpaceConfig = &rtty_bp_12khz_1340;
+		break;
+	case 450:
+		rttyDecoderData.bpfSpaceConfig = &rtty_bp_12khz_1365; // this is space or '0'
+		break;
+	case 850:
+		rttyDecoderData.bpfSpaceConfig = &rtty_bp_12khz_1765; // this is space or '0'
 		break;
 	case 170:
 	default:

--- a/mchf-eclipse/drivers/audio/rtty.c
+++ b/mchf-eclipse/drivers/audio/rtty.c
@@ -178,6 +178,7 @@ const rtty_speed_item_t rtty_speeds[RTTY_SPEED_NUM] =
 const rtty_shift_item_t rtty_shifts[RTTY_SHIFT_NUM] =
 {
 		{ RTTY_SHIFT_170, 170, "170" },
+		{ RTTY_SHIFT_200, 200, "200" },
 		{ RTTY_SHIFT_450, 450, "450" },
 };
 
@@ -331,6 +332,13 @@ static rtty_bpf_config_t rtty_bp_12khz_1085 =
 		.coeffs = { -0.9286270861, 3.1900687350, -4.6666321298, 3.3104336142 },
 		.freq = 1085
 };
+// order 2 Butterworth, freqs: 1065-1165 Hz, centre: 1115Hz
+static rtty_bpf_config_t rtty_bp_12khz_1115 =
+{
+		.gain = 1.513364944e+03,
+		.coeffs = { -0.9286270861, 3.1576917276, -4.6112830458, 3.2768349860 },
+		.freq = 1085
+};
 
 static rtty_lpf_config_t rtty_lp_12khz_50 =
 {
@@ -365,6 +373,9 @@ void RttyDecoder_Init()
 	{
 	case 450:
 		rttyDecoderData.bpfSpaceConfig = &rtty_bp_12khz_1365; // this is space or '0'
+		break;
+	case 200:
+		rttyDecoderData.bpfSpaceConfig = &rtty_bp_12khz_1115;
 		break;
 	case 170:
 	default:

--- a/mchf-eclipse/drivers/audio/rtty.h
+++ b/mchf-eclipse/drivers/audio/rtty.h
@@ -38,6 +38,7 @@ typedef enum {
 
 typedef enum {
     RTTY_SHIFT_170,
+    RTTY_SHIFT_200,
     RTTY_SHIFT_450,
     RTTY_SHIFT_NUM
 } rtty_shift_t;

--- a/mchf-eclipse/drivers/audio/rtty.h
+++ b/mchf-eclipse/drivers/audio/rtty.h
@@ -37,9 +37,12 @@ typedef enum {
 } rtty_speed_t;
 
 typedef enum {
+    RTTY_SHIFT_85,
     RTTY_SHIFT_170,
-    RTTY_SHIFT_200,
-    RTTY_SHIFT_450,
+	RTTY_SHIFT_200,
+    RTTY_SHIFT_425,
+	RTTY_SHIFT_450,
+	RTTY_SHIFT_850,
     RTTY_SHIFT_NUM
 } rtty_shift_t;
 

--- a/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
@@ -1953,7 +1953,6 @@ void UiSpectrum_CalculateSnap(float32_t Lbin, float32_t Ubin, int posbin, float3
 
     if(ts.dmod_mode == DEMOD_DIGI && ts.digital_mode == DigitalMode_BPSK)
     {
-    	// FIXME: has to be substituted by global variable --> centre frequency BPSK
     	if(ts.digi_lsb)
     	{
     		delta = delta + PSK_OFFSET; //

--- a/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
@@ -1843,7 +1843,7 @@ void UiSpectrum_CwSnapDisplay (float32_t delta)
 	static float32_t old_delta = 0.0;
 #endif
 
-	static int old_delta_p = 0.0;
+	static int old_delta_p = 0;
 	if(delta > max_delta)
 	{
 		delta = max_delta;
@@ -1962,11 +1962,8 @@ void UiSpectrum_CalculateSnap(float32_t Lbin, float32_t Ubin, int posbin, float3
     		delta = delta - PSK_OFFSET; //
     	}
     }
-    // these frequency calculations are unused at the moment, they will be used with
-    // real snap by button press
 
     // make 10 frequency measurements and after that take the lowpass filtered frequency to tune to
-
 
     help_freq = help_freq + delta;
     // do we need a lowpass filter?

--- a/mchf-eclipse/hardware/uhsdr_board.h
+++ b/mchf-eclipse/hardware/uhsdr_board.h
@@ -36,7 +36,7 @@
 // 3 RA8875 @800x600
 
 //for manual setting adjust following #define
-//#define LCD_TYPE 1
+#define LCD_TYPE 1
 
 // ALTERNATIVE GROUP START USE_GFX
 

--- a/mchf-eclipse/hardware/uhsdr_board.h
+++ b/mchf-eclipse/hardware/uhsdr_board.h
@@ -36,7 +36,7 @@
 // 3 RA8875 @800x600
 
 //for manual setting adjust following #define
-#define LCD_TYPE 1
+//#define LCD_TYPE 1
 
 // ALTERNATIVE GROUP START USE_GFX
 


### PR DESCRIPTION
* added more RTTY shifts

I had a look which RTTY shifts and speeds are used in practice and which ones are useful for a portable rig like the mcHF or OVI40: 

* standard shifts: 170, 200, & 425Hz
* rare shifts: 85, 450, 850Hz
* Speed: 45.45Bd und 50Bd
all other speeds are not really used in practice (see http://f1ult.free.fr/DIGIMODES/MULTIPSK/RTTY_en.htm), or are useless for us, because traffic is encrypted in > 95% of the cases (eg. Navy MARS "hams" with 75Bd)

TODO: 
* adjust stop bits ?? (not sure about this . . .)

Please test and report here.