### PR TITLE
Refactored Codec IQ/Audio Data Types

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_management.c
+++ b/mchf-eclipse/drivers/audio/audio_management.c
@@ -316,7 +316,7 @@ void AudioManagement_CalcSubaudibleGenFreq(void)
  */
 void AudioManagement_CalcSubaudibleDetFreq(void)
 {
-    const uint32_t size = BUFF_LEN/2;
+    const uint32_t size = AUDIO_SAMPLES_PER_BLOCK;
 
     ads.fm_conf.subaudible_tone_det_freq = fm_subaudible_tone_table[ts.fm_subaudible_tone_det_select];       // look up tone frequency (in Hz)
 

--- a/mchf-eclipse/drivers/audio/codec/codec.c
+++ b/mchf-eclipse/drivers/audio/codec/codec.c
@@ -87,7 +87,7 @@ typedef struct
 } mchf_codec_t;
 
 
-__IO mchf_codec_t mchf_codecs[DMA_AUDIO_NUM];
+__IO mchf_codec_t mchf_codecs[CODEC_NUM];
 
 #ifdef UI_BRD_OVI40
 /**

--- a/mchf-eclipse/drivers/audio/codec/uhsdr_hw_i2s.h
+++ b/mchf-eclipse/drivers/audio/codec/uhsdr_hw_i2s.h
@@ -15,26 +15,14 @@
 #ifndef __MCHF_HW_I2S_H
 #define __MCHF_HW_I2S_H
 
-// #define BUFF_LEN (2*(32*2)) // == 128
-#define BUFF_LEN 128
+#define IQ_SAMPLES_PER_BLOCK 32
+#define AUDIO_SAMPLES_PER_BLOCK 32
 
 /*
  * BUFF_LEN is derived from 2* 32 LR Samples per Audio-Interrupt (== 64 * int16_t )
  * since we get half of the buffer in each DMA Interrupt for processing
  */
-
-typedef struct
-{
-    int16_t out[BUFF_LEN];
-    int16_t in[BUFF_LEN];
-} dma_audio_buffer_t;
-
-
-#if defined(UI_BRD_MCHF)
-#define DMA_AUDIO_NUM 1
-#elif defined(UI_BRD_OVI40)
-#define DMA_AUDIO_NUM 2
-#endif
+// #define BUFF_LEN (4*IQ_SAMPLES_PER_BLOCK)
 
 void UhsdrHwI2s_Codec_StartDMA();
 void UhsdrHwI2s_Codec_StopDMA();

--- a/mchf-eclipse/drivers/usb/app/usbd_audio_if.c
+++ b/mchf-eclipse/drivers/usb/app/usbd_audio_if.c
@@ -45,6 +45,7 @@
 #include "usbd_audio_if.h"
 /* USER CODE BEGIN INCLUDE */
 #include "uhsdr_board.h"
+#include "audio_driver.h"
 /* USER CODE END INCLUDE */
 
 /** @addtogroup STM32_USB_OTG_DEVICE_LIBRARY
@@ -209,20 +210,21 @@ static void audio_out_buffer_pop_pkt(volatile int16_t* ptr, uint32_t len)
     }
 }
 
-/* len is length in 16 bit samples */
-void audio_out_fill_tx_buffer(int16_t *buffer, uint32_t len)
+/* len is length in  stereo  samples */
+void audio_out_fill_tx_buffer(AudioSample_t *buffer, uint32_t len)
 {
-    volatile int16_t *pkt = audio_out_buffer_next_pkt(len);
+    volatile int16_t *pkt = audio_out_buffer_next_pkt(2*len);
 
     static uint16_t fill_buffer = 1;
     if (fill_buffer == 0 && pkt)
     {
-        uint32_t idx;
-        for (idx = len; idx; idx--)
+        for (uint32_t idx = len; idx; idx--)
         {
-            *buffer++ = *pkt++;
+            buffer->l = *pkt++;
+            buffer->r = *pkt++;
+            buffer++;
         }
-        audio_out_buffer_pop_pkt(pkt,len);
+        audio_out_buffer_pop_pkt(pkt,2*len);
     }
     else
     {
@@ -236,10 +238,11 @@ void audio_out_fill_tx_buffer(int16_t *buffer, uint32_t len)
             fill_buffer = 0;
         }
         // Deliver silence if not enough data is stored in buffer
-        // TODO: Make this more efficient by providing 4byte aligned buffers only (and requesting len in 4 byte increments)
-        for (; len; len--)
+        for (uint32_t idx = len; idx; idx--)
         {
-            *buffer++=0;
+            buffer->l = 0;
+            buffer->r = 0;
+            buffer++;
         }
     }
 }

--- a/mchf-eclipse/drivers/usb/app/usbd_audio_if.h
+++ b/mchf-eclipse/drivers/usb/app/usbd_audio_if.h
@@ -52,6 +52,7 @@
 /* Includes ------------------------------------------------------------------*/
 #include "usbd_audio_cdc_comp.h"
 /* USER CODE BEGIN INCLUDE */
+#include "audio_driver.h"
 /* USER CODE END INCLUDE */
 
 /** @addtogroup STM32_USB_OTG_DEVICE_LIBRARY
@@ -124,7 +125,7 @@
 
 /* USER CODE BEGIN EXPORTED_FUNCTIONS */
   extern void audio_in_put_buffer(int16_t sample);
-  extern void audio_out_fill_tx_buffer(int16_t *buffer, uint32_t len);
+  void audio_out_fill_tx_buffer(AudioSample_t *buffer, uint32_t len);
 /* USER CODE END EXPORTED_FUNCTIONS */
 /**
   * @}

--- a/mchf-eclipse/hardware/uhsdr_board_config.h
+++ b/mchf-eclipse/hardware/uhsdr_board_config.h
@@ -50,10 +50,12 @@
 #define SI5351A_I2C				(&hi2c1)
 
 #define CODEC_I2C               (&hi2c2)
-#define CODEC_ANA_I2C               (&hi2c2)
-#define CODEC_IQ_I2C                (&hi2c2)
+#define CODEC_ANA_I2C           (&hi2c2)
+#define CODEC_IQ_I2C            (&hi2c2)
 
-#define SERIALEEPROM_I2C            (&hi2c2)
+#define CODEC_NUM               1
+
+#define SERIALEEPROM_I2C        (&hi2c2)
 
 // -----------------------------------------------------------------------------
 //						PORT PINS ALLOCATION
@@ -392,6 +394,8 @@
 
 #define CODEC_IQ_I2C                (&hi2c4)
 #define CODEC_IQ_SAI                SAI2
+
+#define CODEC_NUM               2
 
 #define SERIALEEPROM_I2C            (&hi2c2)
 


### PR DESCRIPTION
Use different types for the codec interface for different purposes (IQ and Audio data)

It is mostly renaming but a few functions have been changed a little more to simplify the code and make it more readable and robust. 

What we get:
- With a simple define we will be able to switch the bit width used for audio/iq samples (needs matching code for codec and I2S setup and possibly some scaling levels have to be adjusted, which is not yet done).
- On devices with 2 codecs IQ and audio sample bit widths can be differently set (e.g. 24bits for IQ, 16 bits for audio). On devices with a singled codec, the IQ bit width and audio bit width have to be identical.

