### PR TITLE
Added extended command set for CAT

### DIFF
--- a/mchf-eclipse/drivers/ui/ui_configuration.c
+++ b/mchf-eclipse/drivers/ui/ui_configuration.c
@@ -32,6 +32,7 @@
 // If more EEPROM variables are added, make sure that you add to this table - and the index to it in "eeprom.h"
 // and correct MAX_VAR_ADDR in uhsdr_board.h
 
+static uint16_t dummy_val16; // we need this to be able to read config values without modifying anything
 
 #define UI_C_EEPROM_BAND_5W_PF(bandNo,bandName1,bandName2) { ConfigEntry_UInt8, EEPROM_BAND##bandNo##_5W,&ts.pwr_adj[ADJ_5W][BAND_MODE_##bandName1],TX_POWER_FACTOR_##bandName1##_DEFAULT,0,TX_POWER_FACTOR_MAX },
 #define UI_C_EEPROM_BAND_FULL_PF(bandNo,bandName1,bandName2) { ConfigEntry_UInt8, EEPROM_BAND##bandNo##_FULL,&ts.pwr_adj[ADJ_FULL_POWER][BAND_MODE_##bandName1],TX_POWER_FACTOR_##bandName1##_DEFAULT,0,TX_POWER_FACTOR_MAX },
@@ -240,6 +241,7 @@ const ConfigEntryDescriptor ConfigEntryInfo[] =
 	{ ConfigEntry_Int32, EEPROM_TScal3_High,&mchf_touchscreen.cal[3], -1,-2147483648,2147483647},
 	{ ConfigEntry_Int32, EEPROM_TScal4_High,&mchf_touchscreen.cal[4], 74886,-2147483648,2147483647},
 	{ ConfigEntry_Int32, EEPROM_TScal5_High,&mchf_touchscreen.cal[5], -1630326,-2147483648,2147483647},
