### PR TITLE
Refactored key handling and input test screen

### DIFF
--- a/mchf-eclipse/drivers/ui/lcd/ui_lcd_hy28.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_lcd_hy28.c
@@ -1800,6 +1800,9 @@ static void UiLcdHy28_PrintTextCenteredLen(const uint16_t XposStart,const uint16
     }
 }
 
+/*
+ * Print text centered inside the bounding box. Using '\n' to print multline text
+ */
 uint16_t UiLcdHy28_PrintTextCentered(const uint16_t XposStart,const uint16_t YposStart,const uint16_t bbW,const char* str,uint32_t clr_fg,uint32_t clr_bg,uint8_t font)
 {
     // this code is a full clone of the PrintText function, with exception of the function call to PrintTextCenteredLen

--- a/mchf-eclipse/hardware/uhsdr_board.h
+++ b/mchf-eclipse/hardware/uhsdr_board.h
@@ -182,50 +182,6 @@
 #include "uhsdr_board_config.h"
 #include "ui_vkeybrd.h"
 
-// Buttons map structure
-typedef struct ButtonMap
-{
-    GPIO_TypeDef 	*port;
-    ushort			button;
-    const char*     label;
-
-} ButtonMap;
-
-typedef struct
-{
-    const ButtonMap* map;
-    uint32_t num;
-} mchf_buttons_t;
-
-// Button definitions
-//
-enum
-{
-    BUTTON_M2_PRESSED = 0,  // 0
-    BUTTON_G3_PRESSED,  	// 1
-    BUTTON_G2_PRESSED,  	// 2
-    BUTTON_BNDM_PRESSED,    // 3
-    BUTTON_G4_PRESSED,  	// 4
-    BUTTON_M3_PRESSED,  	// 5
-    BUTTON_STEPM_PRESSED,   // 6
-    BUTTON_STEPP_PRESSED,   // 7
-    BUTTON_M1_PRESSED,  	// 8
-    BUTTON_F3_PRESSED,  	// 9 - Press and release handled in UiDriverProcessFunctionKeyClick()
-    BUTTON_F1_PRESSED,  	// 10 - Press and release handled in UiDriverProcessFunctionKeyClick()
-    BUTTON_F2_PRESSED,  	// 11 - Press and release handled in UiDriverProcessFunctionKeyClick()
-    BUTTON_F4_PRESSED,  	// 12 - Press and release handled in UiDriverProcessFunctionKeyClick()
-    BUTTON_BNDP_PRESSED,    // 13
-    BUTTON_F5_PRESSED,  	// 14 - Press and release handled in UiDriverProcessFunctionKeyClick()
-    BUTTON_G1_PRESSED,  	// 15
-    BUTTON_POWER_PRESSED,   // 16 - Used for press and release
-    TOUCHSCREEN_ACTIVE, 	// 17 - Touchscreen touched, needs to last entry before BUTTON_NUM,
-    //      init code relies on this
-    BUTTON_NUM // How many buttons we have defined
-};
-
-extern mchf_buttons_t  buttons;
-extern const ButtonMap  bm_sets[2][BUTTON_NUM];
-
 struct mchf_waterfall
 {
     uint8_t	color_scheme;			// stores waterfall color scheme

--- a/mchf-eclipse/hardware/uhsdr_board_config.h
+++ b/mchf-eclipse/hardware/uhsdr_board_config.h
@@ -716,6 +716,11 @@
 // pin 14
 // pin 15
 
+// PORT H
+// pin1
+#define BUTTON_S19              GPIO_PIN_1
+#define BUTTON_S19_PIO          GPIOH
+
 #ifdef STM32H7
 #define hdac hdac1
 #define FLASHSIZE_BASE 0x1FF1E880

--- a/mchf-eclipse/hardware/uhsdr_keypad.h
+++ b/mchf-eclipse/hardware/uhsdr_keypad.h
@@ -1,0 +1,87 @@
+/*  -*-  mode: c; tab-width: 4; indent-tabs-mode: t; c-basic-offset: 4; coding: utf-8  -*-  */
+/************************************************************************************
+ **                                                                                 **
+ **                                        UHSDR                                    **
+ **               a powerful firmware for STM32 based SDR transceivers              **
+ **                                                                                 **
+ **---------------------------------------------------------------------------------**
+ **                                                                                 **
+ **  Licence:       GNU GPLv3                                                      **
+ ************************************************************************************/
+#ifndef __UHSDR_KEYPAD_H
+#define __UHSDR_KEYPAD_H
+#include "uhsdr_board.h"
+
+// Key map structure
+// represents a physical key which can be pressed (via GPIO)
+typedef struct
+{
+    GPIO_TypeDef    *keyPort;
+    uint16_t        keyPin;
+    uint16_t         button_id;
+    const char*     label;
+
+} ButtonPhys_t;
+
+// represents a logical button
+typedef struct
+{
+    uint16_t        button_id;
+    const char*     label;
+} UhsdrButtonLogical_t;
+
+typedef struct
+{
+    const ButtonPhys_t* map;
+    uint32_t num;
+} UhsdrHwKey_t;
+
+// Logical Button definitions
+//
+enum
+{
+    BUTTON_M2_PRESSED = 0,  // 0
+    BUTTON_G3_PRESSED,  	// 1
+    BUTTON_G2_PRESSED,  	// 2
+    BUTTON_BNDM_PRESSED,    // 3
+    BUTTON_G4_PRESSED,  	// 4
+    BUTTON_M3_PRESSED,  	// 5
+    BUTTON_STEPM_PRESSED,   // 6
+    BUTTON_STEPP_PRESSED,   // 7
+    BUTTON_M1_PRESSED,  	// 8
+    BUTTON_F3_PRESSED,  	// 9 - Press and release handled in UiDriverProcessFunctionKeyClick()
+    BUTTON_F1_PRESSED,  	// 10 - Press and release handled in UiDriverProcessFunctionKeyClick()
+    BUTTON_F2_PRESSED,  	// 11 - Press and release handled in UiDriverProcessFunctionKeyClick()
+    BUTTON_F4_PRESSED,  	// 12 - Press and release handled in UiDriverProcessFunctionKeyClick()
+    BUTTON_BNDP_PRESSED,    // 13
+    BUTTON_F5_PRESSED,  	// 14 - Press and release handled in UiDriverProcessFunctionKeyClick()
+    BUTTON_G1_PRESSED,  	// 15
+    BUTTON_PWR_PRESSED,   // 16 - Used for press and release
+    TOUCHSCREEN_ACTIVE, 	// 17 - Touchscreen touched, needs to last entry before BUTTON_NUM,
+#ifdef UI_BRD_OVI40
+    BUTTON_F6_PRESSED,      // we have one more function button
+    BUTTON_E1_PRESSED,      // encoder 1 click
+    BUTTON_E2_PRESSED,      // encoder 1 click
+    BUTTON_E3_PRESSED,      // encoder 1 click
+    BUTTON_E4_PRESSED,      // encoder 1 click
+#endif
+    //      init code relies on this
+    BUTTON_NUM, // How many buttons we have defined
+    BUTTON_NOP // used for buttons with no function
+};
+
+extern UhsdrHwKey_t  hwKeys; // these buttons represent the gpio to logical button id mapping
+extern const UhsdrButtonLogical_t  buttons[]; // this array gives us the names of the available logical buttons
+
+
+bool Board_IsButtonPressed(uint32_t button_num);
+bool Board_IsAnyButtonPressed();
+bool Board_IsKeyPressed(uint32_t key_num);
+bool Board_IsAnyKeyPressed();
+uint32_t Board_KeyStates();
+uint32_t Board_ButtonStates();
+void Board_KeypadScan();
+
+
+
+#endif


### PR DESCRIPTION
On OVI40 we now have also the additional keys handled
In future we can flexibly map logical button functions to hw keys,
for instance to use same firmware with different key layouts saved
in config memory. This may be a little too flexible, but we'll see.

Also reworked the input test screen to properly support encoder action display,
showing all pressed hw keys, also POWER and BAND- have now (again) some
long enough delay before they do power off or reboot.

This work is not finished (should move low level keyboard handling out of ui_driver)
but should be perfectly usable