### PR TITLE
changed decimation filters before Hilberts to 89 taps: ONLY for STM32F4

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.h
+++ b/mchf-eclipse/drivers/audio/audio_driver.h
@@ -528,16 +528,16 @@ enum	{
 //
 #define	LMS_NOTCH_DELAYBUF_SIZE_MAX	512
 //
-#define	DSP_NOTCH_NUMTAPS_MAX	128
+#define	DSP_NOTCH_NUMTAPS_MAX	32//128
 #define	DSP_NOTCH_NUMTAPS_MIN		32
-#define	DSP_NOTCH_NUMTAPS_DEFAULT	96
+#define	DSP_NOTCH_NUMTAPS_DEFAULT	32//96
 //
-#define	DSP_NOTCH_BUFLEN_MIN	48		// minimum length of decorrelation buffer for the notch filter FIR
-#define	DSP_NOTCH_BUFLEN_MAX	192	// maximum decorrelation buffer length for the notch filter FIR
-#define	DSP_NOTCH_DELAYBUF_DEFAULT	104	// default decorrelation buffer length for the notch filter FIR
+#define	DSP_NOTCH_BUFLEN_MIN	128//48		// minimum length of decorrelation buffer for the notch filter FIR
+#define	DSP_NOTCH_BUFLEN_MAX	128//192	// maximum decorrelation buffer length for the notch filter FIR
+#define	DSP_NOTCH_DELAYBUF_DEFAULT	128//104	// default decorrelation buffer length for the notch filter FIR
 //
-#define	DSP_NOTCH_MU_MAX		40		// maximum "strength" (convergence) setting for the notch
-#define	DSP_NOTCH_MU_DEFAULT	25		// default convergence setting for the notch
+#define	DSP_NOTCH_MU_MAX		10//40		// maximum "strength" (convergence) setting for the notch
+#define	DSP_NOTCH_MU_DEFAULT	10//25		// default convergence setting for the notch
 #endif
 
 #define DSP_SWITCH_OFF				0

--- a/mchf-eclipse/drivers/audio/audio_driver.h
+++ b/mchf-eclipse/drivers/audio/audio_driver.h
@@ -528,16 +528,16 @@ enum	{
 //
 #define	LMS_NOTCH_DELAYBUF_SIZE_MAX	512
 //
-#define	DSP_NOTCH_NUMTAPS_MAX	32//128
+#define	DSP_NOTCH_NUMTAPS_MAX		32//128
 #define	DSP_NOTCH_NUMTAPS_MIN		32
 #define	DSP_NOTCH_NUMTAPS_DEFAULT	32//96
 //
-#define	DSP_NOTCH_BUFLEN_MIN	128//48		// minimum length of decorrelation buffer for the notch filter FIR
-#define	DSP_NOTCH_BUFLEN_MAX	128//192	// maximum decorrelation buffer length for the notch filter FIR
+#define	DSP_NOTCH_BUFLEN_MIN		128//64//48		// minimum length of decorrelation buffer for the notch filter FIR
+#define	DSP_NOTCH_BUFLEN_MAX		128//192	// maximum decorrelation buffer length for the notch filter FIR
 #define	DSP_NOTCH_DELAYBUF_DEFAULT	128//104	// default decorrelation buffer length for the notch filter FIR
 //
-#define	DSP_NOTCH_MU_MAX		10//40		// maximum "strength" (convergence) setting for the notch
-#define	DSP_NOTCH_MU_DEFAULT	10//25		// default convergence setting for the notch
+#define	DSP_NOTCH_MU_MAX			10//40		// maximum "strength" (convergence) setting for the notch
+#define	DSP_NOTCH_MU_DEFAULT		10//25		// default convergence setting for the notch
 #endif
 
 #define DSP_SWITCH_OFF				0

--- a/mchf-eclipse/drivers/audio/audio_filter.c
+++ b/mchf-eclipse/drivers/audio/audio_filter.c
@@ -176,6 +176,284 @@ const FilterPathDescriptor FilterPathInfo[AUDIO_FILTER_PATH_NUM] =
 // CW & SSB filters:
 //###################################################################################################################################
 
+#ifdef USE_SMALL_HILBERT_DECIMATION_FILTERS
+    // 10 filters � 300Hz
+// 4
+    {
+        AUDIO_300HZ, "500Hz", FILTER_MASK_SSBCW, 1, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_300hz_500,
+        &FirRxInterpolate, NULL, 500
+    },
+
+    {
+            AUDIO_300HZ, "550Hz", FILTER_MASK_SSBCW, 2, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+            RX_DECIMATION_RATE_12KHZ, &IIR_300hz_550,
+            &FirRxInterpolate, NULL, 550
+/*            AUDIO_300HZ, "wowHz", FILTER_MASK_SSBCW, 2, IQ_NUM_TAPS_HI, i_rx_wow_coeffs, q_rx_wow_coeffs, &FirRxDecimate,
+            RX_DECIMATION_RATE_12KHZ, &IIR_300hz_550,
+            &FirRxInterpolate, NULL, 550*/
+    },
+
+    {
+        AUDIO_300HZ, "600Hz", FILTER_MASK_SSBCW, 3, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_300hz_600,
+        &FirRxInterpolate, NULL, 600
+    },
+
+    {
+        AUDIO_300HZ, "650Hz", FILTER_MASK_SSBCW, 4, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_300hz_650,
+        &FirRxInterpolate, NULL, 650
+    },
+
+    {
+        AUDIO_300HZ, "700Hz", FILTER_MASK_SSBCW, 5, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_300hz_700,
+        &FirRxInterpolate, NULL, 700
+    },
+
+    {
+        AUDIO_300HZ, "750Hz", FILTER_MASK_SSBCW, 6, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_300hz_750,
+        &FirRxInterpolate, NULL, 750
+    },
+//10
+    {
+        AUDIO_300HZ, "800Hz", FILTER_MASK_SSBCW, 7, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_300hz_800,
+        &FirRxInterpolate, NULL, 800
+    },
+
+    {
+        AUDIO_300HZ, "850Hz", FILTER_MASK_SSBCW, 8, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_300hz_850,
+        &FirRxInterpolate, NULL, 850
+    },
+
+    {
+        AUDIO_300HZ, "900Hz", FILTER_MASK_SSBCW, 9, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_300hz_900,
+        &FirRxInterpolate, NULL, 900
+    },
+
+    {
+        AUDIO_300HZ, "950Hz", FILTER_MASK_SSBCW, 10, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_300hz_950,
+        &FirRxInterpolate, NULL, 950
+    },
+
+    // 5 filters � 500Hz
+    {
+        AUDIO_500HZ, "550Hz", FILTER_MASK_SSBCW, 1, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_500hz_550,
+        &FirRxInterpolate, NULL, 550
+    },
+//15
+    {
+        AUDIO_500HZ, "650Hz", FILTER_MASK_SSBCW, 2, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_500hz_650,
+        &FirRxInterpolate, NULL, 650
+    },
+
+    {
+        AUDIO_500HZ, "750Hz", FILTER_MASK_SSBCW, 3, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_500hz_750,
+        &FirRxInterpolate, NULL, 750
+    },
+
+    {
+        AUDIO_500HZ, "850Hz", FILTER_MASK_SSBCW, 4, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_500hz_850,
+        &FirRxInterpolate, NULL, 850
+    },
+
+    {
+        AUDIO_500HZ, "950Hz", FILTER_MASK_SSBCW, 5, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_500hz_950,
+        &FirRxInterpolate, NULL, 950
+    },
+// 19
+    {
+        AUDIO_1P4KHZ, "LPF", FILTER_MASK_SSBCW, 1, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_1k4_LPF,
+        &FirRxInterpolate, NULL, 700
+    },
+//20
+    {
+        AUDIO_1P4KHZ, "BPF", FILTER_MASK_SSBCW, 2, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_1k4_BPF,
+        &FirRxInterpolate, NULL, 775
+    },
+
+    {
+        AUDIO_1P6KHZ, "LPF", FILTER_MASK_SSBCW, 1, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_1k6_LPF,
+        &FirRxInterpolate, NULL, 800
+    },
+
+    {
+        AUDIO_1P6KHZ, "BPF", FILTER_MASK_SSBCW, 2, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_1k6_BPF,
+        &FirRxInterpolate, NULL, 875
+    },
+
+    {
+        AUDIO_1P8KHZ, "1.1k", FILTER_MASK_SSBCW, 1, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_1k8_1k125,
+        &FirRxInterpolate, NULL, 1125
+    },
+
+    {
+        AUDIO_1P8KHZ, "1.3k", FILTER_MASK_SSBCW, 2, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_1k8_1k275,
+        &FirRxInterpolate, NULL, 1275
+    },
+//25
+    {
+        AUDIO_1P8KHZ, "1.4k", FILTER_MASK_SSBCW, 3, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_1k8_1k425,
+        &FirRxInterpolate, NULL, 1425
+    },
+
+    {
+        AUDIO_1P8KHZ, "1.6k", FILTER_MASK_SSBCW, 4, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_1k8_1k575,
+        &FirRxInterpolate, NULL, 1575
+    },
+
+    {
+        AUDIO_1P8KHZ, "1.7k", FILTER_MASK_SSBCW, 5, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_1k8_1k725,
+        &FirRxInterpolate, NULL, 1725
+    },
+
+    {
+        AUDIO_1P8KHZ, "LPF", FILTER_MASK_SSBCW, 6, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_1k8_LPF,
+        &FirRxInterpolate, NULL, 900
+    },
+
+    {
+        AUDIO_2P1KHZ, "LPF", FILTER_MASK_SSBCW, 1, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_2k1_LPF,
+        &FirRxInterpolate, NULL, 1050
+    },
+//30
+    {
+        AUDIO_2P1KHZ, "BPF", FILTER_MASK_SSBCW, 2, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_2k1_BPF,
+        &FirRxInterpolate, NULL, 1125
+    },
+
+    {
+        AUDIO_2P3KHZ, "1.3k", FILTER_MASK_SSBCW, 1, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_2k3_1k275,
+        &FirRxInterpolate, NULL, 1275
+    },
+
+    {
+        AUDIO_2P3KHZ, "1.4k", FILTER_MASK_SSBCW, 2, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_2k3_1k412,
+        &FirRxInterpolate, NULL, 1412
+    },
+
+    {
+        AUDIO_2P3KHZ, "1.6k", FILTER_MASK_SSBCW, 3, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_2k3_1k562,
+        &FirRxInterpolate, NULL, 1562
+    },
+
+    {
+        AUDIO_2P3KHZ, "1.7k", FILTER_MASK_SSBCW, 4, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_2k3_1k712,
+        &FirRxInterpolate, NULL, 1712
+    },
+//35
+    {
+        AUDIO_2P3KHZ, "LPF", FILTER_MASK_SSBCW, 5, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_2k3_LPF,
+        &FirRxInterpolate, NULL, 1150
+    },
+
+//###################################################################################################################################
+// SSB only filters:
+//###################################################################################################################################
+
+    {
+        AUDIO_2P5KHZ, "LPF", FILTER_MASK_SSB, 1, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_2k5_LPF,
+        &FirRxInterpolate, NULL, 1250
+    },
+
+    {
+        AUDIO_2P5KHZ, "BPF", FILTER_MASK_SSB, 2, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_2k5_BPF,
+        &FirRxInterpolate, NULL, 1325
+    },
+
+    {
+        AUDIO_2P7KHZ, "LPF", FILTER_MASK_SSB, 1, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_2k7_LPF,
+        &FirRxInterpolate, NULL, 1350
+    },
+
+    {
+        AUDIO_2P7KHZ, "BPF", FILTER_MASK_SSB, 2, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_2k7_BPF,
+        &FirRxInterpolate, NULL, 1425
+    },
+//40
+    {
+        AUDIO_2P9KHZ, "LPF", FILTER_MASK_SSB, 1, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_2k9_LPF,
+        &FirRxInterpolate, NULL, 1450
+    },
+
+    {
+        AUDIO_2P9KHZ, "BPF", FILTER_MASK_SSB, 2, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_2k9_BPF,
+        &FirRxInterpolate, NULL, 1525
+    },
+
+    {
+        AUDIO_3P2KHZ, "LPF", FILTER_MASK_SSB, 1, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_3k2_LPF,
+        &FirRxInterpolate, NULL, 1600
+    },
+
+    {
+        AUDIO_3P2KHZ, "BPF", FILTER_MASK_SSB, 2, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_3k2_BPF,
+        &FirRxInterpolate, NULL, 1675
+    },
+
+    // in filters from 3k4 on, the FIR interpolate is 4 taps and an additional IIR interpolation filter
+//44	// is switched in to accurately prevent alias frequencies
+    {
+        AUDIO_3P4KHZ, "LPF", FILTER_MASK_SSB, 1, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_3k4_LPF,
+        &FirRxInterpolate_4_5k, &IIR_aa_5k, 1700
+    },
+//45
+    {
+        AUDIO_3P4KHZ, "BPF", FILTER_MASK_SSB, 2, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_3k4_BPF,
+        &FirRxInterpolate_4_5k, &IIR_aa_5k, 1775
+    },
+
+    {
+        AUDIO_3P6KHZ, "LPF", FILTER_MASK_SSB, 1, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_3k6_LPF,
+        &FirRxInterpolate_4_5k, &IIR_aa_5k, 1800
+    },
+
+    {
+        AUDIO_3P6KHZ, "BPF", FILTER_MASK_SSB, 2, IQ_RX_NUM_TAPS_HI, i_rx_new_coeffs, q_rx_new_coeffs, &FirRxDecimate,
+        RX_DECIMATION_RATE_12KHZ, &IIR_3k6_BPF,
+        &FirRxInterpolate_4_5k, &IIR_aa_5k, 1875
+    },
+
+#else
     // 10 filters � 300Hz
 // 4
     {
@@ -451,7 +729,7 @@ const FilterPathDescriptor FilterPathInfo[AUDIO_FILTER_PATH_NUM] =
         RX_DECIMATION_RATE_12KHZ, &IIR_3k6_BPF,
         &FirRxInterpolate_4_5k, &IIR_aa_5k, 1875
     },
-
+#endif
     {
         AUDIO_3P8KHZ, "LPF", FILTER_MASK_SSB, 1, IQ_RX_NUM_TAPS, i_rx_4k5_coeffs, q_rx_4k5_coeffs, &FirRxDecimate,
         RX_DECIMATION_RATE_12KHZ, &IIR_3k8_LPF,

--- a/mchf-eclipse/drivers/audio/audio_nr.c
+++ b/mchf-eclipse/drivers/audio/audio_nr.c
@@ -297,7 +297,8 @@ void do_alternate_NR(float32_t* inputsamples, float32_t* outputsamples )
         alt_noise_blanking(inputsamples,NR_FFT_SIZE,Energy);
     }
 
-    if((ts.dsp_active & DSP_NR_ENABLE) || (ts.dsp_active & DSP_NOTCH_ENABLE))
+    //    if((ts.dsp_active & DSP_NR_ENABLE) || (ts.dsp_active & DSP_NOTCH_ENABLE))
+    if(ts.dsp_active & DSP_NR_ENABLE)
     {
 		profileTimedEventStart(ProfileTP8);
 

--- a/mchf-eclipse/drivers/ui/menu/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu.c
@@ -3266,12 +3266,12 @@ void UiMenu_UpdateItem(uint16_t select, uint16_t mode, int pos, int var, char* o
     case CONFIG_DSP_NOTCH_FFT_NUMTAPS:      // Adjustment of DSP noise reduction de-correlation delay buffer length
         ts.dsp_notch_numtaps &= 0xf0;   // mask bottom nybble to enforce 16-count boundary
         var_change = UiDriverMenuItemChangeUInt8(var, mode, &ts.dsp_notch_numtaps,
-                                              0,
+                                              16,
                                               DSP_NOTCH_NUMTAPS_MAX,
                                               DSP_NOTCH_NUMTAPS_DEFAULT,
                                               16);
-        if(ts.dsp_notch_numtaps >= ts.dsp_notch_delaybuf_len)   // force buffer size to always be larger than number of taps
-            ts.dsp_notch_delaybuf_len = ts.dsp_notch_numtaps + 8;
+//        if(ts.dsp_notch_numtaps >= ts.dsp_notch_delaybuf_len)   // force buffer size to always be larger than number of taps
+//            ts.dsp_notch_delaybuf_len = ts.dsp_notch_numtaps + 8;
         if(var_change)      // did something change?
         {
             if(ts.dsp_active & DSP_NOTCH_ENABLE)    // only update if DSP NR active

--- a/mchf-eclipse/hardware/uhsdr_board.h
+++ b/mchf-eclipse/hardware/uhsdr_board.h
@@ -34,6 +34,10 @@
 //#define OBSOLETE_NR
 #define USE_LMS_AUTONOTCH
 
+#ifdef STM32F4
+#define USE_SMALL_HILBERT_DECIMATION_FILTERS
+#endif
+
 /**
  * This parameter disables certain features / capabilites in order to achieve a minimum build size for
  * the 192k ram / 512k flash STM32F4 machines. Unless you have such a machine, leave this disabled.


### PR DESCRIPTION
* STM32F4 uses 89 tap lowpass filters before the decimation instead of 199 taps for STM32F7/H7
* also fixed DSP autonotch setting in menu to
DSP Notch ConvRate 10
DSP Notch BufLen 128
DSP Notch FIRNumTap 32
