### PR TITLE
Refactored IQ Correction

### DIFF
--- a/mchf-eclipse/drivers/ui/menu/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu.c
@@ -644,6 +644,11 @@ const char* UiMenu_GetSystemInfo(uint32_t* m_clr_ptr, int info_item)
         snprintf(out,32, "%s", ts.codec_present?"Yes":"N/A");
     }
     break;
+    case INFO_CODEC_TWINPEAKS:
+    {
+        snprintf(out,32, "%s", (ts.twinpeaks_tested == TWINPEAKS_UNCORRECTABLE)? "Failed" : "Done");
+    }
+    break;
     case INFO_LICENCE:
     {
         snprintf(out,32, "%s", UHSDR_LICENCE);

--- a/mchf-eclipse/drivers/ui/menu/ui_menu.h
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu.h
@@ -64,6 +64,7 @@ enum MENU_INFO_ITEM
     INFO_LICENCE,
     INFO_HWLICENCE,
     INFO_CODEC,
+    INFO_CODEC_TWINPEAKS,
 };
 
 const char* UiMenu_GetSystemInfo(uint32_t* m_clr_ptr, int info_item);

--- a/mchf-eclipse/drivers/ui/menu/ui_menu_structure.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu_structure.c
@@ -389,6 +389,7 @@ const MenuDescriptor infoGroup[] =
     { MENU_SYSINFO, MENU_INFO, INFO_BL_VERSION, NULL,"Bootloader", UiMenuDesc("bootloader version") },
     { MENU_SYSINFO, MENU_INFO, INFO_RFBOARD, NULL,"RF Board", UiMenuDesc("Displays the detected RF Board hardware identification.") },
     { MENU_SYSINFO, MENU_INFO, INFO_CODEC, NULL,"Audio Codec Presence", UiMenuDesc("Audio Codec I2C communication successfully tested? This is not a full test of the Audio Codec functionality, it only reports if I2C communication reported no problem talking to the codec.") },
+    { MENU_SYSINFO, MENU_INFO, INFO_CODEC_TWINPEAKS, NULL,"Audio Codec Twinpeaks Corr.", UiMenuDesc("In some cases the audio codec needs to be restarted to produce correct IQ. The IQ auto correction detects this. If this fixes the problem, Done is displayed, Failed otherwise") },
     { MENU_SYSINFO, MENU_INFO, INFO_VBAT, NULL,"Backup RAM Battery", UiMenuDesc("Battery Support for Backup RAM present?") },
     { MENU_SYSINFO, MENU_INFO, INFO_RTC, NULL,"Real Time Clock", UiMenuDesc("Battery Supported Real Time Clock present?") },
     { MENU_SYSINFO, MENU_INFO, INFO_LICENCE, NULL,"FW license", UiMenuDesc("Display license of firmware") },

--- a/mchf-eclipse/drivers/ui/ui_configuration.c
+++ b/mchf-eclipse/drivers/ui/ui_configuration.c
@@ -95,7 +95,7 @@ const ConfigEntryDescriptor ConfigEntryInfo[] =
     { ConfigEntry_UInt8 | Calib_Val, EEPROM_PA_BIAS,&ts.pa_bias,PA_BIAS_DEFAULT,0,PA_BIAS_MAX},
     { ConfigEntry_UInt8 | Calib_Val, EEPROM_PA_CW_BIAS,&ts.pa_cw_bias,PA_BIAS_DEFAULT,0,PA_BIAS_MAX},
 
-    { ConfigEntry_UInt8, EEPROM_IQ_AUTO_CORRECTION,&ts.iq_auto_correction,0,0, 1},
+    { ConfigEntry_UInt8, EEPROM_IQ_AUTO_CORRECTION,&ts.iq_auto_correction,1, 0, 1},
     { ConfigEntry_Int32_16, EEPROM_TX_IQ_80M_GAIN_BALANCE,&ts.tx_iq_gain_balance[IQ_80M].value[IQ_TRANS_ON],IQ_BALANCE_OFF, MIN_IQ_GAIN_BALANCE, MAX_IQ_GAIN_BALANCE},
     { ConfigEntry_Int32_16, EEPROM_TX_IQ_10M_GAIN_BALANCE,&ts.tx_iq_gain_balance[IQ_10M].value[IQ_TRANS_ON],IQ_BALANCE_OFF, MIN_IQ_GAIN_BALANCE, MAX_IQ_GAIN_BALANCE},
     { ConfigEntry_Int32_16, EEPROM_TX_IQ_80M_PHASE_BALANCE,&ts.tx_iq_phase_balance[IQ_80M].value[IQ_TRANS_ON],IQ_BALANCE_OFF, MIN_IQ_PHASE_BALANCE, MAX_IQ_PHASE_BALANCE},

--- a/mchf-eclipse/hardware/uhsdr_board.h
+++ b/mchf-eclipse/hardware/uhsdr_board.h
@@ -989,6 +989,14 @@ typedef struct TransceiverState
 	uint8_t	meter_colour_down;
 	uint8_t   iq_auto_correction;     // switch variable for automatic IQ correction
 	bool	display_rx_iq;
+
+	// twinpeak_tested = 2 --> wait for system to warm up
+    // twinpeak_tested = 0 --> go and test the IQ phase
+    // twinpeak_tested = 1 --> tested, verified, go and have a nice day!
+#define TWINPEAKS_WAIT 2
+#define TWINPEAKS_DONE 1
+#define TWINPEAKS_SAMPLING 0
+#define TWINPEAKS_UNCORRECTABLE 4
 	uint8_t twinpeaks_tested;
 //	uint8_t agc_wdsp;
 	uint8_t agc_wdsp_mode;

--- a/mchf-eclipse/src/uhsdr_main.c
+++ b/mchf-eclipse/src/uhsdr_main.c
@@ -321,9 +321,7 @@ void TransceiverStateInit(void)
 //    ts.dBm_count = 0;						// timer start
     ts.tx_filter = 0;						// which TX filter has been chosen by the user
     ts.iq_auto_correction = 1;              // disable/enable automatic IQ correction
-    ts.twinpeaks_tested = 2;                // twinpeak_tested = 2 --> wait for system to warm up
-    // twinpeak_tested = 0 --> go and test the IQ phase
-    // twinpeak_tested = 1 --> tested, verified, go and have a nice day!
+    ts.twinpeaks_tested = TWINPEAKS_WAIT;
 //    ts.agc_wdsp = 0;
     ts.agc_wdsp_mode = 2;
     ts.agc_wdsp_slope = 70;


### PR DESCRIPTION
- removed unnecessary counter (we always have more than 7 samples)
- added new state to indicate failed twinpeaks auto correction
- changed IQ auto correction default to be enabled by default active
  a new machine