### PR TITLE
Virtual DSP keypad . Fixup for not proper eeprom mask. Attempt#1.

### DIFF
--- a/mchf-eclipse/drivers/ui/ui_configuration.c
+++ b/mchf-eclipse/drivers/ui/ui_configuration.c
@@ -246,7 +246,7 @@ const ConfigEntryDescriptor ConfigEntryInfo[] =
 	{ ConfigEntry_Int32, EEPROM_TScal4_High,&mchf_touchscreen.cal[4], 74886,-2147483648,2147483647},
 	{ ConfigEntry_Int32, EEPROM_TScal5_High,&mchf_touchscreen.cal[5], -1630326,-2147483648,2147483647},
 	{ ConfigEntry_UInt16, EEPROM_NUMBER_OF_ENTRIES,&dummy_val16,EEPROM_FIRST_UNUSED,EEPROM_FIRST_UNUSED,EEPROM_FIRST_UNUSED},
-	{ ConfigEntry_UInt16, EEPROM_DSP_MODE_MASK,&ts.dsp_mode_mask,0xffff,0,0xffff},
+	{ ConfigEntry_UInt16, EEPROM_DSP_MODE_MASK,&ts.dsp_mode_mask,(1<<DSP_SWITCH_MAX)-1,1,(1<<DSP_SWITCH_MAX)-1},
     // the entry below MUST be the last entry, and only at the last position Stop is allowed
     {
         ConfigEntry_Stop

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -5728,7 +5728,9 @@ void UiAction_ChangeLowerMeterUp()
 void UiDriver_UpdateDSPmode()
 {
 
-	do{
+	//loop for detection of first possible DSP function to switch it on if others are disabled/not allowed
+	for(int i=0;i<DSP_SWITCH_MAX;i++)
+	{
 		//
 		// prevent certain modes to prevent CPU crash
 		//
@@ -5746,9 +5748,8 @@ void UiDriver_UpdateDSPmode()
 
 		if (ts.dsp_mode >= DSP_SWITCH_MAX) ts.dsp_mode = DSP_SWITCH_OFF; // flip round
 
-		if(ts.dsp_mode==0)	break;
-
-	}while(1);
+		if(ts.dsp_mode==0)	break;	//safe exit because there is always DSP OFF option at which we can stop
+	}
 
 
 	switch (ts.dsp_mode)

--- a/mchf-eclipse/drivers/ui/ui_vkeybrd.c
+++ b/mchf-eclipse/drivers/ui/ui_vkeybrd.c
@@ -14,7 +14,7 @@
 #define Col_BtnLightLeftTop RGB(0xE0,0xE0,0xE0)
 #define Col_BtnLightRightBot RGB(0x60,0x60,0x60)
 #define Col_BtnDisabled RGB(0x70,0x70,0x70)
-#define Col_Warning RGB(0xC0,0xC0,0x80)
+#define Col_Warning RGB(0xC0,0xC0,0x60)
 
 
 /**
@@ -27,11 +27,11 @@
 
 static void UiVk_DrawButtonBody(UiArea_t* Ka, uint16_t col_Bcgr, uint16_t col_LeftUP, uint16_t col_RightBot)
 {
-	UiLcdHy28_DrawFullRect(Ka->x+1,Ka->y+1,Ka->h-2,Ka->w-2,col_Bcgr);
-	UiLcdHy28_DrawStraightLine(Ka->x,Ka->y,Ka->h,LCD_DIR_VERTICAL,col_LeftUP);
-	UiLcdHy28_DrawStraightLine(Ka->x+1,Ka->y,Ka->w-1,LCD_DIR_HORIZONTAL,col_LeftUP);
-	UiLcdHy28_DrawStraightLine(Ka->x+Ka->w,Ka->y+1,Ka->h-1,LCD_DIR_VERTICAL,col_RightBot);
-	UiLcdHy28_DrawStraightLine(Ka->x+1,Ka->y+Ka->h,Ka->w-1,LCD_DIR_HORIZONTAL,col_RightBot);
+	UiLcdHy28_DrawFullRect(Ka->x+1,Ka->y+1,Ka->h-1,Ka->w-1,col_Bcgr);
+	UiLcdHy28_DrawStraightLine(Ka->x,Ka->y,Ka->h+1,LCD_DIR_VERTICAL,col_LeftUP);	//left
+	UiLcdHy28_DrawStraightLine(Ka->x+1,Ka->y,Ka->w,LCD_DIR_HORIZONTAL,col_LeftUP);	//top
+	UiLcdHy28_DrawStraightLine(Ka->x+Ka->w,Ka->y+1,Ka->h-1,LCD_DIR_VERTICAL,col_RightBot);	//right
+	UiLcdHy28_DrawStraightLine(Ka->x+1,Ka->y+Ka->h,Ka->w,LCD_DIR_HORIZONTAL,col_RightBot); //bottom
 }
 
 /**

--- a/mchf-eclipse/src/uhsdr_main.c
+++ b/mchf-eclipse/src/uhsdr_main.c
@@ -500,6 +500,11 @@ int mchfMain(void)
     // UI HW init
     UiDriver_Init();
 
+    //preventing DSP functions mask to have not proper value
+    ts.dsp_mode_mask|=1;
+    ts.dsp_mode_mask&=(1<<DSP_SWITCH_MAX)-1;
+
+
 	// Si5351a only present at OVI40 and supports VLF...2m
 	if (Si5351a_IsPresent()) {
 		ts.rfmod_present = true;


### PR DESCRIPTION
One remark: if  something was set in eeprom in mask location, before first usage of virtual keypad - it will have impact on available DSP modes. Please unblock it by long press on key(s). Fixup for #1489.