### PR TITLE
 Fixed issue #1610: Firmware not working.

### DIFF
--- a/mchf-eclipse/Makefile
+++ b/mchf-eclipse/Makefile
@@ -138,7 +138,7 @@ ifeq ($(BUILDFOR),F4)
 $(BOOTLOADER).elf : CFLAGS = ${BASECFLAGS_F4} -Os -DBOOTLOADER_BUILD
 $(FIRMWARE).elf : CFLAGS = ${BASECFLAGS_F4} -O2
 $(BOOTLOADER).elf : LDFLAGS = ${LDFLAGS_F4} -T$(LINKERLOC)/arm-gcc-link-bootloader_f4.ld
-$(FIRMWARE).elf : LDFLAGS = ${LDFLAGS_F4} -T$(LINKERLOC)/arm-gcc-link_f4_flash512k.ld
+$(FIRMWARE).elf : LDFLAGS = ${LDFLAGS_F4} -T$(LINKERLOC)/arm-gcc-link_f4_flash1024k.ld
 	
 
 

--- a/mchf-eclipse/Makefile
+++ b/mchf-eclipse/Makefile
@@ -138,7 +138,7 @@ ifeq ($(BUILDFOR),F4)
 $(BOOTLOADER).elf : CFLAGS = ${BASECFLAGS_F4} -Os -DBOOTLOADER_BUILD
 $(FIRMWARE).elf : CFLAGS = ${BASECFLAGS_F4} -O2
 $(BOOTLOADER).elf : LDFLAGS = ${LDFLAGS_F4} -T$(LINKERLOC)/arm-gcc-link-bootloader_f4.ld
-$(FIRMWARE).elf : LDFLAGS = ${LDFLAGS_F4} -T$(LINKERLOC)/arm-gcc-link_f4_flash1024k.ld
+$(FIRMWARE).elf : LDFLAGS = ${LDFLAGS_F4} -T$(LINKERLOC)/arm-gcc-link_f4_flash512k.ld
 	
 
 

--- a/mchf-eclipse/basesw/mcHF/Src/main.c
+++ b/mchf-eclipse/basesw/mcHF/Src/main.c
@@ -94,6 +94,7 @@ int main(void)
   /* USER CODE BEGIN 1 */
 #ifdef BOOTLOADER_BUILD
   mchfBl_CheckAndGoForDfuBoot();
+  mchfBl_CheckAndGoForNormalBoot();
   //  we need to do this as early as possible
 #endif
   /* USER CODE END 1 */

--- a/mchf-eclipse/drivers/audio/audio_nr.c
+++ b/mchf-eclipse/drivers/audio/audio_nr.c
@@ -1855,8 +1855,6 @@ else
     } */
 
 
-Board_RedLed(LED_STATE_OFF);
-
     if(ts.nr_first_time == 1)
     { // TODO: properly initialize all the variables
 

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -1742,6 +1742,8 @@ static void UiDriver_CreateDesktop()
 	//UiSpectrum_GetSpectrumGraticule()->y=ts.graticulePowerupYpos;
 	// Spectrum scope
 	UiSpectrum_Init();
+	//*(volatile uint32_t*)(0x20000000 + 0x0002FFFC) = 123;
+
 
 	UiDriver_RefreshEncoderDisplay();
 

--- a/mchf-eclipse/hardware/uhsdr_board.c
+++ b/mchf-eclipse/hardware/uhsdr_board.c
@@ -456,7 +456,7 @@ static volatile bool busfault_detected;
 
 #define TEST_ADDR_192 (0x20000000 + 0x0001FFFC)
 #define TEST_ADDR_256 (0x20000000 + 0x0002FFFC)
-#define TEST_ADDR_512 (0x20000000 + 0x0004FFFC)
+#define TEST_ADDR_512 (0x20000000 + 0x0005FFFC)
 
 // function below mostly based on http://stackoverflow.com/questions/23411824/determining-arm-cortex-m3-ram-size-at-run-time
 

--- a/mchf-eclipse/linker/arm-gcc-link_f4_flash512k.ld
+++ b/mchf-eclipse/linker/arm-gcc-link_f4_flash512k.ld
@@ -4,7 +4,7 @@ MEMORY
 {
 	rom  (rx)  : ORIGIN = 0x08010000, LENGTH = 512k - 64k
 	/*rom  (rx)  : ORIGIN = 0x08010000, LENGTH = 1024k - 64k*/
-	ram  (rwx) : ORIGIN = 0x20000000, LENGTH = 128k
+	ram  (rwx) : ORIGIN = 0x20000100, LENGTH = 128k-256
 	ram1 (rwx) : ORIGIN = 0x10000000, LENGTH = 64k
 }
 

--- a/mchf-eclipse/src/bootloader/bootloader_main.h
+++ b/mchf-eclipse/src/bootloader/bootloader_main.h
@@ -25,8 +25,17 @@ void BL_Application();
 int bootloader_main();
 void bootTypeSelector();
 void mchfBl_CheckAndGoForDfuBoot();
+void mchfBl_CheckAndGoForNormalBoot();
 void BL_InfoScreen();
 void BL_PrintLine(const char* txt);
+
+enum
+{
+    BOOT_CLEARED = 0,
+    BOOT_REBOOT = 0x55, // this command can be issue also by the firmware indicate immediate start
+    BOOT_DFU = 0x99,
+    BOOT_FIRMWARE = 0x66993300,
+};
 
 #ifdef __cplusplus
 }

--- a/mchf-eclipse/src/bootloader/command.c
+++ b/mchf-eclipse/src/bootloader/command.c
@@ -279,7 +279,8 @@ void COMMAND_DOWNLOAD(void)
 void COMMAND_ResetMCU(uint32_t code)
 {
     *(__IO uint32_t*)(SRAM2_BASE) = code;
-#ifdef STM32F7
+    __DSB();
+#if defined(STM32F7) || defined(STM32H7)
     SCB_CleanDCache();
 #endif
     /* Software reset */

--- a/mchf-eclipse/src/uhsdr_version.h
+++ b/mchf-eclipse/src/uhsdr_version.h
@@ -16,7 +16,7 @@
 #define 	UHSDR_VER_MINOR			"9"
 #define 	UHSDR_VER_RELEASE		"68"
 
-#define		UHSDR_BOOT_VERS			"4.1.2"
+#define		UHSDR_BOOT_VERS			"5.0.0"
 
 
 #ifdef SBLA									// Bootloader enables additional rf bands PCB


### PR DESCRIPTION
The bootloader's interrupt handlers manipulated the data segment memory since
this is initialized before the new vector table is set and the new interrupts
get activated.

Solution: We the bootloader starts the firmware through a shared variable
(which we used already, but not for normal start) and after reset it
goes straight to firmware without enabling any interrupt. Safest way to
do it.

Bumped bootloader up to 5.0.0 so that we can check in firmware for older bootloaders easily!