### PR TITLE
Fixed linker script, shrunk F7 bootloader to fit

### DIFF
--- a/mchf-eclipse/basesw/ovi40/Src/stm32f7xx_it.c
+++ b/mchf-eclipse/basesw/ovi40/Src/stm32f7xx_it.c
@@ -140,20 +140,20 @@ void DebugMon_Handler(void)
   /* USER CODE END DebugMonitor_IRQn 1 */
 }
 
+#ifndef BOOTLOADER_BUILD
 /**
 * @brief This function handles Pendable request for system service.
 */
 void PendSV_Handler(void)
 {
   /* USER CODE BEGIN PendSV_IRQn 0 */
-#ifndef BOOTLOADER_BUILD
     UiDriver_TaskHandler_HighPrioTasks();
-#endif
   /* USER CODE END PendSV_IRQn 0 */
   /* USER CODE BEGIN PendSV_IRQn 1 */
 
   /* USER CODE END PendSV_IRQn 1 */
 }
+#endif
 
 /**
 * @brief This function handles System tick timer.
@@ -176,7 +176,7 @@ void SysTick_Handler(void)
 /* For the available peripheral interrupt handler names,                      */
 /* please refer to the startup file (startup_stm32f7xx.s).                    */
 /******************************************************************************/
-
+#ifndef BOOTLOADER_BUILD
 /**
 * @brief This function handles EXTI line0 interrupt.
 */
@@ -204,6 +204,7 @@ void EXTI1_IRQHandler(void)
 
   /* USER CODE END EXTI1_IRQn 1 */
 }
+#endif
 
 /**
 * @brief This function handles DMA1 stream4 global interrupt.
@@ -273,7 +274,6 @@ void OTG_FS_IRQHandler(void)
   /* USER CODE BEGIN OTG_FS_IRQn 1 */
   /* USER CODE END OTG_FS_IRQn 1 */
 }
-#endif
 
 /**
 * @brief This function handles DMA2 stream6 global interrupt.
@@ -288,6 +288,7 @@ void DMA2_Stream6_IRQHandler(void)
 
   /* USER CODE END DMA2_Stream6_IRQn 1 */
 }
+#endif
 
 #if defined(USE_USBHOST) || defined(BOOTLOADER_BUILD)
 /**

--- a/mchf-eclipse/hardware/uhsdr_board_config.h
+++ b/mchf-eclipse/hardware/uhsdr_board_config.h
@@ -377,8 +377,11 @@
 
 // place tagged elements in a memory to peripheral DMA-able memory region
 // with the correct cache strategy set
-#define __UHSDR_DMAMEM __attribute__ ((section (".dmamem")))
-
+#ifdef STM32H7
+    #define __UHSDR_DMAMEM __attribute__ ((section (".dmamem")))
+#else
+    #define __UHSDR_DMAMEM
+#endif
 
 
 #define SI570_I2C               (&hi2c1)

--- a/mchf-eclipse/linker/arm-gcc-link-bootloader_f4.ld
+++ b/mchf-eclipse/linker/arm-gcc-link-bootloader_f4.ld
@@ -57,7 +57,7 @@ SECTIONS
 	/* _sidata is used in coide startup code */
 	_sidata = __etext;
 	
-	.data : AT (__etext)
+	.data :
 	{
 		__data_start__ = .;
 		
@@ -94,7 +94,7 @@ SECTIONS
 		
 		/* _edata is used in coide startup code */
 		_edata = __data_end__;
-	} > ram 
+	} > ram AT > rom 
 	
 	.bss :
 	{

--- a/mchf-eclipse/linker/arm-gcc-link-bootloader_f7.ld
+++ b/mchf-eclipse/linker/arm-gcc-link-bootloader_f7.ld
@@ -57,7 +57,7 @@ SECTIONS
 	/* _sidata is used in coide startup code */
 	_sidata = __etext;
 	
-	.data : AT (__etext)
+	.data :
 	{
 		__data_start__ = .;
 		
@@ -94,7 +94,7 @@ SECTIONS
 		
 		/* _edata is used in coide startup code */
 		_edata = __data_end__;
-	} > ram 
+	} > ram AT > rom
 	
 	.bss :
 	{

--- a/mchf-eclipse/linker/arm-gcc-link-bootloader_h7.ld
+++ b/mchf-eclipse/linker/arm-gcc-link-bootloader_h7.ld
@@ -59,7 +59,7 @@ SECTIONS
 	/* _sidata is used in coide startup code */
 	_sidata = __etext;
 	
-	.data : AT (__etext)
+	.data :
 	{
 		__data_start__ = .;
 		
@@ -97,7 +97,7 @@ SECTIONS
 		
 		/* _edata is used in coide startup code */
 		_edata = __data_end__;
-	} > ram 
+	} > ram AT > rom 
 	
 	.bss :
 	{

--- a/mchf-eclipse/linker/arm-gcc-link_f4_main.ld
+++ b/mchf-eclipse/linker/arm-gcc-link_f4_main.ld
@@ -58,7 +58,7 @@ SECTIONS
 	/* _sidata is used in coide startup code */
 	_sidata = __etext;
 	
-	.data : AT (__etext)
+	.data :
 	{
 		__data_start__ = .;
 		
@@ -95,7 +95,7 @@ SECTIONS
 		
 		/* _edata is used in coide startup code */
 		_edata = __data_end__;
-	} > ram 
+	} > ram AT > rom 
 	
 	.bss :
 	{

--- a/mchf-eclipse/linker/arm-gcc-link_f7.ld
+++ b/mchf-eclipse/linker/arm-gcc-link_f7.ld
@@ -55,7 +55,7 @@ SECTIONS
 	/* _sidata is used in coide startup code */
 	_sidata = __etext;
 	
-	.data : AT (__etext)
+	.data :
 	{
 		__data_start__ = .;
 		
@@ -93,7 +93,7 @@ SECTIONS
 		
 		/* _edata is used in coide startup code */
 		_edata = __data_end__;
-	} > ram 
+	} > ram AT > rom
 	
 	.bss :
 	{

--- a/mchf-eclipse/linker/arm-gcc-link_h7.ld
+++ b/mchf-eclipse/linker/arm-gcc-link_h7.ld
@@ -59,7 +59,7 @@ SECTIONS
 
 
 	
-	.data : AT (__etext)
+	.data :
 	{
 		__data_start__ = .;
 		
@@ -97,7 +97,7 @@ SECTIONS
 		
 		/* _edata is used in coide startup code */
 		_edata = __data_end__;
-	} > ram 
+	} > ram AT > rom 
 	
 	.bss :
 	{


### PR DESCRIPTION
We now correctly check for the final allocation in the available flash
The F7 bootloader lost 2k of binary size due to placing the display spi memory
in the bss (correct) and not in the data section (incorrect).
this was caused by the H7 dma allocation tag used incorrectly also for F7
Also disabled some more interrupts not used in bootloader