### PR TITLE
Disabled not yet working SSD1289 display support

### DIFF
--- a/mchf-eclipse/hardware/uhsdr_board.h
+++ b/mchf-eclipse/hardware/uhsdr_board.h
@@ -79,7 +79,8 @@
 #ifndef EXTERNAL_USE_GFX_CONFIG
   #define USE_GFX_ILI932x
   #define USE_GFX_ILI9486
-  #define USE_GFX_SSD1289
+  // SSD1289 support is not yet working, also requires USE_GFX_ILI932x to be enabled for now.
+  // #define USE_GFX_SSD1289
   #define USE_DISP_480_320
 #endif
 


### PR DESCRIPTION
Until someone gets this to work and tested, it should not be enabled by default.