### PR TITLE
RA8875 800x480 display support - initial version

### DIFF
--- a/mchf-eclipse/.settings/ilg.gnumcueclipse.managedbuild.cross.prefs
+++ b/mchf-eclipse/.settings/ilg.gnumcueclipse.managedbuild.cross.prefs
@@ -1,0 +1,2 @@
+buildTools.path=C\:\\Program Files\\GNU MCU Eclipse\\Build Tools\\2.10-20180103-1919\\bin
+eclipse.preferences.version=1

--- a/mchf-eclipse/MCHF-FW no load.launch
+++ b/mchf-eclipse/MCHF-FW no load.launch
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="ilg.gnumcueclipse.debug.gdbjtag.openocd.launchConfigurationType">
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doContinue" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doDebugInRam" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doFirstReset" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doGdbServerAllocateConsole" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doGdbServerAllocateTelnetConsole" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doSecondReset" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doStartGdbCLient" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doStartGdbServer" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.enableSemihosting" value="true"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.firstResetType" value="init"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbClientOtherCommands" value="set mem inaccessible-by-default off"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbClientOtherOptions" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerConnectionAddress" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerExecutable" value="C:\ARM\openocd-0.9.0\bin\openocd.exe"/>
+<intAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerGdbPortNumber" value="3333"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerLog" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerOther" value="-f support/MCHF.cfg"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerTclPortNumber" value="6666"/>
+<intAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerTelnetPortNumber" value="4444"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.otherInitCommands" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.otherRunCommands" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.secondResetType" value="halt"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.svdPath" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.imageFileName" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.imageOffset" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.ipAddress" value="localhost"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.jtagDevice" value="GNU MCU OpenOCD"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadImage" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadSymbols" value="true"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.pcRegister" value=""/>
+<intAttribute key="org.eclipse.cdt.debug.gdbjtag.core.portNumber" value="3333"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setPcRegister" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setResume" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setStopAt" value="true"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.stopAt" value="main"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.symbolsFileName" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.symbolsOffset" value=""/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useFileForImage" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useFileForSymbols" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useProjBinaryForImage" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useProjBinaryForSymbols" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useRemoteTarget" value="true"/>
+<stringAttribute key="org.eclipse.cdt.dsf.gdb.DEBUG_NAME" value="${cross_prefix}gdb${cross_suffix}"/>
+<booleanAttribute key="org.eclipse.cdt.dsf.gdb.UPDATE_THREADLIST_ON_SUSPEND" value="false"/>
+<intAttribute key="org.eclipse.cdt.launch.ATTR_BUILD_BEFORE_LAUNCH_ATTR" value="2"/>
+<stringAttribute key="org.eclipse.cdt.launch.COREFILE_PATH" value=""/>
+<stringAttribute key="org.eclipse.cdt.launch.DEBUGGER_REGISTER_GROUPS" value=""/>
+<stringAttribute key="org.eclipse.cdt.launch.PROGRAM_NAME" value="DebugMCHF\fw-mchf.elf"/>
+<stringAttribute key="org.eclipse.cdt.launch.PROJECT_ATTR" value="mchf-eclipse"/>
+<booleanAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_AUTO_ATTR" value="false"/>
+<stringAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_ID_ATTR" value="ilg.gnuarmeclipse.managedbuild.cross.config.elf.debug.433341838"/>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/mchf-eclipse"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="4"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.ui.favoriteGroups">
+<listEntry value="org.eclipse.debug.ui.launchGroup.debug"/>
+</listAttribute>
+<stringAttribute key="org.eclipse.dsf.launch.MEMORY_BLOCKS" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#13;&#10;&lt;memoryBlockExpressionList context=&quot;Context string&quot;/&gt;&#13;&#10;"/>
+<stringAttribute key="process_factory_id" value="org.eclipse.cdt.dsf.gdb.GdbProcessFactory"/>
+</launchConfiguration>

