### PR TITLE
Convolution Filter prototype #1

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_convolution.c
+++ b/mchf-eclipse/drivers/audio/audio_convolution.c
@@ -272,11 +272,11 @@ void AudioDriver_RxProcessorConvolution(AudioSample_t * const src, AudioSample_t
  *  DANILO :-)
  ********************************************************************************************************************/
         	//		2. collect samples until we have 128 samples to deal within the convolution
-            // put those samples into a new buffer adb.i_buffer_convolution and adb.q_buffer_convolution
+            // put those samples into a new buffer cob.i_buffer_convolution and cob.q_buffer_convolution
 
             // when 128 samples are ready, continue HERE:
-            // BTW, please use adb.size instead of hard coded 128, because that could change.
-            // TODO: I will set adb.size in the function AudioDriver_SetRxAudioProcessing
+            // BTW, please use cbs.size instead of hard coded 128, because that could change.
+            // TODO: I will set cbs.size in the function AudioDriver_SetRxAudioProcessing
 
 /****************************************************************
  *
@@ -289,11 +289,11 @@ void AudioDriver_RxProcessorConvolution(AudioSample_t * const src, AudioSample_t
  ****************************************************************/
 
 
-            // input file: adb.i_buffer_convolution
+            // input file: cob.i_buffer_convolution
             // IIIIIIIIIIIIIIII
             // <- cbs.size   ->
             //
-            // input file: adb.q_buffer_convolution
+            // input file: cob.q_buffer_convolution
             // QQQQQQQQQQQQQQQQ
             // <- cbs.size   ->
             //
@@ -702,7 +702,7 @@ void AudioDriver_RxProcessorConvolution(AudioSample_t * const src, AudioSample_t
 
     // interpolation
 
-// TODO: at this point we have 128 real audio samples filtered and AGC´ed in the variable cob.i_buffer_convolution (for mono modes)
+// TODO: at this point we have 128 real audio samples filtered and AGC´ed in the variable 	 (for mono modes)
     // for stereo modes (not yet implemented), the other channel is in cob.q_buffer_convolution
 
     // now we have to make blocks of 32 samples out of that for further processing

--- a/mchf-eclipse/drivers/audio/audio_convolution.h
+++ b/mchf-eclipse/drivers/audio/audio_convolution.h
@@ -59,11 +59,12 @@ typedef struct
     int						buffidx; // buffer pointer
     float32_t				impulse[CONVOLUTION_MAX_NO_OF_COEFFS * 2]; // impulse response has real and imaginary components
     float32_t				maskgen[FFT_CONVOLUTION_SIZE * 2];
-} ConvolutionBuffersshared;
+} ConvolutionBuffersShared;
 
-extern ConvolutionBuffersshared cbs;
+extern ConvolutionBuffersShared cbs;
 
 void AudioDriver_CalcConvolutionFilterCoeffs (int N, float32_t f_low, float32_t f_high, float32_t samplerate, int wintype, int rtype, float32_t scale);
+void AudioDriver_RxProcessorConvolution(AudioSample_t * const src, AudioSample_t * const dst, const uint16_t blockSize);
 
 #endif
 

--- a/mchf-eclipse/drivers/audio/audio_driver.h
+++ b/mchf-eclipse/drivers/audio/audio_driver.h
@@ -20,7 +20,7 @@
 #include "softdds.h"
 #include "uhsdr_hw_i2s.h"
 #include "uhsdr_board.h"
-#include "audio_convolution.h"
+//#include "audio_convolution.h"
 
 // 16 or 24 bits from Codec
 // 24 bits are not supported anywhere in the recent code!
@@ -631,7 +631,6 @@ void AudioDriver_I2SCallback(int16_t *src, int16_t *dst, int16_t *audioDst, int1
 extern AudioDriverState	ads;
 extern __IO SMeter       sm;
 
-//extern ConvolutionBuffersshared cbs;
 extern AudioDriverBuffer adb;
 
 typedef struct SnapCarrier

--- a/mchf-eclipse/hardware/uhsdr_board.h
+++ b/mchf-eclipse/hardware/uhsdr_board.h
@@ -35,7 +35,7 @@
 
 // Fast convolution filtering
 // experimental at the moment DD4WH, 2018_08_18
-#define USE_CONVOLUTION
+//#define USE_CONVOLUTION
 
 // old LMS noise reduction
 // will probably never used any more


### PR DESCRIPTION
Preparations for a barebone Convolution filter finished, except for decimation and interpolation and the collection of cbs.size samples in the AudioDriver_RxProcessorConvolution.

* 32 samples each of I & Q enter the function AudioDriver_RxProcessorConvolution
* in line 271, 32 samples each are in adb.i_buffer and adb.q_buffer
* they need to be collected in cob.i_buffer_convolution and cob.q_buffer_convolution until we have cbs.size samples each (for the first version cbs.size == 128, could change, but not first priority)
* then the Convolution filter can start to work until line 705
* there we have 128 samples of real audio in cob.i_buffer_convolution (for stereo modes the other channel will be in cob.q_buffer_convolution)
* these have to be given to the subsequent processing (beginning in line 714) in blocks of 32 samples in each channel

Danilo, could you please give me a hint on how to achieve this sample collection/release 32 vs 128 vs 32?


