### PR TITLE
#1131 First try to implement storing keyer memories into serial EEPROM

### DIFF
--- a/mchf-eclipse/drivers/ui/ui_configuration.c
+++ b/mchf-eclipse/drivers/ui/ui_configuration.c
@@ -577,6 +577,31 @@ static void __attribute__ ((noinline)) UiConfiguration_ReadConfigEntries()
     }
 }
 
+void UiConfiguration_UpdateMacroCap(void)
+{
+	int c;
+	uint8_t* pmacro;
+
+	for (int i = 0; i < KEYER_BUTTONS; i++)
+	{
+		if (ts.keyer_mode.macro[i] != '\0')
+		{
+			// Make button label from start of the macro
+			pmacro = (uint8_t *)ts.keyer_mode.macro[i];
+			c = 0;
+			while(*pmacro != ' ' && *pmacro != '\0' && c < KEYER_CAP_LEN)
+			{
+				ts.keyer_mode.cap[i][c++] = *pmacro++;
+			}
+			ts.keyer_mode.cap[i][c] = '\0';
+		}
+		else
+		{
+			strcpy((char *) ts.keyer_mode.cap[i], "BTN");
+		}
+
+	}
+}
 
 //
 //*----------------------------------------------------------------------------
@@ -653,6 +678,9 @@ void UiConfiguration_LoadEepromValues(void)
     UiReadSettingEEPROM_UInt32( EEPROM_XVERTER_OFFSET_HIGH,EEPROM_XVERTER_OFFSET_LOW,&ts.xverter_offset,0,0,XVERTER_OFFSET_MAX);
 
     UiReadSettingEEPROM_Filter();
+
+    ConfigStorage_CopySerial2Array(EEPROM_KEYER_MEMORY_ADDRESS, (uint8_t *)ts.keyer_mode.macro, sizeof(ts.keyer_mode.macro));
+    UiConfiguration_UpdateMacroCap();
 
     // post configuration loading actions below
     df.tuning_step  = tune_steps[df.selected_idx];
@@ -774,6 +802,9 @@ uint16_t UiConfiguration_SaveEepromValues(void)
             retval = ConfigStorage_CopyRAMCache2Serial();
             // write ram cache to EEPROM and switch back to I2C EEPROM use
         }
+
+        retval = ConfigStorage_CopyArray2Serial(EEPROM_KEYER_MEMORY_ADDRESS, (uint8_t *)ts.keyer_mode.macro, sizeof(ts.keyer_mode.macro));
+
     }
     return retval;
 }

--- a/mchf-eclipse/drivers/ui/ui_configuration.h
+++ b/mchf-eclipse/drivers/ui/ui_configuration.h
@@ -45,6 +45,7 @@ const ConfigEntryDescriptor* UiConfiguration_GetEntry(uint16_t id);
 
 void        UiConfiguration_LoadEepromValues(void);
 uint16_t    UiConfiguration_SaveEepromValues(void);
+void		UiConfiguration_UpdateMacroCap(void);
 
 // Configuration Value Definitions Follow
 //
@@ -596,5 +597,7 @@ uint16_t    UiConfiguration_SaveEepromValues(void);
 
 // Note: EEPROM addresses up to 383 are currently defined. If this value is passed you
 // need to modify virtual EEPROM routines otherwise system may crash
+
+#define EEPROM_KEYER_MEMORY_ADDRESS		0x7d0
 
 #endif /* DRIVERS_UI_UI_CONFIGURATION_H_ */

--- a/mchf-eclipse/drivers/ui/ui_configuration.h
+++ b/mchf-eclipse/drivers/ui/ui_configuration.h
@@ -598,6 +598,6 @@ void		UiConfiguration_UpdateMacroCap(void);
 // Note: EEPROM addresses up to 383 are currently defined. If this value is passed you
 // need to modify virtual EEPROM routines otherwise system may crash
 
-#define EEPROM_KEYER_MEMORY_ADDRESS		0x7d0
+#define EEPROM_KEYER_MEMORY_ADDRESS		0x1000
 
 #endif /* DRIVERS_UI_UI_CONFIGURATION_H_ */

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -6157,22 +6157,7 @@ static void UiAction_PlayKeyerBtnN(int8_t n)
 		}
 		*pmacro = '\0';
 
-		if (c)
-		{
-			// Make button label from start of the macro
-			pmacro = (uint8_t *)ts.keyer_mode.macro[n];
-			c = 0;
-			while(*pmacro != ' ' && *pmacro != '\0' && c < KEYER_CAP_LEN)
-			{
-				ts.keyer_mode.cap[n][c++] = *pmacro++;
-			}
-			ts.keyer_mode.cap[n][c] = '\0';
-		}
-		else
-		{
-			strcpy((char *) ts.keyer_mode.cap[n], "BTN");
-		}
-
+		UiConfiguration_UpdateMacroCap();
 		UiDriver_TextMsgPutChar('<');
 		ts.keyer_mode.button_recording = KEYER_BUTTON_NONE;
 	}

--- a/mchf-eclipse/misc/config_storage.c
+++ b/mchf-eclipse/misc/config_storage.c
@@ -188,6 +188,28 @@ void ConfigStorage_CopySerial2Flash(void)
     }
 }
 
+//copy array directly to serial EEPROM
+uint16_t ConfigStorage_CopyArray2Serial(uint32_t Addr, const uint8_t *buffer, uint16_t length)
+{
+	uint16_t retval = HAL_OK;
+    if(ts.configstore_in_use == CONFIGSTORE_IN_USE_I2C)
+    {
+        retval = SerialEEPROM_24Cxx_WriteBulk(Addr, buffer, length, ts.ser_eeprom_type);
+    }
+
+	return retval;
+}
+
+//read array directly from serial EEPROM
+void ConfigStorage_CopySerial2Array(uint32_t Addr, uint8_t *buffer, uint16_t length)
+{
+    if(ts.configstore_in_use == CONFIGSTORE_IN_USE_I2C)
+    {
+    	SerialEEPROM_24Cxx_ReadBulk(Addr, buffer, length, ts.ser_eeprom_type);
+    }
+
+}
+
 /**
  * verify data serial / virtual EEPROM
  * sets ts.configstore_in_use to CONFIGSTORE_IN_USE_ERROR if

--- a/mchf-eclipse/misc/config_storage.h
+++ b/mchf-eclipse/misc/config_storage.h
@@ -28,5 +28,7 @@ void ConfigStorage_CopySerial2Flash(void);
 void ConfigStorage_CopySerial2RAMCache();
 uint16_t ConfigStorage_CopyRAMCache2Serial();
 
+uint16_t ConfigStorage_CopyArray2Serial(uint32_t Addr, const uint8_t *buffer, uint16_t length);
+void ConfigStorage_CopySerial2Array(uint32_t Addr, uint8_t *buffer, uint16_t length);
 
 #endif


### PR DESCRIPTION
This is work in progress. It currently works only for the first memory, but I haven't found the bug yet. May be I am misunderstanding how SerialEEPROM_24Cxx_WriteBulk should be called?

Serial EEPROM is mandatory for this f-ty.

Please, comment on the value of EEPROM_KEYER_MEMORY_ADDRESS 
I am not checking the size of EEPROM as the minimum supported size is enough.
