### PR TITLE
Fixed USB Audio device desciptor.

### DIFF
--- a/mchf-eclipse/drivers/usb/app/usbd_desc.c
+++ b/mchf-eclipse/drivers/usb/app/usbd_desc.c
@@ -142,8 +142,12 @@ __ALIGN_BEGIN uint8_t USBD_FS_DeviceDesc[USB_LEN_DEV_DESC] __ALIGN_END =
     0x00,                       /* bcdUSB */
 #endif
     0x02,
-    0xEF,                       /*bDeviceClass*/
-    0x02,                       /*bDeviceSubClass*/
+	/* Typically only the bDeviceClass is set at the device level.
+	 * Most class specifications choose to identify itself at the interface level
+	 * and as a result set the bDeviceClass as 0x00.
+	 * This allows for the one device to support multiple classes. */
+    0x00,                       /*0xEF bDeviceClass*/
+    0x00,                       /*0x02 bDeviceSubClass*/
     0x01,                       /*bDeviceProtocol*/
     USB_MAX_EP0_SIZE,          /*bMaxPacketSize*/
     LOBYTE(USBD_VID),           /*idVendor*/


### PR DESCRIPTION
With this change USB audio works as well on Ubuntu based distros out of the box. bDeviceClass: Most class specifications choose to identify itself at the interface level. This allows for the one device to support multiple classes. bNrChannels: Channel conflict (was 1) and wChannelConfig was set as mono, which won't work as intended. Type III Format: is wrong, it doesn't support PCM at all....so it has to be Type I Format
/HB9GND