### PR TITLE
FreeDV receive params location change for 480x320. Fixup for initial lack of "SNR=" and "BER="

### DIFF
--- a/mchf-eclipse/drivers/audio/freedv_uhsdr.c
+++ b/mchf-eclipse/drivers/audio/freedv_uhsdr.c
@@ -215,8 +215,10 @@ static void FreeDv_DisplaySnr()
 
 void FreeDv_DisplayClear()
 {
-    UiLcdHy28_PrintText(ts.Layout->FREEDV_SNR.x, ts.Layout->FREEDV_SNR.y,"            ",Yellow,Black,ts.Layout->FREEDV_FONT);
-    UiLcdHy28_PrintText(ts.Layout->FREEDV_BER.x, ts.Layout->FREEDV_BER.y,"            ",Yellow,Black,ts.Layout->FREEDV_FONT);
+//    UiLcdHy28_PrintText(ts.Layout->FREEDV_SNR.x, ts.Layout->FREEDV_SNR.y,"            ",Yellow,Black,ts.Layout->FREEDV_FONT);
+//   UiLcdHy28_PrintText(ts.Layout->FREEDV_BER.x, ts.Layout->FREEDV_BER.y,"            ",Yellow,Black,ts.Layout->FREEDV_FONT);
+    UiLcdHy28_PrintText(ts.Layout->FREEDV_SNR.x, ts.Layout->FREEDV_SNR.y,"         ",Yellow,Black,ts.Layout->FREEDV_FONT);		//SNR=00
+    UiLcdHy28_PrintText(ts.Layout->FREEDV_BER.x, ts.Layout->FREEDV_BER.y,"         ",Yellow,Black,ts.Layout->FREEDV_FONT);		//BER=0.000	(max 9 chars)
     UiDriver_TextMsgClear();
 }
 

--- a/mchf-eclipse/drivers/audio/freedv_uhsdr.c
+++ b/mchf-eclipse/drivers/audio/freedv_uhsdr.c
@@ -224,10 +224,10 @@ void FreeDv_DisplayClear()
 
 void FreeDv_DisplayPrepare()
 {
+	UiDriver_TextMsgClear();
 	freedv_display_x_offset = UiLcdHy28_TextWidth("SNR=", ts.Layout->FREEDV_FONT);
     UiLcdHy28_PrintText(ts.Layout->FREEDV_SNR.x, ts.Layout->FREEDV_SNR.y,"SNR=",Yellow,Black, ts.Layout->FREEDV_FONT);
     UiLcdHy28_PrintText(ts.Layout->FREEDV_BER.x, ts.Layout->FREEDV_BER.y,"BER=",Yellow,Black, ts.Layout->FREEDV_FONT);
-    UiDriver_TextMsgClear();
 }
 
 void FreeDv_DisplayUpdate()

--- a/mchf-eclipse/drivers/ui/lcd/ui_lcd_layouts.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_lcd_layouts.c
@@ -339,8 +339,10 @@ const LcdLayout LcdLayouts[LcdLayoutsCount]=
 				.TextMsg_buffer_max=50,
 				.TextMsg_font=0,
 
-				.FREEDV_SNR = { 280, 28},
-				.FREEDV_BER = {380, 28},
+				//.FREEDV_SNR = { 280, 28},
+				//.FREEDV_BER = {380, 28},
+				.FREEDV_SNR = {410,288},
+				.FREEDV_BER = {410,297},
 				.FREEDV_FONT=4,
 
 				.SM_IND={.x = R480320_SM_IND_X, .y = R480320_SM_IND_Y, .h = R480320_SM_IND_H, .w = R480320_SM_IND_W},

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -249,7 +249,7 @@ PowerMeter					pwmt;
 // ------------------------------------------------
 
 uchar drv_state = 0;
-
+ui_driver_mode_t ui_driver_state;
 bool filter_path_change = false;
 
 // check if touched point is within rectangle of valid action
@@ -922,7 +922,7 @@ void UiDriver_EncoderDisplay(const uint8_t row, const uint8_t column, const char
 }
 
 
