### PR TITLE
Fix for GCC 7 makefile build issue #1416

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+env:
+   global:
+   - GCC_BASE=gcc-arm-none-eabi-6-2017-q1-update
+   - GCC_SHORT=6_1-2017q1
+
 sudo: required
 language: generic
 dist: trusty
@@ -9,16 +14,13 @@ addons:
 
 cache:
   directories:
-    - $HOME/gcc-arm-none-eabi-6-2017-q1-update
+    - $HOME/$GCC_BASE
 
 install:
-    - export GCC_DIR=$HOME/gcc-arm-none-eabi-6-2017-q1-update
-    - export GCC_ARCHIVE=$HOME/gcc-arm-none-eabi-6-2017-q1-update-linux.tar.bz2
-    - export GCC_URL=https://developer.arm.com/-/media/Files/downloads/gnu-rm/6_1-2017q1/gcc-arm-none-eabi-6-2017-q1-update-linux.tar.bz2?product=GNU%20ARM%20Embedded%20Toolchain,64-bit,,Linux,6-2017-q1-update
+    - export GCC_DIR=$HOME/$GCC_BASE
+    - export GCC_ARCHIVE=$HOME/$GCC_BASE-linux.tar.bz2
+    - export GCC_URL=https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/$GCC_SHORT/$GCC_BASE-linux.tar.bz2
     - if [ ! -e $GCC_DIR/bin/arm-none-eabi-g++ ]; then wget $GCC_URL -O $GCC_ARCHIVE; tar xfj $GCC_ARCHIVE -C $HOME; fi
-    - sudo add-apt-repository "deb http://ftp.debian.org/debian jessie-backports main"
-    - sudo apt-get -qq update
-    - sudo apt-get install -t jessie-backports -y --force-yes gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib
 script:
     - mkdir -p mchf-eclipse/build-bl
     - mkdir -p mchf-eclipse/build-fw
@@ -28,17 +30,17 @@ script:
     - mkdir -p mchf-eclipse/build-fw-f4-small
     - cd mchf-eclipse/build-bl
     - cd ../build-fw 
-    - make -f ../Makefile ROOTLOC=".." all
+    - make -f ../Makefile OPT_GCC_ARM=$GCC_DIR ROOTLOC=".." all
     - cd ../build-fw-f7
     - make -f ../Makefile OPT_GCC_ARM=$GCC_DIR ROOTLOC=".." BUILDFOR="F7" TRX_ID="ovi40" TRX_NAME="OVI40" all
     - cd ../build-bl
-    - make -f ../Makefile ROOTLOC=".." bootloader
+    - make -f ../Makefile OPT_GCC_ARM=$GCC_DIR ROOTLOC=".." bootloader
     - cd ../build-bl-f7
     - make -f ../Makefile OPT_GCC_ARM=$GCC_DIR ROOTLOC=".." BUILDFOR="F7" TRX_ID="ovi40" TRX_NAME="OVI40" bootloader
     - cd ../build-fw-f4-ili9486-480
-    - make -f ../Makefile ROOTLOC=".." LCD_TYPE=1 all
+    - make -f ../Makefile OPT_GCC_ARM=$GCC_DIR ROOTLOC=".." LCD_TYPE=1 all
     - cd ../build-fw-f4-small
-    - make -f ../Makefile CONFIGFLAGS="-DIS_SMALL_BUILD" ROOTLOC=".." all
+    - make -f ../Makefile OPT_GCC_ARM=$GCC_DIR CONFIGFLAGS="-DIS_SMALL_BUILD" ROOTLOC=".." all
     - cd ..
 before_deploy:
     - sudo apt-get install -y doxygen graphviz

--- a/mchf-eclipse/Makefile
+++ b/mchf-eclipse/Makefile
@@ -1,3 +1,4 @@
+#
 # Author: Harald Baumgart DL4SAI
 # everybody may  copy, use or modify this file
 # there is no guarantee for anything by the author
@@ -65,7 +66,7 @@ endif
 
 COMPILEFLAGS := -DUSE_HAL_DRIVER -DDEBUG -DUSE_FULL_ASSERT -DTRACE -D_GNU_SOURCE \
 	  -DTRX_ID=\"$(TRX_ID)\" -DTRX_NAME=\"$(TRX_NAME)\" $(CONFIGFLAGS) \
-	  -ffunction-sections -fdata-sections -flto -Wall -Wno-unused-function
+	  -ffunction-sections -fdata-sections -flto -Wall -Wno-unused-function -g3
 
 # identifying of "official builds by DF8OE"
 ifneq (,$(wildcard ../DF8OE))
@@ -74,7 +75,7 @@ endif
 
 # compilation options
 MACHFLAGS_F4 := -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -mthumb -DARM_MATH_CM4 -DCORTEX_M4 -DSTM32F407xx -D__FPU_PRESENT=1U
