### PR TITLE
Fix makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
 
 sudo: required
 language: generic
-dist: trusty 
+dist: xenial 
 
 addons:
   apt:
@@ -22,8 +22,6 @@ install:
     - export GCC_URL=https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/$GCC_SHORT/$GCC_BASE-linux.tar.bz2
     - if [ ! -e $GCC_DIR/bin/arm-none-eabi-g++ ]; then wget $GCC_URL -O $GCC_ARCHIVE; tar xfj $GCC_ARCHIVE -C $HOME; fi
 script:
-    - sudo apt-get update
-    - sudo apt-get install make
     - mkdir -p mchf-eclipse/build-bl-f4
     - mkdir -p mchf-eclipse/build-fw-f4
     - mkdir -p mchf-eclipse/build-bl-f7

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
 
 sudo: required
 language: generic
-dist: trusty
+dist: trusty 
 
 addons:
   apt:
@@ -22,6 +22,8 @@ install:
     - export GCC_URL=https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/$GCC_SHORT/$GCC_BASE-linux.tar.bz2
     - if [ ! -e $GCC_DIR/bin/arm-none-eabi-g++ ]; then wget $GCC_URL -O $GCC_ARCHIVE; tar xfj $GCC_ARCHIVE -C $HOME; fi
 script:
+    - sudo apt-get update
+    - sudo apt-get install make
     - mkdir -p mchf-eclipse/build-bl-f4
     - mkdir -p mchf-eclipse/build-fw-f4
     - mkdir -p mchf-eclipse/build-bl-f7

--- a/mchf-eclipse/.gitignore
+++ b/mchf-eclipse/.gitignore
@@ -3,6 +3,7 @@
 *.d
 *~
 *.pyc
+*.lst
 bl-*.bin
 bl-*.dfu
 bl-*.elf

--- a/mchf-eclipse/Makefile
+++ b/mchf-eclipse/Makefile
@@ -316,13 +316,14 @@ $(FIRMWARE).elf:  $(HAL_OBJS) $(DSPLIB_OBJS) $(OBJS)
 	$(ECHO) "  [LD] $@"
 	@$(file > $(ROOTLOC)/firmware_obj_list.lst,$^)
 	@$(CXX) $(LDFLAGS)  -Xlinker --gc-sections -Llibs -Wl,-Map,$(FIRMWARE).map -o$@ @$(ROOTLOC)/firmware_obj_list.lst $(LIBS)
+	$(RM) $(call FixPath,firmware_obj_list.lst)
 
 # compilation
 $(BOOTLOADER).elf:  $(BL_HAL_OBJS) $(BL_OBJS)
 	$(ECHO) "  [LD] $@"
 	@$(file > $(ROOTLOC)/bootloader_obj_list.lst,$^)
 	$(CXX) $(LDFLAGS) -Xlinker --gc-sections -Llibs -Wl,-Map,$(BOOTLOADER).map -o$@ @$(ROOTLOC)/bootloader_obj_list.lst $(LIBS)
-
+	$(RM) $(call FixPath,bootloader_obj_list.lst)
 
 $(TRX_ID).handbook:
 	@$(ROOTLOC)/support/ui/menu/mk-menu-handbook auto

--- a/mchf-eclipse/Makefile
+++ b/mchf-eclipse/Makefile
@@ -196,7 +196,7 @@ OS = @${PREFIX}/bin/arm-none-eabi-size
 HEX2DFU = $(ROOTLOC)/support/hex2dfu/hex2dfu.py
 
 ifdef SystemRoot  # WINxx
-	HEX2DFU = python $(ROOTLOC)/support/hex2dfu/hex2dfu.py
+    HEX2DFU = python $(ROOTLOC)/support/hex2dfu/hex2dfu.py
     CC = arm-none-eabi-gcc
     CXX = arm-none-eabi-g++
     OC = arm-none-eabi-objcopy
@@ -204,7 +204,7 @@ ifdef SystemRoot  # WINxx
 endif
 
 ifdef MSYSTEM