--- a/mchf-eclipse/MCHF-FW.launch
+++ b/mchf-eclipse/MCHF-FW.launch
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="ilg.gnumcueclipse.debug.gdbjtag.openocd.launchConfigurationType">
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doContinue" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doDebugInRam" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doFirstReset" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doGdbServerAllocateConsole" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doGdbServerAllocateTelnetConsole" value="false"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doSecondReset" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doStartGdbCLient" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.doStartGdbServer" value="true"/>
+<booleanAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.enableSemihosting" value="true"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.firstResetType" value="init"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbClientOtherCommands" value="set mem inaccessible-by-default off"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbClientOtherOptions" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerConnectionAddress" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerExecutable" value="C:\ARM\openocd-0.9.0\bin\openocd.exe"/>
+<intAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerGdbPortNumber" value="3333"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerLog" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerOther" value="-f support/MCHF.cfg"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerTclPortNumber" value="6666"/>
+<intAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.gdbServerTelnetPortNumber" value="4444"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.otherInitCommands" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.otherRunCommands" value=""/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.openocd.secondResetType" value="halt"/>
+<stringAttribute key="ilg.gnumcueclipse.debug.gdbjtag.svdPath" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.imageFileName" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.imageOffset" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.ipAddress" value="localhost"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.jtagDevice" value="GNU MCU OpenOCD"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadImage" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadSymbols" value="true"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.pcRegister" value=""/>
+<intAttribute key="org.eclipse.cdt.debug.gdbjtag.core.portNumber" value="3333"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setPcRegister" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setResume" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setStopAt" value="true"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.stopAt" value="main"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.symbolsFileName" value=""/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.symbolsOffset" value=""/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useFileForImage" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useFileForSymbols" value="false"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useProjBinaryForImage" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useProjBinaryForSymbols" value="true"/>
+<booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useRemoteTarget" value="true"/>
+<stringAttribute key="org.eclipse.cdt.dsf.gdb.DEBUG_NAME" value="${cross_prefix}gdb${cross_suffix}"/>
+<booleanAttribute key="org.eclipse.cdt.dsf.gdb.UPDATE_THREADLIST_ON_SUSPEND" value="false"/>
+<intAttribute key="org.eclipse.cdt.launch.ATTR_BUILD_BEFORE_LAUNCH_ATTR" value="2"/>
+<stringAttribute key="org.eclipse.cdt.launch.COREFILE_PATH" value=""/>
+<stringAttribute key="org.eclipse.cdt.launch.DEBUGGER_REGISTER_GROUPS" value=""/>
+<stringAttribute key="org.eclipse.cdt.launch.PROGRAM_NAME" value="DebugMCHF\fw-mchf.elf"/>
+<stringAttribute key="org.eclipse.cdt.launch.PROJECT_ATTR" value="mchf-eclipse"/>
+<booleanAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_AUTO_ATTR" value="false"/>
+<stringAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_ID_ATTR" value="ilg.gnuarmeclipse.managedbuild.cross.config.elf.debug.433341838"/>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/mchf-eclipse"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="4"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.ui.favoriteGroups">
+<listEntry value="org.eclipse.debug.ui.launchGroup.debug"/>
+</listAttribute>
+<stringAttribute key="org.eclipse.dsf.launch.MEMORY_BLOCKS" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#13;&#10;&lt;memoryBlockExpressionList context=&quot;Context string&quot;/&gt;&#13;&#10;"/>
+<stringAttribute key="process_factory_id" value="org.eclipse.cdt.dsf.gdb.GdbProcessFactory"/>
+</launchConfiguration>

