### PR TITLE
Fixed out-of-bounds error which causes firmware crash

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_filter.c
+++ b/mchf-eclipse/drivers/audio/audio_filter.c
@@ -1072,10 +1072,8 @@ uint8_t AudioFilter_NextApplicableFilterPath(const uint16_t query, const uint16_
 arm_fir_instance_f32    FIR_I;
 arm_fir_instance_f32    FIR_Q;
 
-//static float32_t    __MCHF_SPECIALMEM FirState_I[FIR_RXAUDIO_BLOCK_SIZE+Q_NUM_TAPS];
-//static float32_t    __MCHF_SPECIALMEM FirState_Q[FIR_RXAUDIO_BLOCK_SIZE+Q_NUM_TAPS];
-static float32_t    __MCHF_SPECIALMEM FirState_I[FIR_RXAUDIO_BLOCK_SIZE+Q_NUM_TAPS_HI];
-static float32_t    __MCHF_SPECIALMEM FirState_Q[FIR_RXAUDIO_BLOCK_SIZE+Q_NUM_TAPS_HI];
+static float32_t    __MCHF_SPECIALMEM FirState_I[I_BLOCK_SIZE+Q_NUM_TAPS_HI];
+static float32_t    __MCHF_SPECIALMEM FirState_Q[Q_BLOCK_SIZE+Q_NUM_TAPS_HI];
 
 //
 // TX Hilbert transform (90 degree) FIR filter state tables and instances


### PR DESCRIPTION
The wrongly defined filter state size caused crashes in older gcc compiles with -O2
and probably unknown other problems if the firmware did not crash
This fixes -O2 builds for gcc 6.3.1 (and potentially others)
@df8oe: Please set -O2 in Makefile for F7 builds after confirming my fix works.
@DD4WH : Please check the buffer size definitions of the FIR & IIR Filters in audio_filter.c, I am not able to judge easily what is right and wrong here was just able to see that arm_fir_init_f32 used different value then size of supplied state buffer. Yes, C is a very studid language in that respect. 
