### PR TITLE
Convolution: preparations for sample collection and release

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_convolution.h
+++ b/mchf-eclipse/drivers/audio/audio_convolution.h
@@ -23,6 +23,11 @@
 #include "radio_management.h"
 #include "usbd_audio_if.h"
 
+
+#define SAMPLE_BUFFER_SIZE 				256
+#define SAMPLE_BUFFER_NUM 				4
+#define SAMPLE_BUFFER_FIFO_SIZE 		(SAMPLE_BUFFER_NUM + 1)
+
 extern arm_fir_decimate_instance_f32   DECIMATE_RX_I;
 extern arm_fir_decimate_instance_f32   DECIMATE_RX_Q;
 //extern AudioDriverBuffer adb;
@@ -57,6 +62,7 @@ typedef struct
     int 					size; // no. of input samples
     int						nfor; // no. of blocks in the convolution
     int						buffidx; // buffer pointer
+    int						DF; // decimation factor
     float32_t				impulse[CONVOLUTION_MAX_NO_OF_COEFFS * 2]; // impulse response has real and imaginary components
     float32_t				maskgen[FFT_CONVOLUTION_SIZE * 2];
 } ConvolutionBuffersShared;
@@ -65,6 +71,7 @@ extern ConvolutionBuffersShared cbs;
 
 void AudioDriver_CalcConvolutionFilterCoeffs (int N, float32_t f_low, float32_t f_high, float32_t samplerate, int wintype, int rtype, float32_t scale);
 void AudioDriver_RxProcessorConvolution(AudioSample_t * const src, AudioSample_t * const dst, const uint16_t blockSize);
+void convolution_handle(void);
 
 #endif
 

--- a/mchf-eclipse/drivers/audio/audio_driver.h
+++ b/mchf-eclipse/drivers/audio/audio_driver.h
@@ -26,7 +26,6 @@
 // 24 bits are not supported anywhere in the recent code!
 //#define USE_24_BITS
 
-
 #define IQ_SAMPLE_RATE (48000)
 #define IQ_SAMPLE_RATE_F ((float32_t)IQ_SAMPLE_RATE)
 //const float32_t IQ_SAMPLE_RATE_F = ((float32_t)IQ_SAMPLE_RATE);
@@ -37,6 +36,11 @@ typedef struct {
     __packed int16_t r;
 } AudioSample_t;
 
+#ifdef USE_CONVOLUTION
+typedef struct {
+   COMP samples[SAMPLE_BUFFER_SIZE];
+}  Sample_Buffer;
+#endif
 
 // -----------------------------
 // FFT buffer, this is double the size of the length of the FFT used for spectrum display and waterfall spectrum

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -59,6 +59,8 @@
 #include "cw_decoder.h"
 #include "psk.h"
 
+#include "audio_convolution.h"
+
 #define SPLIT_ACTIVE_COLOUR         		Yellow      // colour of "SPLIT" indicator when active
 #define SPLIT_INACTIVE_COLOUR           	Grey        // colour of "SPLIT" indicator when NOT active
 #define COL_PWR_IND                 		White
@@ -6777,6 +6779,11 @@ void UiDriver_TaskHandler_HighPrioTasks()
         alternateNR_handle();
     }
 #endif
+
+#ifdef USE_CONVOLUTION
+    	convolution_handle();
+#endif
+
 }
 
 void UiDriver_TaskHandler_MainTasks()


### PR DESCRIPTION
Routine for sample collection and release from the NR has been copied and modified. However, we need a routine to collect complex samples (128 * I and 128 * Q) instead of 128 real samples.
And we cannot use the FreeDV buffer, because we need filtering AND FreeDV buffers simultaneously.
Preparations are in a preliminary stage, where questions about using pointers and copy-functions remain.
NOT functional at the moment.