-static void UiDriver_DisplayFButton_F1MenuExit()
+void UiDriver_DisplayFButton_F1MenuExit()
 {
 	char* cap;
 	uint32_t color;
@@ -1185,14 +1185,6 @@ void UiDriver_RefreshEncoderDisplay()
  * @brief This is THE function to call after changing operational parameters such as frequency or demod mode
  * It will make sure to update the display AND also tunes to a newly selected frequency if not already tuned to it.
  */
-typedef struct
-{
-	uint8_t dmod_mode;
-	uint8_t digital_mode;
-} ui_driver_mode_t;
-
-ui_driver_mode_t ui_driver_state;
-
 bool UiDriver_IsDemodModeChange()
 {
 	bool retval = (ts.dmod_mode != ui_driver_state.dmod_mode);

--- a/mchf-eclipse/drivers/ui/ui_driver.h
+++ b/mchf-eclipse/drivers/ui/ui_driver.h
@@ -169,6 +169,11 @@ typedef enum
     SPECTRUM_DUAL = 3
 } SpectrumMode_t;
 
+typedef struct
+{
+	uint8_t dmod_mode;
+	uint8_t digital_mode;
+} ui_driver_mode_t;
 //
 // --------------------------------------------------------------------------
 // Exports
@@ -208,7 +213,7 @@ void UiDriver_TextMsgPutChar(char ch);
 void UiDriver_TextMsgPutSign(const char *s);
 void UiDriver_TextMsgDisplay();
 void UiDriver_TextMsgClear();
-
+void UiDriver_DisplayFButton_F1MenuExit();
 
 void UiDriver_SetSpectrumMode(SpectrumMode_t mode);
 SpectrumMode_t UiDriver_GetSpectrumMode();

--- a/mchf-eclipse/drivers/ui/ui_vkeybrd.c
+++ b/mchf-eclipse/drivers/ui/ui_vkeybrd.c
@@ -779,30 +779,40 @@ static void UiVk_ModSelVKeyCallBackShort(uint8_t KeyNum, uint32_t param)
 static void UiVk_ModSelVKeyToggleCW(uint8_t KeyNum, uint32_t param)
 {
 	ts.demod_mode_disable^=DEMOD_CW_DISABLE;
+	ts.menu_var_changed = true;
+	UiDriver_DisplayFButton_F1MenuExit();
 	UiVk_DrawVKeypad();
 }
 
 static void UiVk_ModSelVKeyToggleAM(uint8_t KeyNum, uint32_t param)
 {
 	ts.demod_mode_disable^=DEMOD_AM_DISABLE;
+	ts.menu_var_changed = true;
+	UiDriver_DisplayFButton_F1MenuExit();
 	UiVk_DrawVKeypad();
 }
 
 static void UiVk_ModSelVKeyToggleDIGI(uint8_t KeyNum, uint32_t param)
 {
 	ts.demod_mode_disable^=DEMOD_DIGI_DISABLE;
+	ts.menu_var_changed = true;
+	UiDriver_DisplayFButton_F1MenuExit();
 	UiVk_DrawVKeypad();
 }
 
 static void UiVk_ModSelVKeyToggleSAM(uint8_t KeyNum, uint32_t param)
 {
 	ts.flags1^=FLAGS1_SAM_ENABLE;
+	ts.menu_var_changed = true;
+	UiDriver_DisplayFButton_F1MenuExit();
 	UiVk_DrawVKeypad();
 }
 
 static void UiVk_ModSelVKeyToggleFM(uint8_t KeyNum, uint32_t param)
 {
 	ts.flags2^=FLAGS2_FM_MODE_ENABLE;
+	ts.menu_var_changed = true;
+	UiDriver_DisplayFButton_F1MenuExit();
 	UiVk_DrawVKeypad();
 }
 


### PR DESCRIPTION
This is strange but I can't describe the reason why it not worked and now works (SNR/BER text). Just moved the UiDriver_TextMsgClear(); to first line of FreeDv_DisplayPrepare and now it works. Text buffer length is OK, I can't find any bug there...