### PR TITLE
Fix for #1174 and #1603: CAT PTT via RTS not returning to RX

### DIFF
--- a/mchf-eclipse/drivers/cat/cat_driver.c
+++ b/mchf-eclipse/drivers/cat/cat_driver.c
@@ -53,8 +53,8 @@ static void CatDriver_CatEnableTX(bool enable)
     }
     else
     {
-        ts.ptt_req = false;
         cat_driver.cat_ptt_active = false;
+        ts.tx_stop_req = true;
     }
 }
 


### PR DESCRIPTION
This fix will make Virtual RTS return to RX after RTS has been
cleared by the CAT program on PC side.
So  it was not a fault of TR4W in the end but a mistake on our side.
Wonder why it worked in UCXlog.
Please note: This has not been tested yet but should work. In any case it
cannot make it worse...