### PR TITLE
Refactored BL version detection, RAM size reporting  and RTC Init on H7.

### DIFF
--- a/mchf-eclipse/basesw/ovi40-h7/Src/rtc.c
+++ b/mchf-eclipse/basesw/ovi40-h7/Src/rtc.c
@@ -78,66 +78,68 @@ void MX_RTC_Init(void)
     _Error_Handler(__FILE__, __LINE__);
   }
   /* USER CODE BEGIN RTC_Init 2 */
-
-  /* USER CODE END RTC_Init 2 */
-
-    /**Initialize RTC and set the Time and Date 
-    */
-  sTime.Hours = 0x0;
-  sTime.Minutes = 0x0;
-  sTime.Seconds = 0x0;
-  sTime.DayLightSaving = RTC_DAYLIGHTSAVING_NONE;
-  sTime.StoreOperation = RTC_STOREOPERATION_RESET;
-  if (HAL_RTC_SetTime(&hrtc, &sTime, RTC_FORMAT_BCD) != HAL_OK)
+  if(HAL_RTCEx_BKUPRead(&hrtc, RTC_BKP_DR0) != 0x32F2)
   {
-    _Error_Handler(__FILE__, __LINE__);
+      /* USER CODE END RTC_Init 2 */
+
+      /**Initialize RTC and set the Time and Date
+       */
+      sTime.Hours = 0x0;
+      sTime.Minutes = 0x0;
+      sTime.Seconds = 0x0;
+      sTime.DayLightSaving = RTC_DAYLIGHTSAVING_NONE;
+      sTime.StoreOperation = RTC_STOREOPERATION_RESET;
+      if (HAL_RTC_SetTime(&hrtc, &sTime, RTC_FORMAT_BCD) != HAL_OK)
+      {
+          _Error_Handler(__FILE__, __LINE__);
+      }
+      /* USER CODE BEGIN RTC_Init 3 */
+
+      /* USER CODE END RTC_Init 3 */
+
+      sDate.WeekDay = RTC_WEEKDAY_MONDAY;
+      sDate.Month = RTC_MONTH_JANUARY;
+      sDate.Date = 0x1;
+      sDate.Year = 0x0;
+
+      if (HAL_RTC_SetDate(&hrtc, &sDate, RTC_FORMAT_BCD) != HAL_OK)
+      {
+          _Error_Handler(__FILE__, __LINE__);
+      }
+      /* USER CODE BEGIN RTC_Init 4 */
+
+      /* USER CODE END RTC_Init 4 */
+
+      /**Enable the Alarm A
+       */
+      sAlarm.AlarmTime.Hours = 0x0;
+      sAlarm.AlarmTime.Minutes = 0x0;
+      sAlarm.AlarmTime.Seconds = 0x0;
+      sAlarm.AlarmTime.SubSeconds = 0x0;
+      sAlarm.AlarmTime.DayLightSaving = RTC_DAYLIGHTSAVING_NONE;
+      sAlarm.AlarmTime.StoreOperation = RTC_STOREOPERATION_RESET;
+      sAlarm.AlarmMask = RTC_ALARMMASK_NONE;
+      sAlarm.AlarmSubSecondMask = RTC_ALARMSUBSECONDMASK_ALL;
+      sAlarm.AlarmDateWeekDaySel = RTC_ALARMDATEWEEKDAYSEL_DATE;
+      sAlarm.AlarmDateWeekDay = 0x1;
+      sAlarm.Alarm = RTC_ALARM_A;
+      if (HAL_RTC_SetAlarm(&hrtc, &sAlarm, RTC_FORMAT_BCD) != HAL_OK)
+      {
+          _Error_Handler(__FILE__, __LINE__);
+      }
+      /* USER CODE BEGIN RTC_Init 5 */
+
+      /* USER CODE END RTC_Init 5 */
+
+      /**Enable the WakeUp
+       */
+      if (HAL_RTCEx_SetWakeUpTimer(&hrtc, 0, RTC_WAKEUPCLOCK_RTCCLK_DIV16) != HAL_OK)
+      {
+          _Error_Handler(__FILE__, __LINE__);
+      }
+      /* USER CODE BEGIN RTC_Init 6 */
+      HAL_RTCEx_BKUPWrite(&hrtc,RTC_BKP_DR0,0x32F2);
   }