+	{ ConfigEntry_UInt16, EEPROM_NUMBER_OF_ENTRIES,&dummy_val16,EEPROM_FIRST_UNUSED,EEPROM_FIRST_UNUSED,EEPROM_FIRST_UNUSED},
     // the entry below MUST be the last entry, and only at the last position Stop is allowed
     {
         ConfigEntry_Stop
@@ -584,7 +586,7 @@ void UiConfiguration_UpdateMacroCap(void)
 
 	for (int i = 0; i < KEYER_BUTTONS; i++)
 	{
-		if (ts.keyer_mode.macro[i] != '\0')
+		if (*ts.keyer_mode.macro[i] != '\0')
 		{
 			// Make button label from start of the macro
 			pmacro = (uint8_t *)ts.keyer_mode.macro[i];
@@ -620,10 +622,9 @@ void UiConfiguration_LoadEepromValues(void)
     uint16_t value16;
     uint32_t value32;
 
-    // Do a sample reads to "prime the pump" before we start...
-    // This is to make the function work reliabily after boot-up
-    UiReadSettingEEPROM_UInt16(EEPROM_ZERO_LOC_UNRELIABLE,&value16,0,0,0xffff);
-    // Let's use location zero - which may not work reliably, anyway!
+    // Do a sample read to "prime the pump" before we start...
+    UiReadSettingEEPROM_UInt16(EEPROM_ZERO_LOC,&value16,0,0,0xffff);
+
 
     UiReadSettingEEPROM_UInt16(EEPROM_FLAGS2,&ts.flags2,0,0,255);
     // ------------------------------------------------------------------------------------

--- a/mchf-eclipse/drivers/ui/ui_configuration.h
+++ b/mchf-eclipse/drivers/ui/ui_configuration.h
@@ -156,7 +156,7 @@ void		UiConfiguration_UpdateMacroCap(void);
 //
 //
 
-#define EEPROM_ZERO_LOC_UNRELIABLE			0       // DO NOT USE LOCATION ZERO AS IT MAY BE UNRELIABLE!!!!
+#define EEPROM_ZERO_LOC			            0
 #define EEPROM_BAND_MODE					1
 #define EEPROM_FREQ_HIGH					2
 #define EEPROM_FREQ_LOW						3
@@ -585,8 +585,10 @@ void		UiConfiguration_UpdateMacroCap(void);
 #define EEPROM_CW_DECODER_ENABLE				404
 #define EEPROM_Scope_Graticule_Ypos				405
 #define EEPROM_Freq_Display_Font				406
+#define EEPROM_NUMBER_OF_ENTRIES                407 // this is the index of the config value which holds the number of used config entries
+                                                    // , not the value itself (which is in fact EEPROM_FIRST_UNUSED)
 
-#define EEPROM_FIRST_UNUSED 				407		// change this if new value ids are introduced
+#define EEPROM_FIRST_UNUSED 				408		// change this if new value ids are introduced, must be correct at any time
 
 #define MAX_VAR_ADDR (EEPROM_FIRST_UNUSED - 1)
 

--- a/mchf-eclipse/support/python/testcom.py
+++ b/mchf-eclipse/support/python/testcom.py
@@ -1,0 +1,142 @@
+from __future__ import print_function
+
+
+#comPort="COM15"
+#comPort="/dev/ttyACM0"
+comPort = ""
+
+import serial
+import sys
+import json
+
+# we list all used cat command codes here
+# this list includes the officially known FT817 codes (including the "undocumented" ones)
+class CatCmdFt817:
+    READ_EEPROM = 0xBB
+    WRITE_EEPROM = 0xBC
+
+# this list includes the special UHSDR codes implemented only in the UHSDR dialect of FT817 CAT (which must be different from the Ft817 ones)
+class CatCmdUhsdr(CatCmdFt817):
+    UHSDR_ID = 0x42  # this will return the bytes ['U', 'H' , 'S', 'D', 'R' ] and is used to identify an UHSDR with high enough firmware level
+    
+
+class CatCmd(CatCmdUhsdr):
+    True
+
+class UhsdrConfigIndex:
+    VER_MAJOR = 176
+    VER_MINOR = 310
+    VER_BUILD = 171
+    NUMBER_OF_ENTRIES = 407
+
+def eprint(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
+    
+class catSerial:
+    def __init__(self, comObj):
+        self.comObj = comObj
+    def sendCommand(self, command):
+        bytesWritten = self.comObj.write(command)
+        return bytesWritten == 5
+
+    def readResponse(self,count):
+        response = self.comObj.read(count)
+        return (len(response) == count,response)
+    
+
+
+class catCommands:
+    def __init__(self, catObj):
+        self.catObj = catObj
+
+    def execute(self, cmd, count):
+        if self.catObj.sendCommand(cmd):
+            ok,res = self.catObj.readResponse(count)
+            return ok,bytearray(res)
+        else:
+            return (False,bytearray([]))
+
+    def readEEPROM(self, addr):
+        cmd = bytearray([ (addr & 0xff00)>>8,addr & 0xff, 0x00, 0x00, CatCmd.READ_EEPROM])
+        ok,res = self.execute(cmd,2)
+        if ok:
+            return res[1] * 256 + res[0]
+        else:
+            return ok
+
+    def readUHSDR(self):
+        cmd = bytearray([ 0x00, 0x00 , 0x00, 0x00, CatCmd.UHSDR_ID])
+        ok,res = self.execute(cmd,5)
+
+        return res == bytearray("UHSDR")
+   
+
+    def writeEEPROM(self, addr, value16bit):
+        cmd = bytearray([ (addr & 0xff00)>>8,addr & 0xff, (value16bit & 0xff) >> 0, (value16bit & 0xff00) >> 8, CatCmd.WRITE_EEPROM])
+        ok,res = self.execute(cmd,1)
+        return ok
+    
+    def readUHSDRConfig(self, index):
+        return self.readEEPROM(index + 0x8000);
+
+    def writeUHSDRConfig(self, index, value):
+        return self.writeEEPROM(index + 0x8000, value);
+
+class UhsdrConfig():
+    def __init__(self, catObj):
+        self.catObj = catObj
+
+    def getVersion(self):
+        return (self.catObj.readUHSDRConfig(UhsdrConfigIndex.VER_MAJOR),
+                    self.catObj.readUHSDRConfig(UhsdrConfigIndex.VER_MINOR),
+                    self.catObj.readUHSDRConfig(UhsdrConfigIndex.VER_BUILD))
+    
+    def isUhsdrConnected(self):
+        return self.catObj.readUHSDR()
+    
+    def getConfigValueCount(self):
+        return self.catObj.readUHSDRConfig(UhsdrConfigIndex.NUMBER_OF_ENTRIES)
+        
+    def getValue(self, index):
+        # TODO: do some range checking here
+        return self.catObj.readUHSDRConfig(index)
+
+
+if __name__ == "__main__":   
+    if (len(comPort) > 0):
+        mySer = serial.Serial(comPort, 38400, timeout=0.500, parity=serial.PARITY_NONE)
+        myCom = catSerial(mySer)
+        myCAT = catCommands(myCom)
+        myUHSDR = UhsdrConfig(myCAT)
+
+        if myUHSDR.isUhsdrConnected():
+            print("UHSDR Firmware Version", myUHSDR.getVersion())
+            valList = []
+            data = {}
+            data['eeprom'] = []
+            numberOfValues = myUHSDR.getConfigValueCount()
+            for index in range(numberOfValues):
+                val = myUHSDR.getValue(index)
+                valList.append(val)
+                data['eeprom'].append({ 'addr' : index , 'value' : val })
+            #print(valList)
+                
+            if all(val is not False for val in valList) or len(valList) != 0:
+                with open('uhsdr_config.json', 'w') as outfile:  
+                    json.dump(data, outfile, indent=4)
+                    outfile.close()
+                    print("saved data to uhsdr_config.json file")
+            else:
+                eprint("Could not read list sucessfully")
+        else:   
+            eprint("Could not find a connected UHSDR with extended CAT commands (required)")
+            
+        #print myCAT.readEEPROM(512);
+        #print myCAT.readUHSDRConfig(512);
+        #print myCAT.writeEEPROM(512,0xabcd);
+        #print myCAT.writeUHSDRConfig(512,0xfedc);
+    else:
+        eprint("please specify UHSDR TRX com port at begin of file")
+
+
+


### PR DESCRIPTION
This permits reading and writing of config values using the serial interface,
see https://github.com/df8oe/UHSDR/wiki/USB-CAT-and-AUDIO-Mode#extended-cat-command-set-from-2918

A very experimental python script (testcom.py) shows how to access this
interface and stores the currently saved configuration in JSON-Format.
Writing has not been tested, please be careful if playing.