### PR TITLE
dynamic adjustment steps for NR strength, NB adjustmen changed

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -3575,7 +3575,11 @@ void AudioDriver_LeakyLmsNr (float32_t *in_buff, float32_t *out_buff, int buff_s
 //*----------------------------------------------------------------------------
 static void AudioDriver_RxProcessor(AudioSample_t * const src, AudioSample_t * const dst, const uint16_t blockSize)
 {
-    const int16_t blockSizeDecim = blockSize/(int16_t)ads.decimation_rate;
+    // this is the main RX audio function
+	// it is driven with 32 samples in the complex buffer scr, meaning 32 * I AND 32 * Q
+	// blockSize is thus 32, DD4WH 2018_02_06
+
+	const int16_t blockSizeDecim = blockSize/(int16_t)ads.decimation_rate;
     // we copy volatile variables which are used multiple times to local consts to let the compiler to its optimization magic
     // since we are in an interrupt, no one will change these anyway
     // shaved off a few bytes of code
@@ -3583,7 +3587,7 @@ static void AudioDriver_RxProcessor(AudioSample_t * const src, AudioSample_t * c
     const uint8_t tx_audio_source = ts.tx_audio_source;
     const uint8_t iq_freq_mode = ts.iq_freq_mode;
     const uint8_t  dsp_active = ts.dsp_active;
-	uint32_t no_dec_samples = blockSizeDecim;
+	uint32_t no_dec_samples = blockSizeDecim; // only used for the noise reduction decimation-by-two handling
 #ifdef USE_TWO_CHANNEL_AUDIO
     const bool use_stereo = ((dmod_mode == DEMOD_IQ || dmod_mode == DEMOD_SSBSTEREO || (dmod_mode == DEMOD_SAM && ads.sam_sideband == SAM_SIDEBAND_STEREO)) && ts.stereo_enable);
 #endif

--- a/mchf-eclipse/drivers/audio/audio_driver.h
+++ b/mchf-eclipse/drivers/audio/audio_driver.h
@@ -299,10 +299,10 @@ typedef struct SMeter
 //
 //#define NBLANK_AGC_DECAY	0.002	// Decay rate multiplier for "Fast" AGC
 //
-#define	MAX_NB_SETTING		40
-#define	NB_WARNING1_SETTING	8		// setting at or above which NB warning1 (yellow) is given
+#define	MAX_NB_SETTING		15
+#define	NB_WARNING1_SETTING	7		// setting at or above which NB warning1 (yellow) is given
 #define	NB_WARNING2_SETTING	12		// setting at or above which NB warning2 (orange) is given
-#define	NB_WARNING3_SETTING	16		// setting at or above which NB warning3 (red) is given
+#define	NB_WARNING3_SETTING	15		// setting at or above which NB warning3 (red) is given
 //#define	NB_DURATION			4
 //
 //#define	NB_AGC_FILT			0.999	// Component of IIR filter for recyling previous AGC value

--- a/mchf-eclipse/drivers/audio/audio_nr.c
+++ b/mchf-eclipse/drivers/audio/audio_nr.c
@@ -2373,7 +2373,8 @@ const float32_t NR_test_sinus_samp[128] = {
 
     arm_power_f32(lpcs,order,&lpc_power);  // calculate the sum of the squares (the "power") of the lpc's
 
-    impulse_threshold = (float32_t)ts.nb_setting * 0.5 * sqrtf(sigma2 * lpc_power);  //set a detection level (3 is not really a final setting)
+    //    impulse_threshold = (float32_t)ts.nb_setting * 0.5 * sqrtf(sigma2 * lpc_power);  //set a detection level (3 is not really a final setting)
+    impulse_threshold = (float32_t)(16 - ts.nb_setting) * 0.5 * sqrtf(sigma2 * lpc_power);  //set a detection level (3 is not really a final setting)
 
     //if ((nr_setting > 20) && (nr_setting <51))
     //    impulse_threshold = impulse_threshold / (0.9 + (nr_setting-20.0)/10);  //scaling the threshold by 1 ... 0.26

--- a/mchf-eclipse/drivers/ui/menu/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu.c
@@ -758,6 +758,7 @@ void UiMenu_UpdateItem(uint16_t select, uint16_t mode, int pos, int var, char* o
 
     const char* txt_ptr = NULL;
     uint32_t clr = *clr_ptr;
+	uint8_t nr_step;
 
     // case statement local variables defined for convenience here
     bool var_change = false;
@@ -782,19 +783,30 @@ void UiMenu_UpdateItem(uint16_t select, uint16_t mode, int pos, int var, char* o
     switch(select)          //  DSP_NR_STRENGTH_MAX
     {
     case MENU_DSP_NR_STRENGTH:  // DSP Noise reduction strength
-
+    	nr_step = DSP_NR_STRENGTH_STEP;
+    	if(ts.dsp_nr_strength >= 90)
+    	{
+    		nr_step = 1;
+    	}
         var_change = UiDriverMenuItemChangeUInt8(var, mode, &ts.dsp_nr_strength,
                                               DSP_NR_STRENGTH_MIN,
                                               DSP_NR_STRENGTH_MAX,
                                               DSP_NR_STRENGTH_DEFAULT,
-											  DSP_NR_STRENGTH_STEP
+											  nr_step
                                              );
         if(var_change)
         {
-            // did it change?
+        	if(ts.dsp_nr_strength == 89)
+        	{
+        		ts.dsp_nr_strength = 85;
+        	}
+        	// did it change?
             if(ts.dsp_active & DSP_NR_ENABLE)   // only change if DSP active
             {
-                AudioDriver_SetRxAudioProcessing(ts.dmod_mode, false);
+				// this causes considerable noise
+				//AudioDriver_SetRxAudioProcessing(ts.dmod_mode, false);
+				// we do this instead
+			    ts.nr_alpha = 0.899 + ((float32_t)ts.dsp_nr_strength / 1000.0);
             }
         }
 #ifdef OBSOLETE_NR

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -3438,7 +3438,16 @@ static void UiDriver_CheckEncoderTwo()
 				case ENC_TWO_MODE_NR:
 					if (is_dsp_nr())        // only allow adjustment if DSP NR is active
 					{	//
-						ts.dsp_nr_strength = change_and_limit_uint(ts.dsp_nr_strength,pot_diff_step * DSP_NR_STRENGTH_STEP,DSP_NR_STRENGTH_MIN,DSP_NR_STRENGTH_MAX);
+				    	uint8_t nr_step = DSP_NR_STRENGTH_STEP;
+				    	if(ts.dsp_nr_strength >= 90)
+				    	{
+				    		nr_step = 1;
+				    	}
+						ts.dsp_nr_strength = change_and_limit_uint(ts.dsp_nr_strength,pot_diff_step * nr_step,DSP_NR_STRENGTH_MIN,DSP_NR_STRENGTH_MAX);
+			        	if(ts.dsp_nr_strength == 89)
+			        	{
+			        		ts.dsp_nr_strength = 85;
+			        	}
 
 						// this causes considerable noise
 						//AudioDriver_SetRxAudioProcessing(ts.dmod_mode, false);


### PR DESCRIPTION
* NR adjustment from 5 to 90 in steps of five
* NR adjustment from 90 to 100 in steps of one
* reversed NB setting: 
0 - no NB activated
1 - very high noise blanker threshold --> will probably not do anything with your signal 
9 - ideal setting for most impulse noise situations --> should not distort your signal 
15 - very low noise blanker threshold --> will probably distort your signal in most situations