-MACHFLAGS_F7 := -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-d16    -mthumb -DARM_MATH_CM7 -DCORTEX_M7 -DSTM32F767xx -D__FPU_PRESENT=1 
+MACHFLAGS_F7 := -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-d16 -DARM_MATH_CM7 -DCORTEX_M7 -DSTM32F767xx -D__FPU_PRESENT=1 
 
 #COMPILEFLAGS := -DUSE_HAL_DRIVER -DDEBUG -DUSE_FULL_ASSERT -DTRACE -D_GNU_SOURCE \
 #	-DTRX_ID=\"$(TRX_ID)\" -DTRX_NAME=\"$(TRX_NAME)\" -DOFFICIAL_BUILD=\"$(OFFICIAL_BUILD)\" \
@@ -86,7 +87,7 @@ BASECFLAGS_F7  = $(MACHFLAGS_F7)  $(COMPILEFLAGS) $(EXTRACFLAGS)
 
 LINKERLOC=$(ROOTLOC)/linker
 
-LDFLAGS_BASE := -L$(LINKERLOC) -flto --specs=nano.specs
+LDFLAGS_BASE := -L$(LINKERLOC) -flto --specs=nano.specs -g3
 LDFLAGS_F4 := $(LDFLAGS_BASE) $(MACHFLAGS_F4)
 LDFLAGS_F7 := $(LDFLAGS_BASE) $(MACHFLAGS_F7) 
 
@@ -141,7 +142,7 @@ endif
 ifeq ($(BUILDFOR),F7)
 
 $(BOOTLOADER).elf: CFLAGS = ${BASECFLAGS_F7} -Os -DBOOTLOADER_BUILD
-$(FIRMWARE).elf : CFLAGS = ${BASECFLAGS_F7} -O3
+$(FIRMWARE).elf : CFLAGS = ${BASECFLAGS_F7} -O2
 $(BOOTLOADER).elf : LDFLAGS = ${LDFLAGS_F7} -T$(LINKERLOC)/arm-gcc-link-bootloader_f7.ld
 $(FIRMWARE).elf : LDFLAGS = ${LDFLAGS_F7} -T$(LINKERLOC)/arm-gcc-link_f7.ld
 
@@ -276,12 +277,12 @@ $(BOOTLOADER):  $(BOOTLOADER).bin $(BOOTLOADER).dfu
 	# compile the bootloader ARM-executables .bin / .elf and .dfu for mcHF SDR TRx, generate .map and .dmp
 
 # compilation
-$(FIRMWARE).elf:  $(OBJS) $(HAL_OBJS) $(DSPLIB_OBJS)
+$(FIRMWARE).elf:  $(HAL_OBJS) $(DSPLIB_OBJS) $(OBJS)
 	$(ECHO) "  [LD] $@"
-	$(CXX) $(LDFLAGS)  -Xlinker --gc-sections -Llibs -Wl,-Map,$(FIRMWARE).map -o$@ $^ $(LIBS)
+	@$(CXX) $(LDFLAGS)  -Xlinker --gc-sections -Llibs -Wl,-Map,$(FIRMWARE).map -o$@ $^ $(LIBS)
 
 # compilation
-$(BOOTLOADER).elf:  $(BL_OBJS) $(BL_HAL_OBJS)
+$(BOOTLOADER).elf:  $(BL_HAL_OBJS) $(BL_OBJS)
 	$(ECHO) "  [LD] $@"
 	$(CXX) $(LDFLAGS) -Xlinker --gc-sections -Llibs -Wl,-Map,$(BOOTLOADER).map -o$@ $^ $(LIBS)
 

--- a/mchf-eclipse/f4-bootloader.mak
+++ b/mchf-eclipse/f4-bootloader.mak
@@ -1,4 +1,6 @@
+# IMPORTANT: Keep startup_stm32f407xx.S the first entry, otherwise build will not work with gcc 7, see github issue #1416
 BL_HAL_SRC := \
+basesw/mcHF/Drivers/CMSIS/Device/ST/STM32F4xx/Source/Templates/gcc/startup_stm32f407xx.S \
 basesw/mcHF/Src/adc.c \
 basesw/mcHF/Src/dac.c \
 basesw/mcHF/Src/dma.c \
@@ -107,6 +109,5 @@ basesw/mcHF/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_fmc.c \
 basesw/mcHF/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_fsmc.c \
 basesw/mcHF/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_sdmmc.c \
 basesw/mcHF/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_usb.c \
-basesw/mcHF/Drivers/CMSIS/Device/ST/STM32F4xx/Source/Templates/gcc/startup_stm32f407xx.S \
 basesw/mcHF/Drivers/CMSIS/Device/ST/STM32F4xx/Source/Templates/system_stm32f4xx.c \
 \

