### PR TITLE
Prepared code for change of frequency scaling

### DIFF
--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -5752,7 +5752,7 @@ static uint16_t fw_version_number_release = 0;
 static uint16_t fw_version_number_minor = 0;
 
 /**
- * @returns true if the firmware version is different from version in loaded configuraton settings.
+ * @returns true if the firmware version is different from version in loaded configuration settings.
  */
 static bool UiDriver_FirmwareVersionCheck()
 {

--- a/mchf-eclipse/hardware/uhsdr_board.h
+++ b/mchf-eclipse/hardware/uhsdr_board.h
@@ -253,13 +253,6 @@ struct mchf_waterfall
 // FreeDV USB LSB -  -  -  -
 
 
-
-#define RTC_OSC_FREQ			32768
-
-// Transverter oscillator adds shift
-#define		TRANSVT_FREQ_A	 	42000000
-
-//
 #define		MIN_FREQ_CAL		-1499		// Minimum and maximum range of frequency calibration in 10xppm
 #define		MAX_FREQ_CAL		1499
 //


### PR DESCRIPTION
Added conversion from 4x to 1x and back.
These get active if we reach 2.11.0 firmware version.
Please update 2.10.x  with this PR and release it. Should have been in 2.10.0