-	HEX2DFU = python $(ROOTLOC)/support/hex2dfu/hex2dfu.py
+    HEX2DFU = python $(ROOTLOC)/support/hex2dfu/hex2dfu.py
     CC = arm-none-eabi-gcc
     CXX = arm-none-eabi-g++
     OC = arm-none-eabi-objcopy
@@ -314,15 +314,15 @@ $(BOOTLOADER):  $(BOOTLOADER).bin $(BOOTLOADER).dfu
 # compilation
 $(FIRMWARE).elf:  $(HAL_OBJS) $(DSPLIB_OBJS) $(OBJS)
 	$(ECHO) "  [LD] $@"
-	@$(file > $(ROOTLOC)/firmware_obj_list.lst,$^)
-	@$(CXX) $(LDFLAGS)  -Xlinker --gc-sections -Llibs -Wl,-Map,$(FIRMWARE).map -o$@ @$(ROOTLOC)/firmware_obj_list.lst $(LIBS)
+	@$(file > firmware_obj_list.lst,$^)
+	@$(CXX) $(LDFLAGS)  -Xlinker --gc-sections -Llibs -Wl,-Map,$(FIRMWARE).map -o$@ @firmware_obj_list.lst $(LIBS)
 	$(RM) $(call FixPath,firmware_obj_list.lst)
 
 # compilation
 $(BOOTLOADER).elf:  $(BL_HAL_OBJS) $(BL_OBJS)
 	$(ECHO) "  [LD] $@"
-	@$(file > $(ROOTLOC)/bootloader_obj_list.lst,$^)
-	$(CXX) $(LDFLAGS) -Xlinker --gc-sections -Llibs -Wl,-Map,$(BOOTLOADER).map -o$@ @$(ROOTLOC)/bootloader_obj_list.lst $(LIBS)
+	@$(file > bootloader_obj_list.lst,$^)
+	$(CXX) $(LDFLAGS) -Xlinker --gc-sections -Llibs -Wl,-Map,$(BOOTLOADER).map -o$@ @bootloader_obj_list.lst $(LIBS)
 	$(RM) $(call FixPath,bootloader_obj_list.lst)
 
 $(TRX_ID).handbook:

--- a/mchf-eclipse/Makefile
+++ b/mchf-eclipse/Makefile
@@ -314,15 +314,15 @@ $(BOOTLOADER):  $(BOOTLOADER).bin $(BOOTLOADER).dfu
 # compilation
 $(FIRMWARE).elf:  $(HAL_OBJS) $(DSPLIB_OBJS) $(OBJS)
 	$(ECHO) "  [LD] $@"
-	@$(file > firmware_obj_list.lst,$^)
-	@$(CXX) $(LDFLAGS)  -Xlinker --gc-sections -Llibs -Wl,-Map,$(FIRMWARE).map -o$@ @firmware_obj_list.lst $(LIBS)
+	@$(file > ./firmware_obj_list.lst,$^)
+	@$(CXX) $(LDFLAGS)  -Xlinker --gc-sections -Llibs -Wl,-Map,$(FIRMWARE).map -o$@ @./firmware_obj_list.lst $(LIBS)
 	$(RM) $(call FixPath,firmware_obj_list.lst)
 
 # compilation
 $(BOOTLOADER).elf:  $(BL_HAL_OBJS) $(BL_OBJS)
 	$(ECHO) "  [LD] $@"
-	@$(file > bootloader_obj_list.lst,$^)
-	$(CXX) $(LDFLAGS) -Xlinker --gc-sections -Llibs -Wl,-Map,$(BOOTLOADER).map -o$@ @bootloader_obj_list.lst $(LIBS)
+	@$(file > ./bootloader_obj_list.lst,$^)
+	$(CXX) $(LDFLAGS) -Xlinker --gc-sections -Llibs -Wl,-Map,$(BOOTLOADER).map -o$@ @./bootloader_obj_list.lst $(LIBS)
 	$(RM) $(call FixPath,bootloader_obj_list.lst)
 
 $(TRX_ID).handbook:

--- a/mchf-eclipse/Makefile
+++ b/mchf-eclipse/Makefile
@@ -9,6 +9,7 @@
 # Rev. 2016-04-06 cleanup - Stephan HB9ocq
 # Rev. 06/12/2016 possibility of choosing individual toolchain - Andreas Richter DF8OE
 # Rev. 2017-01-06 HB9ocq - added versioning of build: extracted from source, propagated to env.vars
