### PR TITLE
Low Latency RX TX Switching

### DIFF
--- a/mchf-eclipse/drivers/audio/codec/codec.c
+++ b/mchf-eclipse/drivers/audio/codec/codec.c
@@ -543,3 +543,14 @@ void Codec_IQInGainAdj(uchar gain)
     Codec_InGainAdj(CODEC_IQ_I2C, gain);
 }
 
+/**
+ * @brief Checks if all codec resources are available for switching
+ * It basically checks if the I2C is currently in use
+ * This function must be called before changing the oscillator in interrupts
+ * otherwise deadlocks may happen
+ * @return true if it is safe to call codec functions in an interrupt
+ */
+bool Codec_ReadyForIrqCall()
+{
+    return (CODEC_ANA_I2C->Lock == HAL_UNLOCKED) && (CODEC_IQ_I2C->Lock == HAL_UNLOCKED);
+}

--- a/mchf-eclipse/drivers/audio/codec/codec.h
+++ b/mchf-eclipse/drivers/audio/codec/codec.h
@@ -46,4 +46,5 @@ void     Codec_TxSidetoneSetgain(uint8_t mode);
 void     Codec_SwitchMicTxRxMode(uint8_t mode);
 void     Codec_PrepareTx(uint8_t current_txrx_mode);
 
+bool     Codec_ReadyForIrqCall();
 #endif

--- a/mchf-eclipse/drivers/ui/oscillator/osc_interface.c
+++ b/mchf-eclipse/drivers/ui/oscillator/osc_interface.c
@@ -46,6 +46,16 @@ static bool              OscDummy_IsNextStepLarge()
 {
 	return false;
 }
+/**
+ * @brief Checks if all oscillator resources are available for switching frequency
+ * This function must be called before changing the oscillator in interrupts
+ * otherwise deadlocks may happen
+ * @return true if it is safe to call oscillator functions in an interrupt
+ */
+static bool              OscDummy_ReadyForIrqCall()
+{
+    return true;
+}
 
 
 const OscillatorInterface_t osc_dummy =
@@ -55,7 +65,8 @@ const OscillatorInterface_t osc_dummy =
 		.setPPM = OscDummy_SetPPM,
 		.prepareNextFrequency = OscDummy_PrepareNextFrequency,
 		.changeToNextFrequency = OscDummy_ChangeToNextFrequency,
-		.isNextStepLarge = OscDummy_IsNextStepLarge
+		.isNextStepLarge = OscDummy_IsNextStepLarge,
+		.readyForIrqCall = OscDummy_ReadyForIrqCall,
 };
 
 static void OscDummy_Init()

--- a/mchf-eclipse/drivers/ui/oscillator/osc_interface.h
+++ b/mchf-eclipse/drivers/ui/oscillator/osc_interface.h
@@ -44,7 +44,7 @@ typedef struct
 	Oscillator_ResultCodes_t (*prepareNextFrequency)(ulong freq, int temp_factor);
 	Oscillator_ResultCodes_t (*changeToNextFrequency)();
 	bool 			  (*isNextStepLarge)();
-
+	bool              (*readyForIrqCall)();
 } OscillatorInterface_t;
 
 extern const OscillatorInterface_t *osc;

--- a/mchf-eclipse/drivers/ui/oscillator/osc_si5351a.c
+++ b/mchf-eclipse/drivers/ui/oscillator/osc_si5351a.c
@@ -397,6 +397,18 @@ static bool              Si5351a_IsNextStepLarge()
 	return false;
 }
 
+/**
+ * @brief Checks if all oscillator resources are available for switching frequency
+ * It basically checks if the I2C is currently in use
+ * This function must be called before changing the oscillator in interrupts
+ * otherwise deadlocks may happen
+ * @return true if it is safe to call oscillator functions in an interrupt
+ */
+bool Si5351a_ReadyForIrqCall()
+{
+    return (SI5351A_I2C->Lock == HAL_UNLOCKED);
+}
+
 const OscillatorInterface_t osc_si5351a =
 {
 		.init = Si5351a_Init,
@@ -404,7 +416,8 @@ const OscillatorInterface_t osc_si5351a =
 		.setPPM = Si5351a_SetPPM,
 		.prepareNextFrequency = Si5351a_PrepareNextFrequency,
 		.changeToNextFrequency = Si5351a_ChangeToNextFrequency,
-		.isNextStepLarge = Si5351a_IsNextStepLarge
+		.isNextStepLarge = Si5351a_IsNextStepLarge,
+		.readyForIrqCall = Si5351a_ReadyForIrqCall,
 };
 
 void Si5351a_Init()

--- a/mchf-eclipse/drivers/ui/oscillator/osc_si570.c
+++ b/mchf-eclipse/drivers/ui/oscillator/osc_si570.c
@@ -593,6 +593,18 @@ uint8_t Si570_ResetConfiguration()
 
 static Oscillator_ResultCodes_t Si570_PrepareNextFrequency(ulong freq, int temp_factor);
 