--- a/mchf-eclipse/f4-files.mak
+++ b/mchf-eclipse/f4-files.mak
@@ -1,4 +1,6 @@
+# IMPORTANT: Keep startup_stm32f407xx.S the first entry, otherwise build will not work with gcc 7, see github issue #1416
 HAL_SRC := \
+basesw/mcHF/Drivers/CMSIS/Device/ST/STM32F4xx/Source/Templates/gcc/startup_stm32f407xx.S \
 basesw/mcHF/Src/adc.c \
 basesw/mcHF/Src/dac.c \
 basesw/mcHF/Src/dma.c \
@@ -108,7 +110,6 @@ basesw/mcHF/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_fmc.c \
 basesw/mcHF/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_fsmc.c \
 basesw/mcHF/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_sdmmc.c \
 basesw/mcHF/Drivers/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_usb.c \
-basesw/mcHF/Drivers/CMSIS/Device/ST/STM32F4xx/Source/Templates/gcc/startup_stm32f407xx.S \
 basesw/mcHF/Drivers/CMSIS/Device/ST/STM32F4xx/Source/Templates/system_stm32f4xx.c \
 
 

--- a/mchf-eclipse/f7-bootloader.mak
+++ b/mchf-eclipse/f7-bootloader.mak
@@ -1,4 +1,6 @@
+# IMPORTANT: Keep startup_stm32f767xx.S the first entry, otherwise build will not work with gcc 7, see github issue #1416
 BL_HAL_SRC := \
+basesw/ovi40/Drivers/CMSIS/Device/ST/STM32F7xx/Source/Templates/gcc/startup_stm32f767xx.S \
 basesw/ovi40/Src/adc.c \
 basesw/ovi40/Src/dac.c \
 basesw/ovi40/Src/dma.c \
@@ -117,6 +119,5 @@ basesw/ovi40/Drivers/STM32F7xx_HAL_Driver/Src/stm32f7xx_ll_tim.c \
 basesw/ovi40/Drivers/STM32F7xx_HAL_Driver/Src/stm32f7xx_ll_usart.c \
 basesw/ovi40/Drivers/STM32F7xx_HAL_Driver/Src/stm32f7xx_ll_usb.c \
 basesw/ovi40/Drivers/STM32F7xx_HAL_Driver/Src/stm32f7xx_ll_utils.c \
-basesw/ovi40/Drivers/CMSIS/Device/ST/STM32F7xx/Source/Templates/gcc/startup_stm32f767xx.S \
 basesw/ovi40/Drivers/CMSIS/Device/ST/STM32F7xx/Source/Templates/system_stm32f7xx.c \
 

--- a/mchf-eclipse/f7-files.mak
+++ b/mchf-eclipse/f7-files.mak
@@ -1,4 +1,6 @@
+# IMPORTANT: Keep startup_stm32f767xx.S the first entry, otherwise build will not work with gcc 7, see github issue #1416
 HAL_SRC := \
+basesw/ovi40/Drivers/CMSIS/Device/ST/STM32F7xx/Source/Templates/gcc/startup_stm32f767xx.S \
 basesw/ovi40/Src/adc.c \
 basesw/ovi40/Src/dac.c \
 basesw/ovi40/Src/dma.c \
@@ -121,7 +123,6 @@ basesw/ovi40/Drivers/STM32F7xx_HAL_Driver/Src/stm32f7xx_ll_tim.c \
 basesw/ovi40/Drivers/STM32F7xx_HAL_Driver/Src/stm32f7xx_ll_usart.c \
 basesw/ovi40/Drivers/STM32F7xx_HAL_Driver/Src/stm32f7xx_ll_usb.c \
 basesw/ovi40/Drivers/STM32F7xx_HAL_Driver/Src/stm32f7xx_ll_utils.c \
-basesw/ovi40/Drivers/CMSIS/Device/ST/STM32F7xx/Source/Templates/gcc/startup_stm32f767xx.S \
 basesw/ovi40/Drivers/CMSIS/Device/ST/STM32F7xx/Source/Templates/system_stm32f7xx.c \
 
 DSPLIB_SRC:=\


### PR DESCRIPTION
@df8oe : I changed for F7 from -O3 to -O2, please verify if it causes any problems with older gcc, if so, please change back to -O3

Obviously gcc7 handles weak symbols differently, since linking against weak
symbols seems only to work if the .o file with weak symbols is listed
before the files with the strong symbols. For that reason we had to change
file order for linking. For older GCC this did not seem to be an issue.
Potentially this is a bug in the gcc linker or a changed behavoir but
I found no reference to that yet.
The Eclipse internal builder (I guess by accident) has the right order,
that is why it worked there.

Also adjusted .travis.yml to build all fw with the gcc arm downloaded compiler
just as we do for official builds