### PR TITLE
Encoder boundary crossing fixup. Attempt 1.

### DIFF
--- a/mchf-eclipse/basesw/mcHF/Inc/tim.h
+++ b/mchf-eclipse/basesw/mcHF/Inc/tim.h
@@ -62,7 +62,9 @@ extern TIM_HandleTypeDef htim5;
 extern TIM_HandleTypeDef htim8;
 
 /* USER CODE BEGIN Private defines */
-
+#define ENC_filter 15									//encoder input sampling filter (amount of same input samples to be threated as stable state)
+#define ENC_ClockDivision TIM_CLOCKDIVISION_DIV4		//clock divider for encoder filter
+#define ENCODER_RANGE	0xFFF							// Maximum pot value
 /* USER CODE END Private defines */
 
 extern void Error_Handler(void);

--- a/mchf-eclipse/basesw/mcHF/Src/tim.c
+++ b/mchf-eclipse/basesw/mcHF/Src/tim.c
@@ -65,17 +65,17 @@ void MX_TIM3_Init(void)
   htim3.Instance = TIM3;
   htim3.Init.Prescaler = 0;
   htim3.Init.CounterMode = TIM_COUNTERMODE_UP;
-  htim3.Init.Period = 4103;
-  htim3.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+  htim3.Init.Period = ENCODER_RANGE;
+  htim3.Init.ClockDivision = ENC_ClockDivision;
   sConfig.EncoderMode = TIM_ENCODERMODE_TI12;
   sConfig.IC1Polarity = TIM_ICPOLARITY_FALLING;
   sConfig.IC1Selection = TIM_ICSELECTION_DIRECTTI;
   sConfig.IC1Prescaler = TIM_ICPSC_DIV1;
-  sConfig.IC1Filter = 0;
+  sConfig.IC1Filter = ENC_filter;
   sConfig.IC2Polarity = TIM_ICPOLARITY_FALLING;
   sConfig.IC2Selection = TIM_ICSELECTION_DIRECTTI;
   sConfig.IC2Prescaler = TIM_ICPSC_DIV1;
