### PR TITLE
Fix for clock reconfiguration

### DIFF
--- a/mchf-eclipse/basesw/mcHF/Src/main.c
+++ b/mchf-eclipse/basesw/mcHF/Src/main.c
@@ -104,6 +104,7 @@ int main(void)
   HAL_Init();
 
 
+  HAL_RCC_DeInit();
 
   /* Configure the system clock */
   SystemClock_Config();

--- a/mchf-eclipse/basesw/ovi40/Src/main.c
+++ b/mchf-eclipse/basesw/ovi40/Src/main.c
@@ -117,6 +117,9 @@ int main(void)
   /* Reset of all peripherals, Initializes the Flash interface and the Systick. */
   HAL_Init();
 
+  /* Ensure we have a clock configuration as in reset state, i.e. PLL clock is off and we are using HSI */
+  HAL_RCC_DeInit();
+
   /* Configure the system clock */
   SystemClock_Config();
 


### PR DESCRIPTION
This change should enable reconfiguration of clocks in firmware
so that we can use a different clock configuration in bootloader
and firmware.

This should fix #1465. Please test, I don't have access to hardware right now. 