### PR TITLE
Fixed Bootloader for F4/F7/H7, Bootloader Warning in all Firmwares

### DIFF
--- a/mchf-eclipse/basesw/mcHF/Src/main.c
+++ b/mchf-eclipse/basesw/mcHF/Src/main.c
@@ -93,8 +93,7 @@ int main(void)
 
   /* USER CODE BEGIN 1 */
 #ifdef BOOTLOADER_BUILD
-  mchfBl_CheckAndGoForDfuBoot();
-  mchfBl_CheckAndGoForNormalBoot();
+    Bootloader_CheckAndGoForBootTarget();
   //  we need to do this as early as possible
 #endif
   /* USER CODE END 1 */
@@ -112,7 +111,7 @@ int main(void)
   /* Initialize all configured peripherals */
 
 #ifdef BOOTLOADER_BUILD
-  bootloader_main();
+  Bootloader_Main();
 #else
   MX_GPIO_Init();
   MX_DMA_Init();
@@ -153,7 +152,7 @@ int main(void)
     MX_USB_HOST_Process();
 
     /* USER CODE BEGIN 3 */
-    BL_Application();
+    Bootloader_UsbHostApplication();
 
   }
 #endif

--- a/mchf-eclipse/basesw/mcHF/Src/stm32f4xx_it.c
+++ b/mchf-eclipse/basesw/mcHF/Src/stm32f4xx_it.c
@@ -136,14 +136,14 @@ static void Debug_FaultGetRegistersFromStack( uint32_t *pulFaultStackAddress, ui
 away as the variables never actually get used.  If the debugger won't show the
 values of the variables, make them global my moving their declaration outside
 of this function. */
-volatile uint32_t r0;
-volatile uint32_t r1;
-volatile uint32_t r2;
-volatile uint32_t r3;
-volatile uint32_t r12;
-volatile uint32_t lr; /* Link register. */
-volatile uint32_t pc; /* Program counter. */
-volatile uint32_t psr;/* Program status register. */
+volatile uint32_t r0  __attribute__ ((unused));
+volatile uint32_t r1 __attribute__ ((unused));
+volatile uint32_t r2 __attribute__ ((unused));
+volatile uint32_t r3 __attribute__ ((unused));
+volatile uint32_t r12 __attribute__ ((unused));
+volatile uint32_t lr __attribute__ ((unused)); /* Link register. */
+volatile uint32_t pc __attribute__ ((unused)); /* Program counter. */
+volatile uint32_t psr __attribute__ ((unused));/* Program status register. */
 
     r0 = pulFaultStackAddress[ 0 ];
     r1 = pulFaultStackAddress[ 1 ];

--- a/mchf-eclipse/basesw/ovi40-h7/Src/main.c
+++ b/mchf-eclipse/basesw/ovi40-h7/Src/main.c
@@ -103,7 +103,7 @@ int main(void)
 {
   /* USER CODE BEGIN 1 */
 #ifdef BOOTLOADER_BUILD
-  mchfBl_CheckAndGoForDfuBoot();
+    Bootloader_CheckAndGoForBootTarget();
   //  we need to do this as early as possible
 #endif
   /* USER CODE END 1 */
@@ -131,7 +131,7 @@ int main(void)
   SystemClock_Config();
 
 #ifdef BOOTLOADER_BUILD
-  bootloader_main();
+  Bootloader_Main();
 #else
   /* Initialize all configured peripherals */
   MX_GPIO_Init();
@@ -189,7 +189,7 @@ int main(void)
     MX_USB_HOST_Process();
 
   /* USER CODE BEGIN 3 */
-    BL_Application();
+    Bootloader_UsbHostApplication();
 
   }
 #endif

--- a/mchf-eclipse/basesw/ovi40/Src/main.c
+++ b/mchf-eclipse/basesw/ovi40/Src/main.c
@@ -98,7 +98,7 @@ int main(void)
 {
   /* USER CODE BEGIN 1 */
 #ifdef BOOTLOADER_BUILD
-  mchfBl_CheckAndGoForDfuBoot();
+  Bootloader_CheckAndGoForBootTarget();
   //  we need to do this as early as possible
 #endif
   /* USER CODE END 1 */
@@ -124,7 +124,7 @@ int main(void)
   SystemClock_Config();
 
 #ifdef BOOTLOADER_BUILD
-  bootloader_main();
+  Bootloader_Main();
 #else
   /* Initialize all configured peripherals */
   MX_GPIO_Init();
@@ -179,7 +179,7 @@ int main(void)
     MX_USB_HOST_Process();
 
   /* USER CODE BEGIN 3 */
-    BL_Application();
+    Bootloader_UsbHostApplication();
 
   }
 #endif

--- a/mchf-eclipse/drivers/ui/menu/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu.c
@@ -480,7 +480,6 @@ void __attribute__ ((noinline)) UiDriverMenuMapStrings(char* output, uint32_t va
     strcpy(output,(value <= string_max)?strings[value]:"UNDEFINED");
 }
 
-
 /**
  * @returns: information for requested item as string. Do not write to this string.
  */
@@ -609,36 +608,7 @@ const char* UiMenu_GetSystemInfo(uint32_t* m_clr_ptr, int info_item)
     break;
     case INFO_BL_VERSION:
     {
-        outs = "Unknown BL";
-
-        // We search for string "Version: " in bootloader memory
-        // this assume the bootloader starting at 0x8000000 and being followed by the virtual eeprom
-        // which starts at EEPROM_START_ADDRESS
-        for(uint8_t* begin = (uint8_t*)0x8000000; begin < (uint8_t*)EEPROM_START_ADDRESS-8; begin++)
-        {
-            if (memcmp("Version: ",begin,9) == 0)
-            {
-                snprintf(out,32, "%s", &begin[9]);
-                outs = out;
-                break;
-            }
-            else
-            {
-                if (memcmp("M0NKA 2",begin,7) == 0)
-                {
-                    if (begin[11] == 0xb5)
-                    {
-                        outs = "M0NKA 0.0.0.9";
-                        break;
-                    }
-                    else if (begin[11] == 0xd1)
-                    {
-                        outs = "M0NKA 0.0.0.14";
-                        break;
-                    }
-                }
-            }
-        }
+        outs = Board_BootloaderVersion();
     }
     break;
     case INFO_FW_VERSION:

--- a/mchf-eclipse/hardware/uhsdr_board.h
+++ b/mchf-eclipse/hardware/uhsdr_board.h
@@ -1245,7 +1245,7 @@ inline bool Board_DitLinePressed() {
 unsigned int Board_RamSizeGet();
 void Board_RamSizeDetection();
 void Board_TouchscreenInit();
-
+const char* Board_BootloaderVersion();
 // in main.c
 void CriticalError(ulong error);
 

--- a/mchf-eclipse/src/bootloader/bootloader_main.h
+++ b/mchf-eclipse/src/bootloader/bootloader_main.h
@@ -21,13 +21,10 @@ extern "C" {
 #endif
 
 
-void BL_Application();
-int bootloader_main();
-void bootTypeSelector();
-void mchfBl_CheckAndGoForDfuBoot();
-void mchfBl_CheckAndGoForNormalBoot();
-void BL_InfoScreen();
-void BL_PrintLine(const char* txt);
+void Bootloader_UsbHostApplication();
+int  Bootloader_Main();
+void Bootloader_CheckAndGoForBootTarget();
+void Bootloader_PrintLine(const char* txt);
 
 enum
 {

--- a/mchf-eclipse/src/bootloader/command.c
+++ b/mchf-eclipse/src/bootloader/command.c
@@ -76,9 +76,9 @@ void FlashFail_Handler(mchf_bootloader_error_t redCount)
     char txt[16] = "Error Code  X";
     txt[12] = redCount + '0';
 
-    BL_PrintLine("");
-    BL_PrintLine(txt);
-    BL_PrintLine(error_help[redCount]);
+    Bootloader_PrintLine("");
+    Bootloader_PrintLine(txt);
+    Bootloader_PrintLine(error_help[redCount]);
 
 
     while(1)

--- a/mchf-eclipse/src/bootloader/uhsdr_boot_hw.h
+++ b/mchf-eclipse/src/bootloader/uhsdr_boot_hw.h
@@ -90,12 +90,12 @@ void mcHF_PowerOff();
 /*
  * Just toggles the PowerHold Pin, but does not stop execution
  */
-static inline void mcHF_PowerHoldOff()
+static inline void Bootloader_PowerHoldOff()
 {
     mchfBl_PinOn(PWR_HOLD);
 }
 
-static inline void mcHF_PowerHoldOn()
+static inline void Bootloader_PowerHoldOn()
 {
     mchfBl_PinOff(PWR_HOLD);
 }

--- a/mchf-eclipse/src/uhsdr_main.c
+++ b/mchf-eclipse/src/uhsdr_main.c
@@ -581,6 +581,14 @@ int mchfMain(void)
     UiDriver_StartupScreen_LogIfProblem(ts.codec_present == false,
             "Audiocodec WM8731 NOT detected!");
 
+    const char* bl_version = Board_BootloaderVersion();
+
+    UiDriver_StartupScreen_LogIfProblem(
+            (bl_version[0] == '1' || bl_version[0] == '2' || bl_version[0] == '3' || bl_version[0] == '4')  && bl_version[1] == '.',
+
+                "Upgrade bootloader to 5.0.1 or newer");
+
+
     AudioManagement_CalcSubaudibleGenFreq();		// load/set current FM subaudible tone settings for generation
     AudioManagement_CalcSubaudibleDetFreq();		// load/set current FM subaudible tone settings	for detection
     AudioManagement_LoadToneBurstMode();	// load/set tone burst frequency


### PR DESCRIPTION
Bootloader now disables SysTick instead of doing a 2nd reset.
Also fixed H7 firmware reboot capability
Renamed all Bootloader functions to follow one unified scheme.
Firmware now warns if you have a too old bootloader with the serious
issue present. That may annoy some users but how else can we make them
upgrade? We don't know how many small issues are caused by this.
Let us see how the reaction is...

Main discussion is in #1610