-  sConfig.IC2Filter = 0;
+  sConfig.IC2Filter = ENC_filter;
   if (HAL_TIM_Encoder_Init(&htim3, &sConfig) != HAL_OK)
   {
     Error_Handler();
@@ -98,17 +98,17 @@ void MX_TIM4_Init(void)
   htim4.Instance = TIM4;
   htim4.Init.Prescaler = 0;
   htim4.Init.CounterMode = TIM_COUNTERMODE_UP;
-  htim4.Init.Period = 4103;
-  htim4.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+  htim4.Init.Period = ENCODER_RANGE;
+  htim4.Init.ClockDivision = ENC_ClockDivision;
   sConfig.EncoderMode = TIM_ENCODERMODE_TI12;
   sConfig.IC1Polarity = TIM_ICPOLARITY_FALLING;
   sConfig.IC1Selection = TIM_ICSELECTION_DIRECTTI;
   sConfig.IC1Prescaler = TIM_ICPSC_DIV1;
-  sConfig.IC1Filter = 0;
+  sConfig.IC1Filter = ENC_filter;
   sConfig.IC2Polarity = TIM_ICPOLARITY_FALLING;
   sConfig.IC2Selection = TIM_ICSELECTION_DIRECTTI;
   sConfig.IC2Prescaler = TIM_ICPSC_DIV1;
-  sConfig.IC2Filter = 0;
+  sConfig.IC2Filter = ENC_filter;
   if (HAL_TIM_Encoder_Init(&htim4, &sConfig) != HAL_OK)
   {
     Error_Handler();
@@ -131,17 +131,17 @@ void MX_TIM5_Init(void)
   htim5.Instance = TIM5;
   htim5.Init.Prescaler = 0;
   htim5.Init.CounterMode = TIM_COUNTERMODE_UP;
-  htim5.Init.Period = 4103;
-  htim5.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+  htim5.Init.Period = ENCODER_RANGE;
+  htim5.Init.ClockDivision = ENC_ClockDivision;
   sConfig.EncoderMode = TIM_ENCODERMODE_TI12;
   sConfig.IC1Polarity = TIM_ICPOLARITY_FALLING;
   sConfig.IC1Selection = TIM_ICSELECTION_DIRECTTI;
   sConfig.IC1Prescaler = TIM_ICPSC_DIV1;
-  sConfig.IC1Filter = 0;
+  sConfig.IC1Filter = ENC_filter;
   sConfig.IC2Polarity = TIM_ICPOLARITY_FALLING;
   sConfig.IC2Selection = TIM_ICSELECTION_DIRECTTI;
   sConfig.IC2Prescaler = TIM_ICPSC_DIV1;
-  sConfig.IC2Filter = 0;
+  sConfig.IC2Filter = ENC_filter;
   if (HAL_TIM_Encoder_Init(&htim5, &sConfig) != HAL_OK)
   {
     Error_Handler();
@@ -164,18 +164,18 @@ void MX_TIM8_Init(void)
   htim8.Instance = TIM8;
   htim8.Init.Prescaler = 0;
   htim8.Init.CounterMode = TIM_COUNTERMODE_UP;
-  htim8.Init.Period = 4103;
-  htim8.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+  htim8.Init.Period = ENCODER_RANGE;
+  htim8.Init.ClockDivision = ENC_ClockDivision;
   htim8.Init.RepetitionCounter = 0;
   sConfig.EncoderMode = TIM_ENCODERMODE_TI12;
   sConfig.IC1Polarity = TIM_ICPOLARITY_FALLING;
   sConfig.IC1Selection = TIM_ICSELECTION_DIRECTTI;
   sConfig.IC1Prescaler = TIM_ICPSC_DIV1;
-  sConfig.IC1Filter = 0;
+  sConfig.IC1Filter = ENC_filter;
   sConfig.IC2Polarity = TIM_ICPOLARITY_FALLING;
   sConfig.IC2Selection = TIM_ICSELECTION_DIRECTTI;
   sConfig.IC2Prescaler = TIM_ICPSC_DIV1;
-  sConfig.IC2Filter = 0;
+  sConfig.IC2Filter = ENC_filter;
   if (HAL_TIM_Encoder_Init(&htim8, &sConfig) != HAL_OK)
   {
     Error_Handler();

--- a/mchf-eclipse/basesw/ovi40/Inc/tim.h
+++ b/mchf-eclipse/basesw/ovi40/Inc/tim.h
@@ -53,7 +53,9 @@
 #include "main.h"
 
 /* USER CODE BEGIN Includes */
-
+#define ENC_filter 15									//encoder input sampling filter (amount of same input samples to be threated as stable state)
+#define ENC_ClockDivision TIM_CLOCKDIVISION_DIV4		//clock divider for encoder filter
+#define ENCODER_RANGE	0xFFF							// Maximum pot value
 /* USER CODE END Includes */
 
 extern TIM_HandleTypeDef htim3;

--- a/mchf-eclipse/basesw/ovi40/Src/tim.c
+++ b/mchf-eclipse/basesw/ovi40/Src/tim.c
@@ -65,8 +65,8 @@ void MX_TIM3_Init(void)
   htim3.Instance = TIM3;
   htim3.Init.Prescaler = 0;
   htim3.Init.CounterMode = TIM_COUNTERMODE_UP;
-  htim3.Init.Period = 4103;
-  htim3.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+  htim3.Init.Period = ENCODER_RANGE;
+  htim3.Init.ClockDivision = ENC_ClockDivision;
   htim3.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
   sConfig.EncoderMode = TIM_ENCODERMODE_TI12;
   sConfig.IC1Polarity = TIM_ICPOLARITY_FALLING;
@@ -99,8 +99,8 @@ void MX_TIM4_Init(void)
   htim4.Instance = TIM4;
   htim4.Init.Prescaler = 0;
   htim4.Init.CounterMode = TIM_COUNTERMODE_UP;
-  htim4.Init.Period = 4103;
-  htim4.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+  htim4.Init.Period = ENCODER_RANGE;
+  htim4.Init.ClockDivision = ENC_ClockDivision;
   htim4.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
   sConfig.EncoderMode = TIM_ENCODERMODE_TI12;
   sConfig.IC1Polarity = TIM_ICPOLARITY_FALLING;
@@ -133,8 +133,8 @@ void MX_TIM5_Init(void)
   htim5.Instance = TIM5;
   htim5.Init.Prescaler = 0;
   htim5.Init.CounterMode = TIM_COUNTERMODE_UP;
-  htim5.Init.Period = 4013;
-  htim5.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+  htim5.Init.Period = ENCODER_RANGE;
+  htim5.Init.ClockDivision = ENC_ClockDivision;
   htim5.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
   sConfig.EncoderMode = TIM_ENCODERMODE_TI12;
   sConfig.IC1Polarity = TIM_ICPOLARITY_FALLING;
@@ -167,8 +167,8 @@ void MX_TIM8_Init(void)
   htim8.Instance = TIM8;
   htim8.Init.Prescaler = 0;
   htim8.Init.CounterMode = TIM_COUNTERMODE_UP;
-  htim8.Init.Period = 4103;
-  htim8.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+  htim8.Init.Period = ENCODER_RANGE;
+  htim8.Init.ClockDivision = ENC_ClockDivision;
   htim8.Init.RepetitionCounter = 0;
   htim8.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
   sConfig.EncoderMode = TIM_ENCODERMODE_TI12;

--- a/mchf-eclipse/drivers/ui/encoder/ui_rotary.h
+++ b/mchf-eclipse/drivers/ui/encoder/ui_rotary.h
@@ -25,14 +25,24 @@
 // capacitors
 #define ENCODER_FLICKR_BAND	4
 
-// --------------------------------
-// Maximum pot value
-#define ENCODER_RANGE	0xFFF
-
 // Divider to create non linearity
 #define ENCODER_LOG_D	1
 
 // Audio Gain public structure
+
+typedef struct EncoderSelection
+{
+    // pot values
+    //
+    uint16_t value_old;			// previous value
+    uint16_t value_new;			// most current value
+    uint8_t	de_detent;			// sw de-detent flag
+    TIM_TypeDef* tim;
+
+} EncoderSelection;
+
+//left only for reference:
+/*
 typedef struct EncoderSelection
 {
     // pot values
@@ -43,7 +53,7 @@ typedef struct EncoderSelection
     TIM_TypeDef* tim;
 
 } EncoderSelection;
-
+*/
 
 void UiRotaryFreqEncoderInit(void);
 


### PR DESCRIPTION
Tested on mcHF not on OVI40. Added filtering for timer inputs used for encoders. Works perfect with my 256/rotation encoder.
I'm very curious the effect of this fixup. This is strange but there was NO detection against overflow/underflow of timer in encoder mode. Also corrected strange ARR value for all timers used for encoders.
All this is strange to me that no one noticed it before... Anyway, hope it will work for everyone :)
Changes not added to H7 sources/includes.