### PR TITLE
Buffer cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 docs/
 mchf-eclipse/.settings/org.eclipse.cdt.managedbuilder.core.prefs
+.metadata

--- a/mchf-eclipse/drivers/audio/audio_driver.h
+++ b/mchf-eclipse/drivers/audio/audio_driver.h
@@ -54,7 +54,7 @@
 #define FIR_RXAUDIO_BLOCK_SIZE		IQ_BLOCK_SIZE
 #define FIR_RXAUDIO_NUM_TAPS		16 // maximum number of taps in the decimation and interpolation FIR filters
 #define IIR_RXAUDIO_BLOCK_SIZE		IQ_BLOCK_SIZE
-#define IIR_RXAUDIO_NUM_STAGES		12 // we use a maximum stage number of 10 at the moment, so this is 12 just to be safe
+#define IIR_RXAUDIO_NUM_STAGES_MAX	12 // we use a maximum stage number of 10 at the moment, so this is 12 just to be safe
 //
 #define CODEC_DEFAULT_GAIN		0x1F	// Gain of line input to start with
 #define	ADC_CLIP_WARN_THRESHOLD	4096	// This is at least 12dB below the clipping threshold of the A/D converter itself
@@ -66,19 +66,22 @@
 
 #define SAM_PLL_HILBERT_STAGES 7
 