+/**
+ * @brief Checks if all oscillator resources are available for switching frequency
+ * It basically checks if the I2C is currently in use
+ * This function must be called before changing the oscillator in interrupts
+ * otherwise deadlocks may happen
+ * @return true if it safe to call oscillator functions in an interrupt
+ */
+bool Si570_ReadyForIrqCall()
+{
+    return (SI570_I2C->Lock == HAL_UNLOCKED);
+}
+
 const OscillatorInterface_t osc_si570 =
 {
 		.init = Si570_Init,
@@ -600,8 +612,10 @@ const OscillatorInterface_t osc_si570 =
 		.setPPM = Si570_SetPPM,
 		.prepareNextFrequency = Si570_PrepareNextFrequency,
 		.changeToNextFrequency = Si570_ChangeToNextFrequency,
-		.isNextStepLarge = Si570_IsNextStepLarge
+		.isNextStepLarge = Si570_IsNextStepLarge,
+		.readyForIrqCall = Si570_ReadyForIrqCall,
 };
+
 
 void Si570_Init()
 {

--- a/mchf-eclipse/drivers/ui/radio_management.h
+++ b/mchf-eclipse/drivers/ui/radio_management.h
@@ -252,6 +252,8 @@ int32_t  RadioManagement_GetCWDialOffset();
 void RadioManagement_Request_TxOn();
 void RadioManagement_Request_TxOff();
 
+bool RadioManagement_SwitchTxRx_Possible();
+
 inline void RadioManagement_ToggleVfoMem()
 {
     ts.vfo_mem_flag = ! ts.vfo_mem_flag;
@@ -267,5 +269,19 @@ inline bool is_demod_psk()
 	return ts.dmod_mode == DEMOD_DIGI && ts.digital_mode == DigitalMode_BPSK;
 }
 
+inline void RadioManagement_TxRxSwitching_Disable()
+{
+    ts.txrx_switching_enabled = false;
+}
+
+inline void RadioManagement_TxRxSwitching_Enable()
+{
+    ts.txrx_switching_enabled = true;
+}
+
+inline bool RadioManagement_TxRxSwitching_IsEnabled()
+{
+    return ts.txrx_switching_enabled;
+}
 
 #endif /* DRIVERS_UI_RADIO_MANAGEMENT_H_ */

--- a/mchf-eclipse/hardware/uhsdr_board.h
+++ b/mchf-eclipse/hardware/uhsdr_board.h
@@ -131,6 +131,15 @@
 // of course.
 #define USE_PENDSV_FOR_HIGHPRIO_TASKS
 
+// OPTION: Enable handling of TX/RX switching in an interrupt. Provides very low latency switching
+// EXPERIMENTAL !!!
+#define USE_HIGH_PRIO_PTT
+
+#if !defined(USE_PENDSV_FOR_HIGHPRIO_TASKS) && defined(USE_HIGH_PRIO_PTT)
+#error USE_HIGH_PRIO_PTT requires USE_PENDSV_FOR_HIGHPRIO_TASKS
+#endif
+
+
 #include "uhsdr_mcu.h"
 // HW libs
 #ifdef STM32F7
@@ -841,6 +850,7 @@ typedef struct TransceiverState
 #define TX_DISABLE_ALWAYS       1
 #define TX_DISABLE_USER         2
 #define TX_DISABLE_OUTOFRANGE	4
+#define TX_DISABLE_RXMODE       8
     uint8_t	tx_disable;		// >0 if no transmit permitted, use RadioManagement_IsTxDisabled() to get boolean
 
 
@@ -1076,6 +1086,7 @@ typedef struct TransceiverState
 	RfBoard_t rf_board; // the detected rf board connected to the control logic
 	bool si570_is_present;
 	uint8_t special_functions_enabled;
+	bool txrx_switching_enabled;
 } TransceiverState;
 //
 extern __IO TransceiverState ts;

--- a/mchf-eclipse/src/uhsdr_main.c
+++ b/mchf-eclipse/src/uhsdr_main.c
@@ -68,8 +68,8 @@ void HAL_GPIO_EXTI_Callback (uint16_t GPIO_Pin)
         break;
     case PADDLE_DAH:
         // Call handler
-    	if (Board_PttDahLinePressed() && ts.dmod_mode != DEMOD_SAM)
-    	{  // was PTT line low? Not in a RX Only Mode?
+    	if (Board_PttDahLinePressed() && RadioManagement_IsTxDisabledBy(TX_DISABLE_RXMODE) == false)
+    	{  // was PTT line low? Is it not a RX only mode
     	    RadioManagement_Request_TxOn();     // yes - ONLY then do we activate PTT!  (e.g. prevent hardware bug from keying PTT!)
     		if(ts.dmod_mode == DEMOD_CW || is_demod_rtty() || ts.cw_text_entry)
     		{


### PR DESCRIPTION
CW should now react much more quickly on the first paddle press, i.e.
even with high speed the first dit or dah should have full length.
Needs testing on the mcHF / STM32F4 which suffers most from slow switching.


Moved TX/RX switching into high prio tasks. This requires us to mark
critical sections in order to prevent concurrent access to  shared data
structures and devices, as well as deadlocks.
Test on H7 all modes including CAT does work, but it is highly experimental.