### PR TITLE
Towards flexible translate frequency

### DIFF
--- a/mchf-eclipse/drivers/cat/cat_driver.c
+++ b/mchf-eclipse/drivers/cat/cat_driver.c
@@ -1035,7 +1035,7 @@ static void CatDriver_HandleCommands()
 
             if(ts.xlat == 0)
             {
-                fdelta = (ts.tx_audio_source == TX_AUDIO_DIGIQ)?AudioDriver_GetTranslateFreq()*4:0;
+                fdelta = (ts.tx_audio_source == TX_AUDIO_DIGIQ)?AudioDriver_GetTranslateFreq()*TUNE_MULT:0;
                 // If we are in DIGITAL IQ Output mode, use real tune frequency frequency instead
                 // translated RX frequency
             }

--- a/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
@@ -2110,22 +2110,7 @@ static void UiSpectrum_CalculateDBm()
 
             if(sd.magnify == 0)
             {
-                if(ts.iq_freq_mode == FREQ_IQ_CONV_P6KHZ)       // we are in RF LO HIGH mode (tuning is below center of screen)
-                {
-                    bin_offset = - (buff_len_int / 16);
-                }
-                else if(ts.iq_freq_mode == FREQ_IQ_CONV_M6KHZ)      // we are in RF LO LOW mode (tuning is above center of screen)
-                {
-                    bin_offset = (buff_len_int / 16);
-                }
-                else if(ts.iq_freq_mode == FREQ_IQ_CONV_P12KHZ)     // we are in RF LO HIGH mode (tuning is below center of screen)
-                {
-                    bin_offset =  - (buff_len_int / 8);
-                }
-                else if(ts.iq_freq_mode == FREQ_IQ_CONV_M12KHZ)     // we are in RF LO LOW mode (tuning is above center of screen)
-                {
-                    bin_offset =  (buff_len_int / 8);
-                }
+                bin_offset = - (buff_len_int * AudioDriver_GetTranslateFreq( )) / (2 * IQ_SAMPLE_RATE);
             }
 
             int posbin = buff_len_int / 4 + bin_offset;  // right in the middle!

--- a/mchf-eclipse/drivers/ui/menu/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu.c
@@ -1470,7 +1470,7 @@ void UiMenu_UpdateItem(uint16_t select, uint16_t mode, int pos, int var, char* o
 		{
 		  firstmode = FREQ_IQ_CONV_P6KHZ;
 		}
-        var_change = UiDriverMenuItemChangeUInt8(var, mode, &ts.iq_freq_mode,
+        var_change = UiDriverMenuItemChangeInt32(var, mode, &ts.iq_freq_mode,
                                               firstmode,
                                               FREQ_IQ_CONV_MODE_MAX,
                                               FREQ_IQ_CONV_MODE_DEFAULT,

--- a/mchf-eclipse/drivers/ui/ui_configuration.c
+++ b/mchf-eclipse/drivers/ui/ui_configuration.c
@@ -147,7 +147,7 @@ const ConfigEntryDescriptor ConfigEntryInfo[] =
     { ConfigEntry_UInt16, EEPROM_VERSION_BUILD,&ts.version_number_major,0,0,255},
 //    { ConfigEntry_UInt8, EEPROM_NB_AGC_TIME_CONST,&ts.nb_agc_time_const,NB_AGC_DEFAULT,0,NB_MAX_AGC_SETTING},
     { ConfigEntry_UInt8, EEPROM_CW_OFFSET_MODE,&ts.cw_offset_mode,CW_OFFSET_MODE_DEFAULT,0,CW_OFFSET_NUM-1},
-    { ConfigEntry_UInt8, EEPROM_FREQ_CONV_MODE,&ts.iq_freq_mode,FREQ_IQ_CONV_MODE_DEFAULT,0,FREQ_IQ_CONV_MODE_MAX},
+    { ConfigEntry_Int32_16, EEPROM_FREQ_CONV_MODE,&ts.iq_freq_mode,FREQ_IQ_CONV_MODE_DEFAULT,0,FREQ_IQ_CONV_MODE_MAX},
     { ConfigEntry_UInt8, EEPROM_LSB_USB_AUTO_SELECT,&ts.lsb_usb_auto_select,AUTO_LSB_USB_DEFAULT,0,AUTO_LSB_USB_MAX},
     { ConfigEntry_UInt8, EEPROM_LCD_BLANKING_CONFIG,&ts.lcd_backlight_blanking,0,0,255},
     { ConfigEntry_UInt32_16, EEPROM_VFO_MEM_MODE,&ts.vfo_mem_mode,0,0,255},

--- a/mchf-eclipse/hardware/uhsdr_board.h
+++ b/mchf-eclipse/hardware/uhsdr_board.h
@@ -893,7 +893,7 @@ typedef struct TransceiverState
     uint8_t	nb_agc_time_const;			// used to calculate the AGC time constant
     uint8_t	cw_offset_mode;				// CW offset mode (USB, LSB, etc.)
     bool	cw_lsb;					// flag used to indicate that CW is to operate in LSB when TRUE
-    uint8_t	iq_freq_mode;				// used to set/configure the I/Q frequency/conversion mode
+    int32_t	iq_freq_mode;				// used to set/configure the I/Q frequency/conversion mode
     uint8_t	lsb_usb_auto_select;			// holds setting of LSB/USB auto-select above/below 10 MHz
     bool	conv_sine_flag;				// FALSE until the sine tables for the frequency conversion have been built (normally zero, force 0 to rebuild)
     ulong	last_tuning;				// this is a timer used to prevent too fast tuning per second
@@ -948,7 +948,6 @@ typedef struct TransceiverState
     mchf_touchscreen_t *tp;
 
     bool	show_debug_info;	// show coordinates on LCD
-    uint8_t	multi;					// actual translate factor
     uint8_t	tune_power_level;		// TX power in antenna tuning function
     uint8_t	power_temp;				// temporary tx power if tune is different from actual tx power
     uint8_t	cat_band_index;			// buffered bandindex before first CAT command arrived

--- a/mchf-eclipse/src/uhsdr_main.c
+++ b/mchf-eclipse/src/uhsdr_main.c
@@ -305,7 +305,6 @@ void TransceiverStateInit(void)
     ts.display = &mchf_display;
 
     ts.show_debug_info = false;					// dont show coordinates on LCD
-    ts.multi = 0;							// non-translate
     ts.tune_power_level = 0;					// Tune with FULL POWER
     ts.xlat = 0;							// 0 = report base frequency, 1 = report xlat-frequency;
     ts.audio_int_counter = 0;					// test DL2FW


### PR DESCRIPTION
Removed all direct references to the non-zero frequency translation mode,
replace with use of actual translation frequency.
This change alone does not permit free selection of translation frequency in the full
possible range (+/-24khz) since we have in some places code assume the translation frequency
being a in a power of 2 relationship with the sample frequency of 48000 khz.
But it makes it much easier. I think due to missing performance we should
not enabled free choice of translation frequency on the STM32F4 (here 12khz is
best for performance) but the F7 and H7 should have enough horsepower to
use arbitrary translation frequency in the baseband.

This change should not cause a noticable difference. If it does,
it is unintended and can be fixed.