+
+#ifdef USE_TWO_CHANNEL_AUDIO
+    #define NUM_AUDIO_CHANNELS 2
+#else
+    #define NUM_AUDIO_CHANNELS 1
+#endif
+
 typedef struct
 {
     // Stereo buffers
-    float32_t                   i_buffer[IQ_BUFSZ];
-    float32_t                   q_buffer[IQ_BUFSZ];
+    float32_t               i_buffer[IQ_BLOCK_SIZE];
+    float32_t               q_buffer[IQ_BLOCK_SIZE];
 
-    float32_t                   a_buffer[IQ_BUFSZ];
-    float32_t                   b_buffer[IQ_BUFSZ];
-    float32_t					NR_dec_buffer[16];
-#ifdef USE_TWO_CHANNEL_AUDIO
-    float32_t					r_buffer[IQ_BUFSZ]; // used for the right channel in STEREO DEMODULATION
-#endif
-    float32_t               agc_valbuf[BUFF_LEN];   // holder for "running" AGC value
+    float32_t               a_buffer[2][IQ_BLOCK_SIZE];
+    float32_t				NR_dec_buffer[16];
+    float32_t               agc_valbuf[IQ_BLOCK_SIZE];   // holder for "running" AGC value
     float32_t               DF;
     float32_t               pll_fmax;
     // DX adjustments: zeta = 0.15, omegaN = 100.0

--- a/mchf-eclipse/drivers/audio/audio_filter.h
+++ b/mchf-eclipse/drivers/audio/audio_filter.h
@@ -34,18 +34,8 @@ extern arm_fir_instance_f32    Fir_TxFreeDV_Interpolate_I;
 extern arm_fir_decimate_instance_f32 FirDecim_RxSam_I;
 extern arm_fir_decimate_instance_f32 FirDecim_RxSam_Q;
 
-
-
-// Audio filter select enumeration
 void 	AudioFilter_InitRxHilbertFIR(uint8_t dmod_mode);
-//void    AudioFilter_CalcRxPhaseAdj(void);
 void 	AudioFilter_InitTxHilbertFIR(void);
-//void    AudioFilter_CalcTxPhaseAdj(void);
-
-
-
-
-
 
 enum
 {
@@ -93,8 +83,6 @@ enum
     FILTER_MODE_MAX
 };
 
-//
-//
 #define AUDIO_DEFAULT_FILTER        AUDIO_2P3KHZ
 //
 // use below to define the lowest-used filter number
@@ -104,7 +92,6 @@ enum
 // use below to define the highest-used filter number-1
 //
 #define AUDIO_MAX_FILTER        (AUDIO_FILTER_NUM-1)
-//
 
 
 typedef struct FilterDescriptor_s
@@ -151,15 +138,6 @@ typedef struct FilterPathDescriptor_s
 #define AUDIO_FILTER_PATH_NUM 87
 
 extern const FilterPathDescriptor FilterPathInfo[AUDIO_FILTER_PATH_NUM];
-//
-// Define visual widths of audio filters for on-screen indicator in Hz
-//
-//
-#define HILBERT_3600HZ_WIDTH        3800    // Approximate bandwidth of 3.6 kHz wide Hilbert - This used to depict FM detection bandwidth
-//
-//
-#define HILBERT3600         1900    // "width" of "3.6 kHz" Hilbert filter - This used to depict FM detection bandwidth
-//
 
 enum
 {
@@ -179,6 +157,7 @@ void     AudioFilter_GetNamesOfFilterPath(uint16_t filter_path,const char** filt
 uint16_t AudioFilter_GetFilterModeFromDemodMode(uint8_t dmod_mode);
 uint8_t  AudioFilter_NextApplicableFilter();
 void     AudioFilter_SetDefaultMemories();
+
 
 typedef struct
 {

--- a/mchf-eclipse/drivers/audio/audio_nr.h
+++ b/mchf-eclipse/drivers/audio/audio_nr.h
@@ -18,6 +18,9 @@
 #include "uhsdr_board.h"
 
 #ifdef USE_ALTERNATE_NR
+// this contains our shared buffer structure, since FreeDV and NR are mutually exclusive
+// they can use the same set of buffers for exchanging data between audio interrupt and
+// user code
 #include "freedv_uhsdr.h"
 
 #define NR_FFT_SIZE 128
@@ -52,9 +55,9 @@ typedef struct NoiseReduction // declaration
 	//ulong						long_tone_counter;
 } NoiseReduction;
 
+
 // we need another struct, because of the need for strict allocation of memory for users of the
 // mcHF hardware with small RAM (192 kb)
-//
 typedef struct NoiseReduction2 // declaration
 {
 	float32_t 					X[NR_FFT_L_2 / 2][2]; // magnitudes of the current and the last FFT bins

--- a/mchf-eclipse/drivers/ui/radio_management.c
+++ b/mchf-eclipse/drivers/ui/radio_management.c
@@ -1247,13 +1247,24 @@ uint32_t RadioManagement_NextNormalDemodMode(uint32_t loc_mode)
 
 bool RadioManagement_UsesBothSidebands(uint16_t dmod_mode)
 {
+    bool retval =
+            (
+                    (dmod_mode == DEMOD_AM)
+                    ||(dmod_mode == DEMOD_SAM && (ads.sam_sideband == SAM_SIDEBAND_BOTH))
+                    || (dmod_mode == DEMOD_FM)
+            );
+
+
 #ifdef USE_TWO_CHANNEL_AUDIO
-    return ((dmod_mode == DEMOD_SSBSTEREO) || (dmod_mode == DEMOD_IQ) || (dmod_mode == DEMOD_AM) ||
-    		(dmod_mode == DEMOD_SAM && (ads.sam_sideband == SAM_SIDEBAND_BOTH || ads.sam_sideband == SAM_SIDEBAND_STEREO )) ||
-			(dmod_mode == DEMOD_FM));
-#else
-    return ((dmod_mode == DEMOD_AM) ||(dmod_mode == DEMOD_SAM && (ads.sam_sideband == SAM_SIDEBAND_BOTH)) || (dmod_mode == DEMOD_FM));
+    // if we support two channel audio, then both bands are used by some additional modes
+    retval = retval ||
+            (
+                    (dmod_mode == DEMOD_SSBSTEREO)
+                    || (dmod_mode == DEMOD_IQ)
+                    || (dmod_mode == DEMOD_SAM && ads.sam_sideband == SAM_SIDEBAND_STEREO )
+            );
 #endif
+    return retval;
 }
 
 bool RadioManagement_LSBActive(uint16_t dmod_mode)

--- a/mchf-eclipse/drivers/ui/ui_configuration.h
+++ b/mchf-eclipse/drivers/ui/ui_configuration.h
@@ -93,6 +93,7 @@ uint16_t    UiConfiguration_SaveEepromValues(void);
 #define MAGNIFY_MIN                 0
 #define MAGNIFY_MAX                 5
 #define MAGNIFY_DEFAULT             0
+#define MAGNIFY_NUM                 (MAGNIFY_MAX+1)
 
 //
 #define PA_BIAS_MAX         115     // Maximum PA Bias Setting


### PR DESCRIPTION
Buffer Usage cleanup

Reduced required static audio buffers in adb (remove r_buffer and b_buffer),
both replaced by more efficient usage of the now 2 element a_buffer[0] and
a_buffer[1]. a_buffer[1] is basically used where b_buffer was used before
and a_buffer[0] is both a_buffer and r_buffer in one.

Use of 2 buffer array allows to handle TWO_CHANNEL_AUDIO by means of for loops
in a number of places.

Introduced filter buffer arrays also in other places where the number of
buffers depends on the number of audio channels (1 or 2) for similar reasons.

I also reduced the buffer size to IQ_BLOCK_SIZE == 32 from IQ_BUFSZ == 64.
Could not find a single use with more than IQ_BLOCK_SIZE.

Also checked many buffer sizes for filter structures and
reduced the size in most cases to the "required minimum" (or a little above,
did not use TAPS + BLOCKSIZE -1 but TAPS + BLOCKSIZE)

Introduced a number of defines for the size of a filter state buffer so that
we can reference the correct size more easily in clear functions.

Renamed some filters to use _I when these have matching _Q filters.

All of this is intended to reduce memory usage AND make code a little simpler.
At least lmsData now fits into MCHF_SPECIALMEM aka CCM on the mcHF / STM32F4

I also replaced a number (not all) of "manual" filter initialization with the official ones, we cannot do this everywhere due to the way we do this concurrently with the audio driver interrupt which may use filters we are about to change. 

This needs testing. It works for me, and most filters touched are in active use almost all the time so I hope we don't discover any issues. 



Also added in separate commit gitignore change for .metadata (no harm with that)