### PR TITLE
NR strength: limit range to 5 - 100 and step = 5

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -1362,7 +1362,7 @@ void AudioDriver_SetRxAudioProcessing(uint8_t dmod_mode, bool reset_dsp_nr)
     // convert user setting of noise reduction to alpha NR parameter
     // alpha ranges from 0.9 to 0.999 [float32_t]
     // dsp_nr_strength is from 0 to 100 [uint8_t]
-    ts.nr_alpha = 0.9 + ((float32_t)ts.dsp_nr_strength / 1000.0);
+    ts.nr_alpha = 0.899 + ((float32_t)ts.dsp_nr_strength / 1000.0);
 
 // NEW AUTONOTCH
     // set to passthrough

--- a/mchf-eclipse/drivers/audio/audio_driver.h
+++ b/mchf-eclipse/drivers/audio/audio_driver.h
@@ -467,8 +467,8 @@ enum	{
 #define	RX_DECIMATION_RATE_24KHZ		2		// Decimation/Interpolation rate in receive function for 24 kHz sample rate
 #define RX_DECIMATION_RATE_48KHZ		1		// Deimcation/Interpolation rate in receive function for 48 kHz sample rate (e.g. no decimation!)
 
-#define	DSP_NR_STRENGTH_MAX		99	// Maximum menu setting for DSP "Strength"
-#define	DSP_NR_STRENGTH_DEFAULT	50	// Default setting
+#define	DSP_NR_STRENGTH_MAX		100	// Maximum menu setting for DSP "Strength"
+#define	DSP_NR_STRENGTH_DEFAULT	60	// Default setting
 #ifdef OBSOLETE_NR
 //
 // ************

--- a/mchf-eclipse/drivers/audio/audio_driver.h
+++ b/mchf-eclipse/drivers/audio/audio_driver.h
@@ -467,7 +467,9 @@ enum	{
 #define	RX_DECIMATION_RATE_24KHZ		2		// Decimation/Interpolation rate in receive function for 24 kHz sample rate
 #define RX_DECIMATION_RATE_48KHZ		1		// Deimcation/Interpolation rate in receive function for 48 kHz sample rate (e.g. no decimation!)
 
+#define DSP_NR_STRENGTH_MIN		5
 #define	DSP_NR_STRENGTH_MAX		100	// Maximum menu setting for DSP "Strength"
+#define DSP_NR_STRENGTH_STEP	5
 #define	DSP_NR_STRENGTH_DEFAULT	60	// Default setting
 #ifdef OBSOLETE_NR
 //

--- a/mchf-eclipse/drivers/ui/menu/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu.c
@@ -784,10 +784,10 @@ void UiMenu_UpdateItem(uint16_t select, uint16_t mode, int pos, int var, char* o
     case MENU_DSP_NR_STRENGTH:  // DSP Noise reduction strength
 
         var_change = UiDriverMenuItemChangeUInt8(var, mode, &ts.dsp_nr_strength,
-                                              1,
+                                              DSP_NR_STRENGTH_MIN,
                                               DSP_NR_STRENGTH_MAX,
                                               DSP_NR_STRENGTH_DEFAULT,
-											  2
+											  DSP_NR_STRENGTH_STEP
                                              );
         if(var_change)
         {

--- a/mchf-eclipse/drivers/ui/menu/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu.c
@@ -784,10 +784,10 @@ void UiMenu_UpdateItem(uint16_t select, uint16_t mode, int pos, int var, char* o
     case MENU_DSP_NR_STRENGTH:  // DSP Noise reduction strength
 
         var_change = UiDriverMenuItemChangeUInt8(var, mode, &ts.dsp_nr_strength,
-                                              0,
+                                              1,
                                               DSP_NR_STRENGTH_MAX,
                                               DSP_NR_STRENGTH_DEFAULT,
-											  1
+											  2
                                              );
         if(var_change)
         {

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -3438,12 +3438,12 @@ static void UiDriver_CheckEncoderTwo()
 				case ENC_TWO_MODE_NR:
 					if (is_dsp_nr())        // only allow adjustment if DSP NR is active
 					{
-						ts.dsp_nr_strength = change_and_limit_uint(ts.dsp_nr_strength,pot_diff_step,0,DSP_NR_STRENGTH_MAX);
+						ts.dsp_nr_strength = change_and_limit_uint(ts.dsp_nr_strength,pot_diff_step * 2,1,DSP_NR_STRENGTH_MAX);
 
 						// this causes considerable noise
 						//AudioDriver_SetRxAudioProcessing(ts.dmod_mode, false);
 						// we do this instead
-					    ts.nr_alpha = 0.9 + ((float32_t)ts.dsp_nr_strength / 1000.0);
+					    ts.nr_alpha = 0.899 + ((float32_t)ts.dsp_nr_strength / 1000.0);
 					}
 					// Signal processor setting
 					UiDriver_DisplayDSPMode(1);

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -3437,8 +3437,8 @@ static void UiDriver_CheckEncoderTwo()
 					break;
 				case ENC_TWO_MODE_NR:
 					if (is_dsp_nr())        // only allow adjustment if DSP NR is active
-					{
-						ts.dsp_nr_strength = change_and_limit_uint(ts.dsp_nr_strength,pot_diff_step * 2,1,DSP_NR_STRENGTH_MAX);
+					{	//
+						ts.dsp_nr_strength = change_and_limit_uint(ts.dsp_nr_strength,pot_diff_step * DSP_NR_STRENGTH_STEP,DSP_NR_STRENGTH_MIN,DSP_NR_STRENGTH_MAX);
 
 						// this causes considerable noise
 						//AudioDriver_SetRxAudioProcessing(ts.dmod_mode, false);


### PR DESCRIPTION
* this is intended to achieve faster adjustment of the noise reduction strength
* also avoids ambiguity of NR = 0, --> now NR strength minimum is 5
* NR on / off switching is unchanged --> use DSP box 