### PR TITLE
Added IS_SMALL_BUILD define support for smaller firmware builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ script:
     - mkdir -p mchf-eclipse/build-bl-f7
     - mkdir -p mchf-eclipse/build-fw-f7
     - mkdir -p mchf-eclipse/build-fw-f4-ili9486-480
+    - mkdir -p mchf-eclipse/build-fw-f4-small
     - cd mchf-eclipse/build-bl
     - cd ../build-fw 
     - make -f ../Makefile ROOTLOC=".." all
@@ -36,6 +37,8 @@ script:
     - make -f ../Makefile OPT_GCC_ARM=$GCC_DIR ROOTLOC=".." BUILDFOR="F7" TRX_ID="ovi40" TRX_NAME="OVI40" bootloader
     - cd ../build-fw-f4-ili9486-480
     - make -f ../Makefile ROOTLOC=".." LCD_TYPE=1 all
+    - cd ../build-fw-f4-small
+    - make -f ../Makefile CONFIGFLAGS="-DIS_SMALL_BUILD" ROOTLOC=".." all
     - cd ..
 before_deploy:
     - sudo apt-get install -y doxygen graphviz

--- a/mchf-eclipse/Makefile
+++ b/mchf-eclipse/Makefile
@@ -125,7 +125,7 @@ ifeq ($(BUILDFOR),F4)
 $(BOOTLOADER).elf : CFLAGS = ${BASECFLAGS_F4} -Os -DBOOTLOADER_BUILD
 $(FIRMWARE).elf : CFLAGS = ${BASECFLAGS_F4} -O2
 $(BOOTLOADER).elf : LDFLAGS = ${LDFLAGS_F4} -T$(LINKERLOC)/arm-gcc-link-bootloader_f4.ld
-$(FIRMWARE).elf : LDFLAGS = ${LDFLAGS_F4} -T$(LINKERLOC)/arm-gcc-link_f4_flash512k.ld
+$(FIRMWARE).elf : LDFLAGS = ${LDFLAGS_F4} -T$(LINKERLOC)/arm-gcc-link_f4_flash1024k.ld
 	
 
 

--- a/mchf-eclipse/drivers/audio/audio_nr.h
+++ b/mchf-eclipse/drivers/audio/audio_nr.h
@@ -20,6 +20,8 @@
 #ifdef USE_ALTERNATE_NR
 #include "freedv_uhsdr.h"
 
+#define NR_FFT_SIZE 128
+
 #define NR_FFT_L (NR_FFT_SIZE) // for NR FFT size 128
 //#define NR_FFT_L (NR_FFT_SIZE * 2) // for NR FFT size 256
 

--- a/mchf-eclipse/drivers/ui/lcd/ui_lcd_hy28.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_lcd_hy28.c
@@ -33,8 +33,6 @@
 #define USE_DISPLAY_SPI
 #define USE_DISPLAY_PAR
 
-// #define HY28BHISPEED true // does not work with touchscreen and HY28A and some HY28B
-
 #include "spi.h"
 
 #ifdef USE_DISPLAY_PAR