+# Rev. 20/11/2018 RV9YW (m-chichikalov) - fixed limitation of parameter length on cmd.exe windows by passing all obj. as one file to linker
 
 #  -*- makefile -*-
 # if you want to build in a different directory than this one
@@ -195,6 +196,7 @@ OS = @${PREFIX}/bin/arm-none-eabi-size
 HEX2DFU = $(ROOTLOC)/support/hex2dfu/hex2dfu.py
 
 ifdef SystemRoot  # WINxx
+	HEX2DFU = python $(ROOTLOC)/support/hex2dfu/hex2dfu.py
     CC = arm-none-eabi-gcc
     CXX = arm-none-eabi-g++
     OC = arm-none-eabi-objcopy
@@ -202,6 +204,7 @@ ifdef SystemRoot  # WINxx
 endif
 
 ifdef MSYSTEM
+	HEX2DFU = python $(ROOTLOC)/support/hex2dfu/hex2dfu.py
     CC = arm-none-eabi-gcc
     CXX = arm-none-eabi-g++
     OC = arm-none-eabi-objcopy
@@ -221,6 +224,9 @@ else ifeq ($(shell uname), Darwin)
     RM = rm -f
     FixPath = $1
 else ifeq ($(shell uname), CYGWIN_NT-10.0)
+    RM = rm -f
+    FixPath = $1
+else
     RM = rm -f
     FixPath = $1
 endif
@@ -308,12 +314,14 @@ $(BOOTLOADER):  $(BOOTLOADER).bin $(BOOTLOADER).dfu
 # compilation
 $(FIRMWARE).elf:  $(HAL_OBJS) $(DSPLIB_OBJS) $(OBJS)
 	$(ECHO) "  [LD] $@"
-	@$(CXX) $(LDFLAGS)  -Xlinker --gc-sections -Llibs -Wl,-Map,$(FIRMWARE).map -o$@ $^ $(LIBS)
+	@$(file > $(ROOTLOC)/firmware_obj_list.lst,$^)
+	@$(CXX) $(LDFLAGS)  -Xlinker --gc-sections -Llibs -Wl,-Map,$(FIRMWARE).map -o$@ @$(ROOTLOC)/firmware_obj_list.lst $(LIBS)
 
 # compilation
 $(BOOTLOADER).elf:  $(BL_HAL_OBJS) $(BL_OBJS)
 	$(ECHO) "  [LD] $@"
-	$(CXX) $(LDFLAGS) -Xlinker --gc-sections -Llibs -Wl,-Map,$(BOOTLOADER).map -o$@ $^ $(LIBS)
+	@$(file > $(ROOTLOC)/bootloader_obj_list.lst,$^)
+	$(CXX) $(LDFLAGS) -Xlinker --gc-sections -Llibs -Wl,-Map,$(BOOTLOADER).map -o$@ @$(ROOTLOC)/bootloader_obj_list.lst $(LIBS)
 
 
 $(TRX_ID).handbook:
@@ -345,7 +353,6 @@ clean-libs:
 	# remove libs object files (.o)
 	$(RM) $(call FixPath,$(DSPLIB_OBJS))
 	$(RM) $(call FixPath,$(HAL_OBJS))
-
 
 clean:  clean-firmware clean-bootloader clean-libs
 	# remove the executables, map, dmp and all object files (.o)


### PR DESCRIPTION
I failed to build under the windows. 

GNU Make 4.2.1
Built for x86_64-w64-mingw32
Windows 7 x64
GNU Tools for Arm Embedded Processors 7-2017-q4-major - 7.2.1 20170904 
MINGW64_NT-6.1

It's very known issue with windows...
There are the next fixes:
1. all objects passing to linker as one file this list of them (windows has limitation on number of parameters and length of parameter for creating process, so...)
2. As long as I know windows cannot run .py files as executable, so needed mention explicitly. e.x. "python somefile.py"
3. There is no default values for FixPath in Makefile. So cleaning faild on my system. 