### PR TITLE
Disable MCP9801 warning if SoftTCXO is not enabled

### DIFF
--- a/mchf-eclipse/drivers/ui/menu/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu.c
@@ -1970,14 +1970,15 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
         temp_var_u8 = RadioManagement_TcxoGetMode();     // get current setting without upper nibble
         var_change = UiDriverMenuItemChangeUInt8(var, mode, &temp_var_u8,
                 0,
-                TCXO_TEMP_STATE_MAX,
-                                              TCXO_OFF,
+                TCXO_STATE_NUMBER-1,
+                                              TCXO_ON,
                                               1
                                              );
 
         if(lo.sensor_present == false)            // no sensor present
         {
             temp_var_u8 = TCXO_OFF; // force TCXO disabled
+            var_change = true;
         }
 
         RadioManagement_TcxoSetMode(temp_var_u8);   // overlay new temperature setting with old status of upper nibble

--- a/mchf-eclipse/drivers/ui/radio_management.h
+++ b/mchf-eclipse/drivers/ui/radio_management.h
@@ -61,12 +61,20 @@ typedef struct DialFrequency
 // Frequency public
 extern DialFrequency               df;
 
+typedef enum
+{
+    TCXO_OFF =              0,      // TXCO temperature compensation off,
+    TCXO_ON  =              1,      // TCXO temperature compensation on
+    TCXO_STOP =             2,      // TXCO temperature compensation off, but read temperature sensor
+    TCXO_STATE_NUMBER               // Maximum setting for TCXO setting state
+} Tcxo_Mode_t;
 
-inline uint8_t RadioManagement_TcxoGetMode()
+
+inline Tcxo_Mode_t RadioManagement_TcxoGetMode()
 {
     return (df.temp_enabled & TCXO_MODE_MASK);
 }
-inline void RadioManagement_TcxoSetMode(uint8_t mode)
+inline void RadioManagement_TcxoSetMode(Tcxo_Mode_t mode)
 {
     df.temp_enabled = (df.temp_enabled & ~TCXO_MODE_MASK) | (mode & TCXO_MODE_MASK) ;
 }

--- a/mchf-eclipse/drivers/ui/ui_configuration.c
+++ b/mchf-eclipse/drivers/ui/ui_configuration.c
@@ -61,7 +61,7 @@ const ConfigEntryDescriptor ConfigEntryInfo[] =
     { ConfigEntry_UInt8, EEPROM_SPEC_SCOPE_SPEED,&ts.scope_speed,SPECTRUM_SCOPE_SPEED_DEFAULT,0,SPECTRUM_SCOPE_SPEED_MAX},
     { ConfigEntry_UInt32_16, EEPROM_FREQ_STEP,&df.selected_idx,3,0,T_STEP_MAX_STEPS-2},
     { ConfigEntry_UInt8, EEPROM_TX_AUDIO_SRC,&ts.tx_audio_source,0,0,TX_AUDIO_MAX_ITEMS},
-    { ConfigEntry_UInt8, EEPROM_TCXO_STATE,&df.temp_enabled,TCXO_ON,0,255},
+    { ConfigEntry_UInt8, EEPROM_TCXO_STATE,&df.temp_enabled,TCXO_ON,0,TCXO_STATE_NUMBER-1},
     { ConfigEntry_UInt8, EEPROM_AUDIO_GAIN,&ts.rx_gain[RX_AUDIO_SPKR].value,AUDIO_GAIN_DEFAULT,0,AUDIO_GAIN_MAX},
     { ConfigEntry_UInt8, EEPROM_RX_CODEC_GAIN,&ts.rf_codec_gain,DEFAULT_RF_CODEC_GAIN_VAL,0,MAX_RF_CODEC_GAIN_VAL},
 //    { ConfigEntry_Int32_16, EEPROM_RX_GAIN,&ts.rf_gain,DEFAULT_RF_GAIN,0,MAX_RF_GAIN},

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -5822,7 +5822,9 @@ void UiDriver_StartUpScreenFinish()
 	uint32_t hold_time;
 
 	UiDriver_StartupScreen_LogIfProblem(osc->isPresent() == false, "Local Oscillator NOT Detected!");
-	if(!Si5351a_IsPresent()) {
+
+	if(!Si5351a_IsPresent() && RadioManagement_TcxoIsEnabled())
+	{
 		UiDriver_StartupScreen_LogIfProblem(lo.sensor_present == false, "MCP9801 Temp Sensor NOT Detected!");
 	}
 

--- a/mchf-eclipse/hardware/uhsdr_board.h
+++ b/mchf-eclipse/hardware/uhsdr_board.h
@@ -256,11 +256,6 @@ struct mchf_waterfall
 
 #define RTC_OSC_FREQ			32768
 
-#define	TCXO_OFF				0		// TXCO temperature compensation off
-#define	TCXO_ON					1		// TCXO temperature compensation on
-#define	TCXO_STOP				2		// Stop reading of temperature sensor
-#define	TCXO_TEMP_STATE_MAX		2		// Maximum setting for TCXO setting state
-
 // Transverter oscillator adds shift
 #define		TRANSVT_FREQ_A	 	42000000
 


### PR DESCRIPTION
This is to support owners of mcHF rev 0.6.1 / 0.6.2 which have no MCP9801.

Just set TCXO to OFF in the Standard menu.