--- a/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
@@ -321,12 +321,14 @@ static void UiSpectrum_UpdateSpectrumPixelParameters()
             float32_t mode_marker[SPECTRUM_MAX_MARKER];
             switch(ts.digital_mode)
             {
+#ifdef USE_FREEDV
             case DigitalMode_FreeDV:
             	// 1500 +/- 625Hz
                 mode_marker[0] = 875;
                 mode_marker[1] = 2125;
                 sd.marker_num = 2;
                 break;
+#endif
             case DigitalMode_RTTY:
                 mode_marker[0] = 915; // Mark Frequency
                 mode_marker[1] = mode_marker[0] + rtty_shifts[rtty_ctrl_config.shift_idx].value;

--- a/mchf-eclipse/drivers/ui/menu/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu.c
@@ -4068,7 +4068,7 @@ void UiMenu_UpdateItem(uint16_t select, uint16_t mode, int pos, int var, char* o
     	 break;
 
     case MENU_DIGITAL_MODE_SELECT:
-        var_change = UiDriverMenuItemChangeUInt8(var, mode, &ts.digital_mode,0,DigitalMode_BPSK,0,1);
+        var_change = UiDriverMenuItemChangeUInt8(var, mode, &ts.digital_mode,0,DigitalMode_Num_Modes-1,0,1);
         if (var_change)
         {
             // TODO: Factor this out into a Ui function for (de-)activating Rtty mode

--- a/mchf-eclipse/drivers/ui/radio_management.h
+++ b/mchf-eclipse/drivers/ui/radio_management.h
@@ -170,13 +170,11 @@ typedef enum {
 typedef enum
 {
     DigitalMode_None = 0,
+#ifdef USE_FREEDV
     DigitalMode_FreeDV,
+#endif
     DigitalMode_RTTY,
     DigitalMode_BPSK,
-    DigitalMode_FreeDV2,
-    DigitalMode_SSTV,
-    DigitalMode_WSPR_A,
-    DigitalMode_WSPR_P,
     DigitalMode_Num_Modes
 } digital_modes_t;
 

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -1267,11 +1267,11 @@ void UiDriver_ModeSpecificDisplayClear(uint8_t dmod_mode, uint8_t digital_mode)
 	{
 		switch(digital_mode)
 		{
-		case DigitalMode_FreeDV:
 #ifdef USE_FREEDV
+		case DigitalMode_FreeDV:
 			FreeDv_DisplayClear();
-#endif
 			break;
+#endif
 		case DigitalMode_RTTY:
 		case DigitalMode_BPSK:
 			UiDriver_TextMsgClear();
@@ -1313,11 +1313,11 @@ void UiDriver_ModeSpecificDisplayPrepare(uint8_t dmod_mode, uint8_t digital_mode
 	{
 		switch(digital_mode)
 		{
-		case DigitalMode_FreeDV:
 #ifdef USE_FREEDV
+		case DigitalMode_FreeDV:
 			FreeDv_DisplayPrepare();
-#endif
 			break;
+#endif
 		case DigitalMode_RTTY:
 		case DigitalMode_BPSK:
 			UiDriver_TextMsgClear();
@@ -6069,7 +6069,7 @@ static void UiAction_ChangeFrequencyByTouch()
 #endif
 static void UiAction_ChangeDigitalMode()
 {
-	incr_wrap_uint8(&ts.digital_mode,0,DigitalMode_BPSK);
+	incr_wrap_uint8(&ts.digital_mode,0,DigitalMode_Num_Modes-1);
 	// We limit the reachable modes to the ones truly available
 	// which is FreeDV1, RTTY, BPSK for now
 	UiDriver_ToggleDigitalMode();

--- a/mchf-eclipse/hardware/uhsdr_board.h
+++ b/mchf-eclipse/hardware/uhsdr_board.h
@@ -14,15 +14,34 @@
 #ifndef __MCHF_BOARD_H
 #define __MCHF_BOARD_H
 #include "uhsdr_mcu.h"
+/***
+ * Please document all switches/parameters with what they are supposed to do and what values they can have.
+ * Please use proper naming:
+ * For capabilities of the software which can be enabled and disabled
+ * use USE_<CAPABILITY/FEATURENAME>
+ *
+ * These should be defined using #define USE_CAPABILITY
+ * or left undefined if not enabled so that these can be checked using #ifdef
+ *
+ * For related parameters DON'T USE USE_...
+ *
+ * In an ideal world please use PAR_<CAPABILITY/FEATURE>_<PARAMETERNAME> (we haven't done that yet)
+ * Please don't define constant or local parameters here, only those a user (!) is supposed to change as part of
+ * configuring a specific build variant.
+ *
+ */
+
+/**
+ * This parameter disables certain features / capabilites in order to achieve a minimum build size for
+ * the 192k ram / 512k flash STM32F4 machines. Unless you have such a machine, leave this disabled.
+ */
+// #define IS_SMALL_BUILD
+
 // some special switches
 //#define 	DEBUG_BUILD
 
+// if enabled the alternate (read new and better) noise reduction is active
 #define USE_ALTERNATE_NR
-//#define debug_alternate_NR
-
-#ifdef USE_ALTERNATE_NR
-#define NR_FFT_SIZE 128
-#endif
 
 //time optimisation debug pin enable
 //#define TimeDebug
@@ -81,10 +100,13 @@
 #endif
 
 // OPTION
-#define USE_FREEDV
+// with IS_SMALL_BUILD we are not automatically including USE_FREEDV as it uses lot of memory both RAM and flash
+#ifndef IS_SMALL_BUILD
+    #define USE_FREEDV
+#endif
 // #define DEBUG_FREEDV
 // hardware specific switches
-//#define HY28BHISPEED			true		// uncomment for using new HY28B in SPI with bus speed 50MHz instead of 25MHz
+
 
 // Unified the 3 graphics drivers.
 


### PR DESCRIPTION
This builds a smaller variant with less features and capabilities than
the normal build. Right now we leave out FreeDV as it frees roughly 180k
flash. Please use only if you have a 512k flash STM32F4.
Better option is to replace MCU ASAP.

Small refactorings where necessary but with no functional impact.
Removed unused define HY28BHISPEED