### PR TITLE
Oscillator Modifications

### DIFF
--- a/mchf-eclipse/basesw/ovi40/Src/gpio.c
+++ b/mchf-eclipse/basesw/ovi40/Src/gpio.c
@@ -183,10 +183,9 @@ void MX_GPIO_Init(void)
 
   /*Configure GPIO pin : PC9 */
   GPIO_InitStruct.Pin = GPIO_PIN_9;
-  GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+  GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
   GPIO_InitStruct.Pull = GPIO_NOPULL;
   GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-  GPIO_InitStruct.Alternate = GPIO_AF0_MCO;
   HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
 
   /*Configure GPIO pins : PAPin PAPin */

--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -3028,7 +3028,7 @@ static void AudioDriver_SpectrumNoZoomProcessSamples(const uint16_t blockSize)
                     sd.samp_ptr = 0;
                 }
             }
-            sd.FFT_frequency = (ts.tune_freq / TUNE_MULT); // spectrum shows all, LO is center frequency;
+            sd.FFT_frequency = (ts.tune_freq); // spectrum shows all, LO is center frequency;
         }
     }
 }
@@ -3090,7 +3090,7 @@ static void AudioDriver_SpectrumZoomProcessSamples(const uint16_t blockSize)
                     sd.samp_ptr = 0;
                 }
             } // end for
-            sd.FFT_frequency = (ts.tune_freq / TUNE_MULT) + AudioDriver_GetTranslateFreq(); // spectrum shows center at translate frequency, LO + Translate Freq  is center frequency;
+            sd.FFT_frequency = (ts.tune_freq) + AudioDriver_GetTranslateFreq(); // spectrum shows center at translate frequency, LO + Translate Freq  is center frequency;
 
 
             // TODO: also insert sample collection for snap carrier here

--- a/mchf-eclipse/drivers/ui/menu/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu.c
@@ -405,7 +405,7 @@ void UiMenu_HandleIQAdjust(int var, uint8_t mode, char* options, uint32_t* clr_p
                 1);
         if(tchange)
         {
-            AudioManagement_CalcIqPhaseGainAdjust(ts.tune_freq/TUNE_MULT);
+            AudioManagement_CalcIqPhaseGainAdjust(ts.tune_freq);
         }
     }
     else        // Orange if not in correct mode

--- a/mchf-eclipse/drivers/ui/oscillator/osc_interface.h
+++ b/mchf-eclipse/drivers/ui/oscillator/osc_interface.h
@@ -39,6 +39,8 @@ typedef struct
 	void  (*setPPM)(float32_t ppm);
 
 	// normal operations interface
+	// freq is given in Hz, is QSD mixing frequency,
+	// internally multiplied by 4 for Johnson Counter clock counters if needed by circuit
 	Oscillator_ResultCodes_t (*prepareNextFrequency)(ulong freq, int temp_factor);
 	Oscillator_ResultCodes_t (*changeToNextFrequency)();
 	bool 			  (*isNextStepLarge)();

--- a/mchf-eclipse/drivers/ui/oscillator/osc_si570.c
+++ b/mchf-eclipse/drivers/ui/oscillator/osc_si570.c
@@ -687,14 +687,15 @@ static Oscillator_ResultCodes_t Si570_PrepareNextFrequency(ulong freq, int temp_
     if (osc->isPresent() == true) {
         float64_t  freq_calc, temp_scale;
 
-        freq_calc = freq;     // copy frequency
+        freq_calc = freq * 4.0;
+        // frequency multiplied with 4 since we drive a johnson counter for phased clock generation
 
-        temp_scale = temp_factor;    // get temperature factor
-        temp_scale /= 14000000;     // calculate scaling factor for the temperature correction (referenced to 14.000 MHz)
+        temp_scale = ((float64_t)temp_factor)/14000000.0;
+        // calculate scaling factor for the temperature correction (referenced to 14.000 MHz)
 
         freq_calc *= (1 + temp_scale);  // rescale by temperature correction factor
 
-        // new DF8OE disabler of system crash when tuning frequency is outside SI570 hard limits
+        // when tuning frequency is outside SI570 hard limits, don't do it
         if (freq_calc <= SI570_HARD_MAX_FREQ && freq_calc >= SI570_HARD_MIN_FREQ)
         {
             // tuning inside known working spec

--- a/mchf-eclipse/drivers/ui/radio_management.c
+++ b/mchf-eclipse/drivers/ui/radio_management.c
@@ -298,7 +298,7 @@ uint32_t RadioManagement_Dial2TuneFrequency(const uint32_t dial_freq, uint8_t tx
         tune_freq += (ts.rit_value*20); // Add RIT on receive
     }
 
-    return tune_freq*TUNE_MULT;
+    return tune_freq;
 }
 
 /**
@@ -406,7 +406,7 @@ bool RadioManagement_ChangeFrequency(bool force_update, uint32_t dial_freq,uint8
                 ts.tx_disable |= TX_DISABLE_OUTOFRANGE;
             }
 
-            uint32_t tune_freq_real = ts.tune_freq/TUNE_MULT;
+            uint32_t tune_freq_real = ts.tune_freq;
 
             RadioManagement_SetHWFiltersForFrequency(tune_freq_real);  // check the filter status with the new frequency update
             AudioManagement_CalcIqPhaseGainAdjust(tune_freq_real);

--- a/mchf-eclipse/hardware/uhsdr_board_config.h
+++ b/mchf-eclipse/hardware/uhsdr_board_config.h
@@ -507,8 +507,8 @@
 #define POWER_DOWN              GPIO_PIN_8
 #define POWER_DOWN_PIO          GPIOC
 // pin 9
-#define CODEC_CLOCK             GPIO_PIN_9
-#define CODEC_CLOCK_PIO         GPIOC
+#define IQ_CLOCK_DIV4_SIG             GPIO_PIN_9
+#define IQ_CLOCK_DIV4_SIG_PIO         GPIOC
 // pin 10
 #define CODEC_I2S_SCK           GPIO_PIN_10
 #define CODEC_I2S_SCK_PIO       GPIOC


### PR DESCRIPTION
Please test before releasing, I was not able to do so for mcHF.

- Si5351a now uses CLK2 for 4x clock , CLK0+CLK1 for 90 degreed phased output @ 1x clock
- Si5351a code now toogles gpio (high for 4x none-phased output, low for 1x phased output
- Oscillator Interface now expects 1x frequency value as input and internally scales by 4
  if is driving a 4x johnson counter based clock phasing circuit.