--- a/mchf-eclipse/drivers/ui/lcd/ui_lcd_hy28.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_lcd_hy28.c
@@ -2240,7 +2240,7 @@ static void UiLcdHy28_SetCursorA_SSD1289( unsigned short Xpos, unsigned short Yp
 
 const uhsdr_display_info_t display_infos[] = {
         {
-                DISPLAY_NONE,  "No Display", NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0
+                DISPLAY_NONE,  "No Display", NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0
         },
 #ifdef USE_DISPLAY_PAR
 #ifdef USE_GFX_ILI9486
@@ -2392,7 +2392,7 @@ const uhsdr_display_info_t display_infos[] = {
         // RPI_SPI NEEDS TO BE LAST IN LIST!!!
 #endif
         {
-                DISPLAY_NUM, "Unknown", NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0
+                DISPLAY_NUM, "Unknown", NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0
         }
  };
 

--- a/mchf-eclipse/drivers/ui/lcd/ui_lcd_hy28.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_lcd_hy28.c
@@ -2285,6 +2285,21 @@ const uhsdr_display_info_t display_infos[] = {
         },
 #endif
 #endif
+#ifdef USE_GFX_RA8875
+        {
+                DISPLAY_RA8875_PARALLEL, "RA8875 Para.",
+				.ReadDisplayId = UiLcdHy28_ReadDisplayId_RA8875,
+                .SetActiveWindow = UiLcdHy28_SetActiveWindow_RA8875,
+                .SetCursorA = UiLcdHy28_SetCursorA_RA8875,
+                .WriteRAM_Prepare = UiLcdHy28_WriteRAM_Prepare_RA8875,
+				.WriteReg = UiLcdHy28_WriteRegRA8875,
+				.ReadReg = UiLcdHy28_ReadRegRA8875,
+				.DrawStraightLine = UiLcdHy28_DrawStraightLine_RA8875,
+				.DrawFullRect = UiLcdHy28_DrawFullRect_RA8875,
+				.DrawColorPoint = UiLcdHy28_DrawColorPoint_RA8875,
+
+        },
+#endif
 #endif
 
 #if  defined(USE_SPI_DISPLAY)
@@ -2328,37 +2343,7 @@ const uhsdr_display_info_t display_infos[] = {
 				.spi_speed=false
         },
 #endif
-#if defined(USE_GFX_ILI9486)
-        {       DISPLAY_RPI_SPI, "RPi 3.5 SPI",
-                .ReadDisplayId = UiLcdHy28_ReadDisplayId_ILI9486,
-                .SetActiveWindow = UiLcdHy28_SetActiveWindow_ILI9486,
-                .SetCursorA = UiLcdHy28_SetCursorA_ILI9486,
-                .WriteRAM_Prepare = UiLcdHy28_WriteRAM_Prepare_ILI9486,
-                .WriteDataSpiStart_Prepare = UiLcdHy28_WriteDataSpiStart_Prepare_ILI9486,
-                .WriteIndexSpi_Prepare = UiLcdHy28_WriteIndexSpi_Prepare_ILI9486,
-                .spi_cs_port = LCD_CSA_PIO,
-                .spi_cs_pin = LCD_CSA,
-                true, true
-        },
-        // RPI_SPI NEEDS TO BE LAST IN LIST!!!
-#endif
-#endif
 #ifdef USE_GFX_RA8875
-        {
-                DISPLAY_RA8875_PARALLEL, "RA8875 Para.",
-				.ReadDisplayId = UiLcdHy28_ReadDisplayId_RA8875,
-                .SetActiveWindow = UiLcdHy28_SetActiveWindow_RA8875,
-                .SetCursorA = UiLcdHy28_SetCursorA_RA8875,
-                .WriteRAM_Prepare = UiLcdHy28_WriteRAM_Prepare_RA8875,
-				.WriteReg = UiLcdHy28_WriteRegRA8875,
-				.ReadReg = UiLcdHy28_ReadRegRA8875,
-				.DrawStraightLine = UiLcdHy28_DrawStraightLine_RA8875,
-				.DrawFullRect = UiLcdHy28_DrawFullRect_RA8875,
-				.DrawColorPoint = UiLcdHy28_DrawColorPoint_RA8875,
-                .spi_cs_port = LCD_CSA_PIO,
-                .spi_cs_pin = LCD_CSA,
-
-        },
 		//currently RA8875 parallel interface supported only
 /*        {
                 DISPLAY_RA8875_SPI, "RA8875 SPI",
@@ -2367,11 +2352,16 @@ const uhsdr_display_info_t display_infos[] = {
                 .WriteRAM_Prepare = UiLcdHy28_WriteRAM_Prepare_RA8875,
                 .WriteDataSpiStart_Prepare = UiLcdHy28_WriteDataSpiStart_Prepare_RA8875,
                 .WriteIndexSpi_Prepare = UiLcdHy28_WriteIndexSpi_Prepare_RA8875,
+  				.WriteReg = UiLcdHy28_WriteRegRA8875,
+				.ReadReg = UiLcdHy28_ReadRegRA8875,
+				.DrawStraightLine = UiLcdHy28_DrawStraightLine_RA8875,
+				.DrawFullRect = UiLcdHy28_DrawFullRect_RA8875,
+				.DrawColorPoint = UiLcdHy28_DrawColorPoint_RA8875,
                 .spi_cs_port = LCD_CSA_PIO,
                 .spi_cs_pin = LCD_CSA,
                 true, false },*/
 #endif
-#if defined(USE_GFX_ILI9486) && defined(USE_SPI_DISPLAY)
+#if defined(USE_GFX_ILI9486)
         {       DISPLAY_RPI_SPI, "RPi 3.5 SPI",
                 .ReadDisplayId = UiLcdHy28_ReadDisplayId_ILI9486,
                 .SetActiveWindow = UiLcdHy28_SetActiveWindow_ILI9486,
@@ -2391,6 +2381,8 @@ const uhsdr_display_info_t display_infos[] = {
         },
         // RPI_SPI NEEDS TO BE LAST IN LIST!!!
 #endif
+#endif
+
         {
                 DISPLAY_NUM, "Unknown", NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0
         }

--- a/mchf-eclipse/drivers/ui/lcd/ui_lcd_hy28.h
+++ b/mchf-eclipse/drivers/ui/lcd/ui_lcd_hy28.h
@@ -110,7 +110,11 @@ typedef struct
     void (*WriteRAM_Prepare) ();
     void (*WriteDataSpiStart_Prepare)();
     void (*WriteIndexSpi_Prepare)();
-
+    void (*WriteReg)(unsigned short LCD_Reg, unsigned short LCD_RegValue);
+    uint16_t (*ReadReg)( uint16_t LCD_Reg);
+    void (*DrawStraightLine)(uint16_t x, uint16_t y, uint16_t Length, uint8_t Direction,uint16_t color);
+    void (*DrawFullRect)(uint16_t Xpos, uint16_t Ypos, uint16_t Height, uint16_t Width ,uint16_t color);
+    void (*DrawColorPoint)(uint16_t Xpos, uint16_t Ypos, uint16_t point);
     GPIO_TypeDef* spi_cs_port;
     uint16_t      spi_cs_pin;
     uint16_t      is_spi:1;
@@ -121,7 +125,7 @@ typedef struct
 typedef struct
 {
     uint8_t display_type;           // existence/identification of display type
-    uint16_t DeviceCode;      // LCD ident code
+    uint16_t DeviceCode;      		// LCD ident code
     bool use_spi;
     int16_t lcd_cs;
     uint16_t MAX_X;
@@ -133,6 +137,11 @@ typedef struct
     void (*WriteRAM_Prepare) ();
     void (*WriteDataSpiStart_Prepare)();
     void (*WriteIndexSpi_Prepare)();
+    void (*WriteReg)(unsigned short LCD_Reg, unsigned short LCD_RegValue);
+    uint16_t (*ReadReg)( uint16_t LCD_Reg);
+    void (*DrawStraightLine)(uint16_t x, uint16_t y, uint16_t Length, uint8_t Direction,uint16_t color);
+    void (*DrawFullRect)(uint16_t Xpos, uint16_t Ypos, uint16_t Height, uint16_t Width ,uint16_t color);
+    void (*DrawColorPoint)(uint16_t Xpos, uint16_t Ypos, uint16_t point);
 } mchf_display_t;
 
 extern mchf_display_t mchf_display;

--- a/mchf-eclipse/drivers/ui/lcd/ui_lcd_layouts.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_lcd_layouts.c
@@ -360,7 +360,81 @@ const LcdLayout LcdLayouts[LcdLayoutsCount]=
 				.MENU_TEXT_SIZE_MAX=40,
 
 				.touchaction_list=R480320_touch_regions
+		},
+		//-----------------------------------------------------------------
+		{		//800x480
+				.Size = { 800, 480},
+				.StartUpScreen_START ={ 80, 60},
+				.SpectrumWindow={ .x = 0, .y = 110, .w = 480, .h = 176 },
+				.SpectrumWindowPadding=0,
+
+				.TUNE_FREQ= { R480320_TUNE_FREQ_X, R480320_TUNE_FREQ_Y},
+				.TUNE_SPLIT_FREQ_X=R480320_TUNE_SPLIT_FREQ_X,
+				.TUNE_SPLIT_MARKER_X=R480320_TUNE_SPLIT_MARKER_X,
+				.TUNE_SPLIT_FREQ_Y_TX=R480320_TUNE_SPLIT_FREQ_Y_TX,
+				.TUNE_SFREQ = { R480320_TUNE_SFREQ_X, R480320_TUNE_SFREQ_Y},
+				.DisplayDbm = { R480320_DisplayDbm_X, R480320_DisplayDbm_Y},
+				.MEMORYLABEL = { R480320_MEMORYLABEL_X, R480320_MEMORYLABEL_Y},
+
+				.BAND_MODE = { R480320_BAND_MODE_X, R480320_BAND_MODE_Y},
+				.BAND_MODE_MASK = { .x = R480320_BAND_MODE_MASK_X, .y = R480320_BAND_MODE_MASK_Y, .h = R480320_BAND_MODE_MASK_H, .w= R480320_BAND_MODE_MASK_W},
+
+				.DEMOD_MODE_MASK = { .x = R480320_DEMOD_MODE_MASK_X, .y = R480320_DEMOD_MODE_MASK_Y, .h = R480320_DEMOD_MODE_MASK_H,
+                .w = R480320_DEMOD_MODE_MASK_W},
+				.AGC_MASK = {.x = R480320_AGC_MASK_X, .y = R480320_AGC_MASK_Y, .h = R480320_AGC_MASK_H,
+		                .w = R480320_AGC_MASK_W},
+				.TUNE_STEP={.x=R480320_TUNE_STEP_X, .y=R480320_TUNE_STEP_Y, .h=R480320_TUNE_STEP_MASK_H, .w=R480320_TUNE_STEP_MASK_W},
+
+				.ENCODER_IND = { R480320_ENCODER_IND_X, R480320_ENCODER_IND_Y},
+				.ENCODER_MODE=MODE_HORIZONTAL,
+
+				.DIGMODE={.x=R480320_DIGMODE_IND_X,.y=R480320_DIGMODE_IND_Y,.w=R480320_DIGMODE_IND_W},
+
+				.LEFTBOXES_IND = { .x=R480320_LEFTBOXES_IND_X, .y=R480320_LEFTBOXES_IND_Y, .w=R480320_LEFTBOX_WIDTH, .h=R480320_LEFTBOX_ROW_H},
+				.LEFTBOXES_MODE=MODE_HORIZONTAL,
+				.LEFTBOXES_ROW_2ND_OFF=R480320_LEFTBOX_ROW_2ND_OFF,
+
+				.PW_IND = { .x=R480320_PW_IND_X, .y=R480320_PW_IND_Y, .w=R480320_PW_IND_W},
+				.TEMP_IND={.x = 370,.y = 64},
+				.RTC_IND={.x = 415,.y = 80},
+
+				.LOADANDDEBUG_Y=96,
+				.DEBUG_X=0,
+				.LOAD_X=280,
+
+				.PWR_NUM_IND ={ 320, 96},
+
+				.CW_DECODER_WPM = { 420, 290},
+
+				.SNAP_CARRIER= { 242, 29},
+
+				.TextMsgLine = { 0, 290 },
+				.TextMsg_buffer_max=50,
+				.TextMsg_font=0,
+
+				//.FREEDV_SNR = { 280, 28},
+				//.FREEDV_BER = {380, 28},
+				.FREEDV_SNR = {410,288},
+				.FREEDV_BER = {410,297},
+				.FREEDV_FONT=4,
+
+				.SM_IND={.x = R480320_SM_IND_X, .y = R480320_SM_IND_Y, .h = R480320_SM_IND_H, .w = R480320_SM_IND_W},
+				.PWR_IND={ .x = 420, .y = 307},
+
+#ifdef UI_BRD_OVI40
+				.BOTTOM_BAR={.x=0,.y=308, .h=16, .w=74},
+#else
+				.BOTTOM_BAR={.x=32,.y=308, .h=16, .w=74},
+#endif
+				.MENUSIZE=14,
+				.MENU_IND = { 80, 110 },
+				.MENU_CHANGE_X=280,
+				.MENU_CURSOR_X=360,
+				.MENU_TEXT_SIZE_MAX=40,
+
+				.touchaction_list=R480320_touch_regions
 		}
+
 };
 
 

--- a/mchf-eclipse/drivers/ui/lcd/ui_lcd_layouts.h
+++ b/mchf-eclipse/drivers/ui/lcd/ui_lcd_layouts.h
@@ -37,7 +37,8 @@
 typedef enum
 {
     RESOLUTION_320_240,
-    RESOLUTION_480_320
+    RESOLUTION_480_320,
+	RESOLUTION_800_480
 } disp_resolution_t;
 
 typedef struct {
@@ -148,6 +149,7 @@ enum MODE_{
 enum LcdLayout_{
 	LcdLayout_320x240=0,
 	LcdLayout_480x320,
+	LcdLayout_800x480,
 	LcdLayoutsCount		//this is last position enumerated used for layout array definition. Insert new layout name before this one
 };
 

--- a/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
@@ -977,6 +977,11 @@ static void UiSpectrum_InitSpectrumDisplayData()
     	sd.fft_iq_len = 1024;
     	sd.cfft_instance = &arm_cfft_sR_f32_len512;
     	break;
+    case RESOLUTION_800_480:	//FIXME: fill with correct values (move to layouts.c ??)
+    	sd.spec_len = 512;
+    	sd.fft_iq_len = 1024;
+    	sd.cfft_instance = &arm_cfft_sR_f32_len512;
+    	break;
     }
 
 

--- a/mchf-eclipse/drivers/ui/menu/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu.c
@@ -502,7 +502,14 @@ const char* UiMenu_GetSystemInfo(uint32_t* m_clr_ptr, int info_item)
     {
         // const char* disp_com = ts.display_type==3?"parallel":"SPI";
         // snprintf(out,32,"ILI%04x %s",ts.DeviceCode,disp_com);
-        snprintf(out,32,"ILI%04x",ts.display->DeviceCode);
+    	if(ts.display->DeviceCode==0x8875)
+    	{
+    		snprintf(out,32,"RA%04x",ts.display->DeviceCode);
+    	}
+    	else
+    	{
+    		snprintf(out,32,"ILI%04x",ts.display->DeviceCode);
+    	}
         break;
     }
 #ifdef USE_OSC_SI570

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -5838,7 +5838,7 @@ void UiDriver_StartUpScreenFinish()
 	}
 	if (UiDriver_FirmwareVersionCheck())
 	{
-		hold_time = 10000; // 15s
+		hold_time = 10000; // 10s
 		txp = "Firmware change detected!\nPlease review settings!";
 		startUpScreen_nextLineY = UiLcdHy28_PrintTextCentered(ts.Layout->StartUpScreen_START.x,startUpScreen_nextLineY + 10,320,txp,White,Black,0);
 
@@ -5848,6 +5848,7 @@ void UiDriver_StartUpScreenFinish()
 	if(startUpError == true)
 	{
 		hold_time = 15000; // 15s
+		//hold_time = 3000; // 3s
 		txp = "Boot Delay because of Errors or Warnings";
 		clr = Red3;
 		fg_clr = Black;

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -4327,7 +4327,7 @@ static void UiDriver_DisplayModulationType()
 	// Draw line for box
 	UiLcdHy28_DrawStraightLine(ts.Layout->DIGMODE.x,(ts.Layout->DIGMODE.y - 1),ts.Layout->DIGMODE.w,LCD_DIR_HORIZONTAL,bgclr);
 	UiLcdHy28_PrintTextCentered(ts.Layout->DIGMODE.x,ts.Layout->DIGMODE.y,ts.Layout->DIGMODE.w,txt,color,bgclr,0);
-	if(disp_resolution==RESOLUTION_480_320)
+	if(disp_resolution!=RESOLUTION_320_240)
 	{
 		UiLcdHy28_DrawStraightLineDouble(ts.Layout->DIGMODE.x,ts.Layout->DIGMODE.y+12,ts.Layout->DIGMODE.w,LCD_DIR_HORIZONTAL,bgclr);
 		UiLcdHy28_DrawStraightLine(ts.Layout->DIGMODE.x,ts.Layout->DIGMODE.y+14,ts.Layout->DIGMODE.w,LCD_DIR_HORIZONTAL,Blue);

--- a/mchf-eclipse/hardware/uhsdr_board.h
+++ b/mchf-eclipse/hardware/uhsdr_board.h
@@ -82,6 +82,9 @@
   // SSD1289 support is not yet working, also requires USE_GFX_ILI932x to be enabled for now.
   // #define USE_GFX_SSD1289
   #define USE_DISP_480_320
+#if defined(STM32F7) || defined(STM32H7)
+  #define USE_GFX_RA8875
+#endif
 #endif
 
 #if !defined(USE_GFX_ILI932x) && !defined(USE_GFX_ILI9486)
@@ -91,8 +94,6 @@
 #define USE_FFT_1024
 
 #ifndef IS_SMALL_BUILD
-
-  #define USE_GFX_RA8875
   #define USE_8bit_FONT
   #define USE_PREDEFINED_WINDOW_DATA
 #endif

--- a/mchf-eclipse/hardware/uhsdr_board.h
+++ b/mchf-eclipse/hardware/uhsdr_board.h
@@ -91,6 +91,8 @@
 #define USE_FFT_1024
 
 #ifndef IS_SMALL_BUILD
+
+  #define USE_GFX_RA8875
   #define USE_8bit_FONT
   #define USE_PREDEFINED_WINDOW_DATA
 #endif


### PR DESCRIPTION
This driver is provided for use with F7/H7 cores.
Current parallel displays tested on OVI40 UI (F7) and mcHF (F4), SPI displays not checked.
RA8875 driver with parallel support, uses cloned layout from 480x320.

TODO: 
- Touch screen driver (internal resistive or/and external capacitive).
- New layout for 800x480