### PR TITLE
Fix for F7 bootloader not working on gcc7 issue

### DIFF
--- a/mchf-eclipse/src/bootloader/command.c
+++ b/mchf-eclipse/src/bootloader/command.c
@@ -36,10 +36,7 @@
 
 /* Private macros ------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
-static uint8_t RAM_Buf[BUFFER_SIZE] =
-{
-        0x00
-};
+static uint8_t RAM_Buf[BUFFER_SIZE] __attribute__ ((aligned (4)));
 
 static FIL file;
 static FIL fileR;


### PR DESCRIPTION
It was an issue with unaligned data. Obviously gcc7
did not align the buffer for FatFs USB drive access to a 4 byte boundary.
This causes the diskwrite (or read) to fail. This misalignment was not
happening on F4/H7 builds and on gcc6 F7 builds out of pure luck.

Now with an alignment attribute all is working on all builds...
BTW, initializing  a global static array with 0 is not necessary, that is done automatically (because it is global).