### PR TITLE
Fixed OVI40 Tune Issue and minor other changes

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -749,7 +749,7 @@ void AudioDriver_Init(void)
     ts.codec_present = Codec_Reset(ts.samp_rate,word_size) == HAL_OK;
 
     // Start DMA transfers
-    MchfHw_Codec_StartDMA();
+    UhsdrHwI2s_Codec_StartDMA();
 
     // Audio filter enabled
     ads.af_disabled = 0;
@@ -5056,6 +5056,7 @@ void AudioDriver_I2SCallback(int16_t *src, int16_t *dst, int16_t* audioDst, int1
             if (to_rx)
             {
                 AudioDriver_ClearAudioDelayBuffer();
+                UhsdrHwI2s_Codec_ClearTxDmaBuffer();
             }
             if ( ts.audio_processor_input_mute_counter >0)
             {
@@ -5086,14 +5087,10 @@ void AudioDriver_I2SCallback(int16_t *src, int16_t *dst, int16_t* audioDst, int1
     }
     else  			// Transmit mode
     {
-        if((to_tx) || (ts.audio_processor_input_mute_counter>0))	 	// the first time back to RX, or TX audio muting timer still active - clear the buffers to reduce the "crash"
+        if((to_tx) || (ts.audio_processor_input_mute_counter>0))	 	// the first time back to TX, or TX audio muting timer still active - clear the buffers to reduce the "crash"
         {
             muted = true;
             arm_fill_q15(0, src, size);
-            if (to_rx)
-            {
-                AudioDriver_ClearAudioDelayBuffer();
-            }
             to_tx = false;                          // caused by the content of the buffers from TX - used on return from SSB TX
             if ( ts.audio_processor_input_mute_counter >0)
             {

--- a/mchf-eclipse/drivers/audio/codec/uhsdr_hw_i2s.c
+++ b/mchf-eclipse/drivers/audio/codec/uhsdr_hw_i2s.c
@@ -52,6 +52,11 @@ typedef int16_t audio_data_t;
 #define CODEC_ANA_IDX 0
 #endif
 
+void UhsdrHwI2s_Codec_ClearTxDmaBuffer()
+{
+    memset((void*)&audio_buf[CODEC_IQ_IDX].out, 0, sizeof(audio_buf[CODEC_IQ_IDX].out));
+}
+
 static void MchfHw_Codec_HandleBlock(uint16_t which)
 {
 #ifdef PROFILE_EVENTS
@@ -140,7 +145,7 @@ void HAL_SAI_RxHalfCpltCallback(SAI_HandleTypeDef *hi2s)
 }
 #endif
 
-void MchfHw_Codec_StartDMA()
+void UhsdrHwI2s_Codec_StartDMA()
 {
     szbuf = BUFF_LEN;
 
@@ -158,7 +163,7 @@ void MchfHw_Codec_StartDMA()
 }
 
 
-void MchfHw_Codec_StopDMA(void)
+void UhsdrHwI2s_Codec_StopDMA(void)
 {
 #ifdef UI_BRD_MCHF
     HAL_I2S_DMAStop(&hi2s3);

--- a/mchf-eclipse/drivers/audio/codec/uhsdr_hw_i2s.h
+++ b/mchf-eclipse/drivers/audio/codec/uhsdr_hw_i2s.h
@@ -36,11 +36,10 @@ typedef struct
 #define DMA_AUDIO_NUM 2
 #endif
 
-extern __IO dma_audio_buffer_t audio_buf[DMA_AUDIO_NUM];
+void UhsdrHwI2s_Codec_StartDMA();
+void UhsdrHwI2s_Codec_StopDMA();
 
-
-void MchfHw_Codec_StartDMA();
-void MchfHw_Codec_StopDMA();
+void UhsdrHwI2s_Codec_ClearTxDmaBuffer();
 
 #endif
 

--- a/mchf-eclipse/drivers/audio/softdds/softdds.c
+++ b/mchf-eclipse/drivers/audio/softdds/softdds.c
@@ -99,10 +99,9 @@ void softdds_genIQSingleTone(soft_dds_t* dds, float32_t *i_buff,float32_t *q_buf
  */
 void softdds_genIQTwoTone(soft_dds_t* ddsA, soft_dds_t* ddsB, float *i_buff,float *q_buff,ushort size)
 {
-    ulong   i,k[2];
-
-    for(i = 0; i < size; i++)
+    for(int i = 0; i < size; i++)
     {
+        uint32_t k[2];
         // Calculate next sample
         k[0]    = softdds_nextSampleIndex(ddsA);
         k[1]    = softdds_nextSampleIndex(ddsB);


### PR DESCRIPTION
- In some modes (SSB) on OVI40 after tuning distorted audio was received
with signals a RX+/-750 Hz, 1500 Hz etc. This was cause by an unclean IQ TX buffer.
Since OVI40 HW can send and receive IQ at the same time, some of the unwanted
TX signal came back via RX. Now fixed by cleaning the IQ TX data.
- Some minor changes along the way to simplify code and use more consistent naming

mcHF (single codec architecture) was not affected by the issue.