### PR TITLE
Refactored S-Meter to be configurable and more load independent

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -723,11 +723,18 @@ void AudioDriver_Init(void)
     ts.dsp_inhibit = 1;
     ads.af_disabled = 1;
 
-    // Reset S meter public
-    sm.skip		= 0;
-    sm.s_count	= 0;
-    sm.curr_max	= 0;
-    sm.gain_calc = 0;	// gain calculation used for S-meter
+    // Reset S meter data
+    sm.s_count = 0;
+
+    // Variables for dbm display --> void calculate_dBm
+    sm.AttackAvedbm = 0.0;
+    sm.DecayAvedbm = 0.0;
+    sm.AttackAvedbmhz = 0.0;
+    sm.DecayAvedbmhz = 0.0;
+    // ALPHA = 1 - e^(-T/Tau)
+    sm.AttackAlpha = 50; // we use 100 => alpha == 1.0  0.5
+    sm.DecayAlpha  = 5; // 0.05
+
 #if 0
     ads.agc_val = 1;			// Post AF Filter gain (AGC)
     ads.agc_var = 1;			// used in AGC processing

--- a/mchf-eclipse/drivers/audio/audio_driver.h
+++ b/mchf-eclipse/drivers/audio/audio_driver.h
@@ -240,13 +240,26 @@ void AudioManagement_CalcIQPhaseAdjust(uint32_t freq);
 // S meter public
 typedef struct SMeter
 {
-    ulong	skip;
-    ulong	s_count;
-    float	gain_calc;
-    int		curr_max;
+    // configurable ALPHA = 1 - e^(-T/Tau)
+    uint8_t AttackAlpha;
+    uint8_t DecayAlpha;
+
+
+    // averaged values, used for display
     float32_t dbm;
     float32_t dbmhz;
 
+    // current measurements, used for averaging
+    float32_t dbm_cur;
+    float32_t dbmhz_cur;
+
+    // internal variables for dbm low pass calculation
+    float32_t AttackAvedbm;
+    float32_t DecayAvedbm;
+    float32_t AttackAvedbmhz;
+    float32_t DecayAvedbmhz;
+
+    uint32_t s_count; // number of S steps, used for display and CAT level
 } SMeter;
 
 

--- a/mchf-eclipse/drivers/ui/menu/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu.c
@@ -4244,6 +4244,15 @@ void UiMenu_UpdateItem(uint16_t select, uint16_t mode, int pos, int var, char* o
             break;
 
 #endif
+        case CONFIG_SMETER_ATTACK:
+            var_change = UiDriverMenuItemChangeUInt8(var, mode, &sm.AttackAlpha,1,100,50,1);
+            snprintf(options,32,"     %d",sm.AttackAlpha);
+            break;
+        case CONFIG_SMETER_DECAY:
+            var_change = UiDriverMenuItemChangeUInt8(var, mode, &sm.DecayAlpha,1,100,5,1);
+            snprintf(options,32,"     %d",sm.DecayAlpha);
+            break;
+
     default:                        // Move to this location if we get to the bottom of the table!
         txt_ptr = "ERROR!";
         break;

--- a/mchf-eclipse/drivers/ui/menu/ui_menu_internal.h
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu_internal.h
@@ -292,6 +292,8 @@ enum
     MENU_DYNAMICTUNE,
     MENU_DIGITAL_MODE_SELECT,
     MENU_DEBUG_CW_OFFSET_SHIFT_KEEP_SIGNAL,
+    CONFIG_SMETER_ATTACK,
+    CONFIG_SMETER_DECAY,
     MAX_RADIO_CONFIG_ITEM   // Number of radio configuration menu items - This must ALWAYS remain as the LAST item!
 };
 

--- a/mchf-eclipse/drivers/ui/menu/ui_menu_structure.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu_structure.c
@@ -444,7 +444,8 @@ const MenuDescriptor debugGroup[] =
     { MENU_DEBUG, MENU_ITEM, MENU_DEBUG_HMC1023_BYPASS, &hmc1023.present,"HMC1023 Bypass", UiMenuDesc("Debug Setting: Set HMC1023 to bypass mode") },
     { MENU_DEBUG, MENU_ITEM, MENU_DEBUG_HMC1023_OPAMP, &hmc1023.present,"HMC1023 Opamp Bias", UiMenuDesc("Debug Setting: Switch LPF HMC1023LP5E Opamp Bias") },
     { MENU_DEBUG, MENU_ITEM, MENU_DEBUG_HMC1023_DRVR, &hmc1023.present,"HMC1023 Driver Bias", UiMenuDesc("Debug Setting: Set HMC1023 Driver Bias") },
-
+    { MENU_DEBUG, MENU_ITEM, CONFIG_SMETER_ATTACK, NULL, "S-Meter Attack", UiMenuDesc("Attack controls how quickly the S-Meter reacts to rising signal levels, higher values represent quicker reaction") },
+    { MENU_DEBUG, MENU_ITEM, CONFIG_SMETER_DECAY, NULL, "S-Meter Attack", UiMenuDesc("Decay controls how quickly the S-Meter reacts to falling signal levels, higher values represent quicker reaction") },
 	{ MENU_DEBUG, MENU_STOP, 0, NULL, NULL, UiMenuDesc("") }
 };
 


### PR DESCRIPTION
S-Meter attack and decay can now be configured in the Debug menu.
Changed attack/decay values are not yet saved, just for experimentation to identify suitable
ranges. Later we will have permanent configuration.
The attack and decay behavior should now be more reliable under changing load except
if there is very high load.
Removed unused parts of the S-Meter data structure and integrated the low pass
variables there.