-  /* USER CODE BEGIN RTC_Init 3 */
-
-  /* USER CODE END RTC_Init 3 */
-
-  sDate.WeekDay = RTC_WEEKDAY_MONDAY;
-  sDate.Month = RTC_MONTH_JANUARY;
-  sDate.Date = 0x1;
-  sDate.Year = 0x0;
-
-  if (HAL_RTC_SetDate(&hrtc, &sDate, RTC_FORMAT_BCD) != HAL_OK)
-  {
-    _Error_Handler(__FILE__, __LINE__);
-  }
-  /* USER CODE BEGIN RTC_Init 4 */
-
-  /* USER CODE END RTC_Init 4 */
-
-    /**Enable the Alarm A 
-    */
-  sAlarm.AlarmTime.Hours = 0x0;
-  sAlarm.AlarmTime.Minutes = 0x0;
-  sAlarm.AlarmTime.Seconds = 0x0;
-  sAlarm.AlarmTime.SubSeconds = 0x0;
-  sAlarm.AlarmTime.DayLightSaving = RTC_DAYLIGHTSAVING_NONE;
-  sAlarm.AlarmTime.StoreOperation = RTC_STOREOPERATION_RESET;
-  sAlarm.AlarmMask = RTC_ALARMMASK_NONE;
-  sAlarm.AlarmSubSecondMask = RTC_ALARMSUBSECONDMASK_ALL;
-  sAlarm.AlarmDateWeekDaySel = RTC_ALARMDATEWEEKDAYSEL_DATE;
-  sAlarm.AlarmDateWeekDay = 0x1;
-  sAlarm.Alarm = RTC_ALARM_A;
-  if (HAL_RTC_SetAlarm(&hrtc, &sAlarm, RTC_FORMAT_BCD) != HAL_OK)
-  {
-    _Error_Handler(__FILE__, __LINE__);
-  }
-  /* USER CODE BEGIN RTC_Init 5 */
-
-  /* USER CODE END RTC_Init 5 */
-
-    /**Enable the WakeUp 
-    */
-  if (HAL_RTCEx_SetWakeUpTimer(&hrtc, 0, RTC_WAKEUPCLOCK_RTCCLK_DIV16) != HAL_OK)
-  {
-    _Error_Handler(__FILE__, __LINE__);
-  }
-  /* USER CODE BEGIN RTC_Init 6 */
-
   /* USER CODE END RTC_Init 6 */
 
 }

--- a/mchf-eclipse/drivers/ui/menu/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu.c
@@ -608,33 +608,34 @@ const char* UiMenu_GetSystemInfo(uint32_t* m_clr_ptr, int info_item)
     break;
     case INFO_BL_VERSION:
     {
-        const uint8_t* begin = (uint8_t*)0x8000000;
         outs = "Unknown BL";
 
         // We search for string "Version: " in bootloader memory
-        for(int i=0; i < 32768-8; i++)
+        // this assume the bootloader starting at 0x8000000 and being followed by the virtual eeprom
+        // which starts at EEPROM_START_ADDRESS
+        for(uint8_t* begin = (uint8_t*)0x8000000; begin < (uint8_t*)EEPROM_START_ADDRESS-8; begin++)
         {
-            if( begin[i] == 'V' && begin[i+1] == 'e' && begin[i+2] == 'r'
-                    && begin[i+3] == 's' && begin[i+4] == 'i' && begin[i+5] == 'o'
-                    && begin[i+6] == 'n' && begin[i+7] == ':' && begin[i+8] == ' ')
+            if (memcmp("Version: ",begin,9) == 0)
             {
-                snprintf(out,32, "%s", &begin[i+9]);
+                snprintf(out,32, "%s", &begin[9]);
                 outs = out;
                 break;
             }
-            else if (begin[i] == 'M' && begin[i+1] == '0' && begin[i+2] == 'N'
-                    && begin[i+3] == 'K' && begin[i+4] == 'A' && begin[i+5] == ' '
-                    && begin[i+6] == '2' && begin[i+11] == 0xb5)
+            else
             {
-                outs = "M0NKA 0.0.0.9";
-                break;
-            }
-            else if (begin[i] == 'M' && begin[i+1] == '0' && begin[i+2] == 'N'
-                    && begin[i+3] == 'K' && begin[i+4] == 'A' && begin[i+5] == ' '
-                    && begin[i+6] == '2' && begin[i+11] == 0xd1)
-            {
-                outs = "M0NKA 0.0.0.14";
-                break;
+                if (memcmp("M0NKA 2",begin,7) == 0)
+                {
+                    if (begin[11] == 0xb5)
+                    {
+                        outs = "M0NKA 0.0.0.9";
+                        break;
+                    }
+                    else if (begin[11] == 0xd1)
+                    {
+                        outs = "M0NKA 0.0.0.14";
+                        break;
+                    }
+                }
             }
         }
     }

--- a/mchf-eclipse/hardware/uhsdr_board.c
+++ b/mchf-eclipse/hardware/uhsdr_board.c
@@ -521,6 +521,7 @@ unsigned int Board_RamSizeGet() {
     // instead of hard faults
     // this will run our very special bus fault handler in case no memory
     // is at the defined location
+#if defined(STM32F4) || defined(STM32F7)
     SCB->SHCSR |= SCB_SHCSR_BUSFAULTENA_Msk;
     if (is_ram_at((volatile uint32_t*)TEST_ADDR_512)){
         retval=512;
@@ -532,7 +533,13 @@ unsigned int Board_RamSizeGet() {
     // now we disable it
     // we'll get hard faults as usual if we access wrong addresses
     SCB->SHCSR &= ~SCB_SHCSR_BUSFAULTENA_Msk;
-
+#elif defined(STM32H7)
+    //  TODO make it detect the really available RAM
+    retval = 512;
+#else
+    #warning Unkown processor, cannot determine ramsize
+    retval = 0;
+#endif
     return retval;
 }
 


### PR DESCRIPTION
BL version detection should now work on all platforms, as well as the
RTC is now only initialized once on H7, and the RAM is reported for H7 as fixed
size 512k (which is what we use).