### PR TITLE
2 improvements: fixing part of #1131 and implementing double marker for PSK

### DIFF
--- a/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
@@ -332,8 +332,9 @@ static void UiSpectrum_UpdateSpectrumPixelParameters()
                 sd.marker_num = 2;
                 break;
             case DigitalMode_BPSK:
-            	mode_marker[0] = PSK_OFFSET;
-            	sd.marker_num = 1;
+                mode_marker[0] = PSK_OFFSET - psk_speeds[psk_ctrl_config.speed_idx].value / 2;
+                mode_marker[1] = PSK_OFFSET + psk_speeds[psk_ctrl_config.speed_idx].value / 2;
+                sd.marker_num = 2;
             	break;
             default:
                 mode_marker[0] = 0;

--- a/mchf-eclipse/drivers/ui/radio_management.c
+++ b/mchf-eclipse/drivers/ui/radio_management.c
@@ -48,6 +48,7 @@
 #include "cw_decoder.h"
 
 #include "psk.h"
+#include "rtty.h"
 
 #define SWR_SAMPLES_SKP             1   //5000
 #define SWR_SAMPLES_CNT             5//10
@@ -935,6 +936,7 @@ void RadioManagement_SetBandPowerFactor(uchar band)
 void RadioManagement_SetDemodMode(uint8_t new_mode)
 {
 
+	DigiModes_TxBufferReset();
 
     ts.dsp_inhibit++;
     ads.af_disabled++;


### PR DESCRIPTION
Double marker allows to understand width of the specific PSK speed, thus less need for speed guessing.
Digi TxBuffer is now reset upon mode change, which fixes part of #1131 