### PR TITLE
Review of UHSDR interface for HW interfaces.

### DIFF
--- a/mchf-eclipse/hardware/uhsdr_hw_fmc.c
+++ b/mchf-eclipse/hardware/uhsdr_hw_fmc.c
@@ -1,0 +1,185 @@
+/*  -*-  mode: c; tab-width: 4; indent-tabs-mode: t; c-basic-offset: 4; coding: utf-8  -*-  */
+/*************************************************************************************
+ **                                                                                 **
+ **                                        UHSDR                                    **
+ **               a powerful firmware for STM32 based SDR transceivers              **
+ **                                                                                 **
+ **---------------------------------------------------------------------------------**
+ **  Description:    FMC boundary. Provides wrappers for HW depended functions.     **
+ **  Last Modified:  rv9yw - m.chichikalov@outlook.com                              **
+ **                  2018-12-21 : Added this file and initial implementation.       **
+ **                                                                                 **
+ **  License:         GNU GPLv3                                                     **
+ ************************************************************************************/
+
+//TODO review dependencies !!!
+#include "uhsdr_board.h"
+#include "uhsdr_mcu.h"
+
+#include <assert.h>
+#include "uhsdr_hw_fmc.h"
+#include "locks.h"
+
+#ifdef UI_BRD_OVI40
+	#include "fmc.h"
+#else
+	#include "fsmc.h"
+#endif
+
+#define DEFAULT_FMC_TIMEOUT 100
+
+static volatile ushort* __address;
+
+// There is only one FMC in use, so implemented in more simple way than SPI.
+static HW_INTERFACE_t available_fmc[ ] = {
+    #if defined ( STM32F4 )
+         { (void*)&hdma_mem_to_mem, false, DEFAULT_FMC_TIMEOUT, NULL, MX_FSMC_Init, MX_FSMC_DeInit },
+    #elif defined ( STM32F7 ) || defined ( STM32H7 )
+         // FIXME correct code for F7 and H7
+        #error "Not added mem-to-mem for F7 and H7."
+         { (void*)&hdma_mem_to_mem, false, DEFAULT_FMC_TIMEOUT, NULL, MX_FSMC_Init(), NULL },
+    #else
+        #error "For now! UHSDR supports only stm32 MCU."
+    #endif
+
+    #if defined ( SOME_OTHERS_MCU )
+    #endif
+};
+
+int32_t UHSDR_FMC_RequestTransaction ( UHSDR_INTERFACE_t* uhsdr_fmc, uint32_t time_out ) // take SPI semaphore
+{
+    // We do not save uhsdr_fmc as a parent as we have only one fmc interface
+    return sem_take ( &uhsdr_fmc->hw->lock, time_out );
+}
+
+void UHSDR_FMC_CloseTransaction ( UHSDR_INTERFACE_t* uhsdr_fmc ) // give back SPI semaphore
+{
+    sem_give ( &uhsdr_fmc->hw->lock );
+}
+
+//call back on DMA done for memory-to-memory
+static void MEM_TO_MEM_TxCpltCallback ( DMA_HandleTypeDef *_hdma )
+{
+    //Using fixed pointer to dma handler as we have only one fmc interface.
+    if ( _hdma == &hdma_mem_to_mem )
+    {
+        __DMB ( );
+        // give back FMC semaphore
+        UHSDR_FMC_CloseTransaction ( available_fmc[ __UHSDR_FMC_DISPLAY__ ].parent );
+    }
+}
+
+void UHSDR_FMC_Send_Polling ( UHSDR_INTERFACE_t* uhsdr_fmc, uint8_t* source, uint16_t size,
+        IO_bitwidth_e width )
+{
+    (void) (uhsdr_fmc);
+    assert( source );
+    assert( size );
+
+    if ( width == DATA_16_BIT )
+    {
+        ushort* __source = (uint16_t*)source;
+        while ( size-- )
+        {
+            *__address = *__source++;
+        }
+    }
+    else
+    {
+        while ( size-- )
+        {
+            *__address = *source++;
+        }
+    }
+
+    __DMB ( );
+}
+
+//	TODO
+void UHSDR_FMC_Receive_Polling ( UHSDR_INTERFACE_t* uhsdr_fmc, uint8_t* buffer, uint16_t size,
+        IO_bitwidth_e width )
+{
+    assert( buffer );
+    assert( size );
+    assert( false );
+}
+
+// FIXME remove later
+void UHSDR_FMC_SendReceive_Polling ( UHSDR_INTERFACE_t* uhsdr_fmc, uint8_t* tx_buffer,
+        uint8_t* rx_buffer, uint16_t size, IO_bitwidth_e width )
+{
+    assert( rx_buffer );
+    assert( tx_buffer );
+    assert( size );
+    assert( false ); // FAILED
+}
+
+void UHSDR_FMC_Send_DMA ( UHSDR_INTERFACE_t* uhsdr_fmc, uint8_t* source, uint16_t size,
+        IO_bitwidth_e width )
+{
+    assert( source );
+    assert( size );
+
+    HAL_DMA_Start_IT ( &hdma_mem_to_mem, (uint32_t)source, (uint32_t)__address, size );
+}
+
+void UHSDR_FMC_Receive_DMA ( UHSDR_INTERFACE_t* uhsdr_fmc, uint8_t* source, uint16_t size,
+        IO_bitwidth_e width )
+{
+    (void) (uhsdr_fmc);
+    assert( source );
+    assert( size );
+    assert( false ); // FAILED
+    // FIXME not implemented
+}
+
+static int32_t UHSDR_FMC_Init ( UHSDR_INTERFACE_t* uhsdr_fmc )
+{
+    uhsdr_fmc->hw->parent = uhsdr_fmc; // save as parent to use from irq callback
+
+    uhsdr_fmc->hw->Init ( );
+    HAL_DMA_RegisterCallback ( &hdma_mem_to_mem, HAL_DMA_XFER_CPLT_CB_ID,
+            MEM_TO_MEM_TxCpltCallback );
+    return 0;
+}
+
+static int32_t UHSDR_FMC_DeInit ( UHSDR_INTERFACE_t* uhsdr_fmc )
+{
+    uhsdr_fmc->hw->DeInit ( );
+    return 0;
+}
+
+const IO_t FMC_IO = {
+    .Init               = UHSDR_FMC_Init,
+    .DeInit             = UHSDR_FMC_DeInit,
+
+    .RequestTransaction = UHSDR_FMC_RequestTransaction,
+    .CloseTransaction   = UHSDR_FMC_CloseTransaction,
+
+    .Send_DMA           = UHSDR_FMC_Send_DMA,
+    .Receive_DMA        = UHSDR_FMC_Receive_DMA,
+
+    .Send_Polling       = UHSDR_FMC_Send_Polling,
+    .Receive_Polling    = UHSDR_FMC_Receive_Polling,
+};
+
+inline void UHSDR_FMC_SetAddress ( volatile uint16_t* address )
+{
+    assert( address);
+
+    __address = address;
+}
+
+inline void UHSDR_FMC_SetTimeout ( UHSDR_INTERFACE_t* uhsdr_fmc, uint32_t time_out )
+{
+    assert( uhsdr_fmc );
+    assert( uhsdr_fmc->hw );
+
+    uhsdr_fmc->hw->time_out = time_out;
+}
+
+void UHSDR_FMC_GetInstance ( UHSDR_INTERFACE_t* uhsdr_fmc, fmc_e fmc_name )
+{
+    uhsdr_fmc->IO = &FMC_IO;
+    uhsdr_fmc->hw = &available_fmc[ fmc_name ];
+}

--- a/mchf-eclipse/hardware/uhsdr_hw_fmc.h
+++ b/mchf-eclipse/hardware/uhsdr_hw_fmc.h
@@ -1,0 +1,69 @@
+/*  -*-  mode: c; tab-width: 4; indent-tabs-mode: t; c-basic-offset: 4; coding: utf-8  -*-  */
+/*************************************************************************************
+ **                                                                                 **
+ **                                        UHSDR                                    **
+ **               a powerful firmware for STM32 based SDR transceivers              **
+ **                                                                                 **
+ **---------------------------------------------------------------------------------**
+ **  Description:    FMC boundary. Provides wrappers for HW depended functions.     **
+ **  Last Modified:  rv9yw - m.chichikalov@outlook.com                              **
+ **                  2018-12-20 : Added this file and initial implementation.       **
+ **                                                                                 **
+ **   static UHSDR_INTERFACE_t uhsdr_lcd; // statically allocated mem for struct    **
+ **                                                                                 **
+ **   UHSDR_FMC_GetInstance ( &uhsdr_lcd, __UHSDR_FMC_DISPLAY__ );                  **
+ **   uhsdr_lcd.IO->Init( &uhsdr_lcd );                                             **
+ **   UHSDR_FMC_SetAddress( volatile ushort* Address );                             **
+ **                                                                                 **
+ **   after this is done any functions could be called like                         **
+ **                                                                                 **
+ **   uhsdr_lcd.IO->Send_Polling( &uhsdr_lcd, ... );                                **
+ **   uhsdr_lcd.IO->Receive_Polling( &uhsdr_lcd, ... );                             **
+ **   uhsdr_lcd.IO->Send_DMA( &uhsdr_lcd, ... );                                    **
+ **                                                                                 **
+ **   it can simply be switched to use another interface                            **
+ **   UHSDR_SPI_GetInstance ( &uhsdr_lcd, __UHSDR_SPI_DISPLAY__ );                  **
+ **                                                                                 **
+ **                                                                                 **
+ **  License:         GNU GPLv3                                                     **
+ ************************************************************************************/
+
+#ifndef __MCHF_HW_FMC_H
+#define __MCHF_HW_FMC_H
+
+#include "uhsdr_types.h"
+#include "uhsdr_structs.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum
+{
+    #if defined ( STM32F4 ) || defined ( STM32F7 ) || defined ( STM32H7 )
+        __UHSDR_FMC_DISPLAY__ = 0,
+    #endif
+        NUMBER_OF_USED_FMC, // should be the last in enum.
+} fmc_e;
+
+/*
+ * TODO
+ */
+void UHSDR_FMC_GetInstance ( UHSDR_INTERFACE_t* uhsdr_fmc, fmc_e fmc_name );
+
+/*
+ * TODO
+ */
+void UHSDR_FMC_SetAddress( volatile uint16_t* Address );
+
+/*
+ * TODO
+ */
+void UHSDR_FMC_SetTimeout ( UHSDR_INTERFACE_t* uhsdr_spi, uint32_t time_out );
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __MCHF_HW_FMC_H

--- a/mchf-eclipse/hardware/uhsdr_hw_spi.c
+++ b/mchf-eclipse/hardware/uhsdr_hw_spi.c
@@ -1,0 +1,272 @@
+/*  -*-  mode: c; tab-width: 4; indent-tabs-mode: t; c-basic-offset: 4; coding: utf-8  -*-  */
+/*************************************************************************************
+ **                                                                                 **
+ **                                        UHSDR                                    **
+ **               a powerful firmware for STM32 based SDR transceivers              **
+ **                                                                                 **
+ **---------------------------------------------------------------------------------**
+ **  Description:    SPI boundary. Provides wrappers for HW depended functions.     **
+ **  Last Modified:  rv9yw - m.chichikalov@outlook.com                              **
+ **                  2018-12-20 : Added this file and initial implementation.       **
+ **                                                                                 **
+ **  License:        GNU GPLv3                                                      **
+ ************************************************************************************/
+#include <assert.h>
+#include "locks.h"
+
+//TODO review dependencies !!!
+#include "uhsdr_board.h"
+#include "uhsdr_mcu.h"
+#include "spi.h"
+
+#include "uhsdr_hw_spi.h"
+//#include "unity.h"
+
+#define DEFAULT_SPI_TIMEOUT ( 200U ) // TODO review when RTOS added
+
+#if defined ( STM32F7 ) || defined ( STM32H7 ) || defined ( STM32F4 )
+    #define SPI_HW_CAST_TYPE (SPI_HandleTypeDef*)
+#elif defined ( SOME_OTHER_ARCH_CPU )
+    #error "For now! UHSDR supports only stm32 MCU."
+#endif
+
+// all spi should be at the same order as spi_e ENUM.
+static HW_INTERFACE_t available_spi[ ] = {
+    #if defined ( STM32F4 ) || defined ( STM32F7 ) || defined ( STM32H7 )
+         { (void*)&hspi2, false, DEFAULT_SPI_TIMEOUT, NULL, MX_SPI2_Init, MX_SPI2_DeInit },
+    #endif
+    #if defined ( STM32F7 ) || defined ( STM32H7 )
+        { (void*)&hspi3, false, DEFAULT_SPI_TIMEOUT, NULL, MX_SPI3_Init, MX_SPI3_DeInit },
+        { (void*)&hspi6, false, DEFAULT_SPI_TIMEOUT, NULL, MX_SPI6_Init, MX_SPI6_DeInit },
+    #endif
+};
+
+static int32_t UHSDR_SPI_Init ( UHSDR_INTERFACE_t* uhsdr_spi )
+{
+    assert( uhsdr_spi );
+
+    // STM32_HAL links dma into SPI handler in spi.c
+    // can be accessed by ( SPI_HW_CAST_TYPE uhsdr_spi->hw->handler)->hdmatx
+    uhsdr_spi->hw->Init ( );
+    return 0; // FIXME should we return status?
+}
+
+static int32_t UHSDR_SPI_DeInit ( UHSDR_INTERFACE_t* uhsdr_spi )
+{
+    assert( uhsdr_spi );
+
+    uhsdr_spi->hw->DeInit ( );
+    return 0; // FIXME should we return status?
+}
+
+static int32_t UHSDR_SPI_RequestTransaction ( UHSDR_INTERFACE_t* uhsdr_spi, uint32_t time_out )
+{
+    assert( uhsdr_spi );
+    assert( uhsdr_spi->extra_parameter.spi.cs.GPIO_port );
+
+    int retval = sem_take ( &uhsdr_spi->hw->lock, time_out );
+
+    // FIXME now the dummy semaphore implementation returns only ERR_NONE
+    if ( retval == UHSDR_ERR_NONE )
+    {
+        uhsdr_spi->hw->parent = uhsdr_spi; // save as a parent to restore in irq handler
+
+        // FIXME should get rid of dependency of GPIO_TypeDef from here.
+        GPIO_ResetBits(( GPIO_TypeDef* ) uhsdr_spi->extra_parameter.spi.cs.GPIO_port,
+                uhsdr_spi->extra_parameter.spi.cs.GPIO_pin );
+    }
+    return retval;
+}
+
+static void UHSDR_SPI_CloseTransaction ( UHSDR_INTERFACE_t* uhsdr_spi ) // give back SPI semaphore
+{
+    assert( uhsdr_spi );
+    assert( uhsdr_spi->extra_parameter.spi.cs.GPIO_port );
+
+    GPIO_SetBits( (GPIO_TypeDef* )uhsdr_spi->extra_parameter.spi.cs.GPIO_port,
+            uhsdr_spi->extra_parameter.spi.cs.GPIO_pin );
+    sem_give ( &uhsdr_spi->hw->lock );
+}
+
+void HAL_SPI_TxCpltCallback ( SPI_HandleTypeDef *hspi )
+{
+    uint32_t idx = NUMBER_OF_USED_SPI;
+    do
+    {
+        if ( hspi == available_spi[ idx ].handler )
+        {
+            UHSDR_SPI_CloseTransaction ( available_spi[ idx ].parent ); // give back SPI semaphore
+        }
+    } while ( --idx );
+}
+
+static inline void UHSDR_SPI_SetBitWidth( UHSDR_INTERFACE_t* uhsdr_spi, uint32_t width )
+{
+    assert( uhsdr_spi );
+    assert( width != DATA_32_BIT); // supported only by H7
+
+    uint32_t bit_width;
+    bit_width = ( width & ( ~SPI_DMA_mask )); // clear value from DMA settings
+    ( SPI_HW_CAST_TYPE uhsdr_spi->hw->handler)->Init.DataSize = bit_width;
+
+    #if defined ( STM32F4 )
+        MODIFY_REG(( SPI_HW_CAST_TYPE uhsdr_spi->hw->handler)->Instance->CR1, SPI_CR1_DFF, bit_width );
+    #elif defined ( STM32F7 )
+        MODIFY_REG(( SPI_HW_CAST_TYPE uhsdr_spi->hw->handler)->Instance->CR2, SPI_CR2_DS, bit_width );
+        #warning "Not tested on F7."
+    #elif defined ( STM32H7 )
+        MODIFY_REG(( SPI_HW_CAST_TYPE uhsdr_spi->hw->handler)->Instance->CFG1, SPI_CFG1_DSIZE, bit_width );
+        #warning "Not tested on H7."
+    #endif
+}
+
+static inline void UHSDR_SPI_SetDMA_Settings( UHSDR_INTERFACE_t* uhsdr_spi, uint32_t settings )
+{
+    assert( uhsdr_spi );
+
+    #if defined ( STM32F4 ) || defined ( STM32F7 ) || defined ( STM32H7 )
+    uint32_t mask = DMA_SxCR_PSIZE | DMA_SxCR_MSIZE | DMA_SxCR_MINC;
+    uint32_t set = DMA_MDATAALIGN_BYTE | DMA_PDATAALIGN_BYTE | DMA_MINC_DISABLE;
+
+    if (( settings & ( ~SPI_DMA_mask )) == SPI_16_BIT )
+    {
+        set |= DMA_MDATAALIGN_HALFWORD | DMA_PDATAALIGN_HALFWORD;
+    }
+
+    if (( settings & ( ~SPI_DATASIZE_mask )) == SPI_DMA_NORMAL_MODE )
+    {
+        set |= DMA_MINC_ENABLE;
+    }
+
+    MODIFY_REG(( SPI_HW_CAST_TYPE uhsdr_spi->hw->handler)->hdmatx->Instance->CR, mask, set );
+    #endif
+}
+
+static void UHSDR_SPI_Send_Polling ( UHSDR_INTERFACE_t* uhsdr_spi, uint8_t* source, uint16_t size,
+        uint32_t width )
+{
+    assert( source );
+    assert( size );
+
+    UHSDR_SPI_SetBitWidth( uhsdr_spi, width );
+    HAL_SPI_Transmit ( SPI_HW_CAST_TYPE( uhsdr_spi->hw->handler ), source, size, uhsdr_spi->hw->time_out );
+}
+
+static void UHSDR_SPI_Receive_Polling ( UHSDR_INTERFACE_t* uhsdr_spi, uint8_t* buffer, uint16_t size,
+        uint32_t width )
+{
+    assert( buffer );
+    assert( size );
+
+//	FIXME handle different size
+    HAL_SPI_Receive ( SPI_HW_CAST_TYPE( uhsdr_spi->hw->handler ), buffer, size, uhsdr_spi->hw->time_out );
+}
+
+static void UHSDR_SPI_SendReceive_Polling ( UHSDR_INTERFACE_t* uhsdr_spi, uint8_t* tx_buffer,
+        uint8_t* rx_buffer, uint16_t size, uint32_t width )
+{
+    assert( rx_buffer );
+    assert( tx_buffer );
+    assert( size );
+
+//	FIXME handle different size
+    HAL_SPI_TransmitReceive ( SPI_HW_CAST_TYPE (uhsdr_spi->hw->handler), tx_buffer, rx_buffer,
+            size, uhsdr_spi->hw->time_out );
+}
+
+// FIXME DMA works only with 16 bit data now.
+// 'settings' could be as OR of next parameters
+// (  SPI_8_BIT | SPI_DMA_CIRCULAR_MODE )
+// ( SPI_16_BIT | SPI_DMA_NORMAL_MODE )
+static void UHSDR_SPI_Send_DMA ( UHSDR_INTERFACE_t* uhsdr_spi, uint8_t* source, uint16_t size,
+        uint32_t settings )
+{
+    assert( source );
+    assert( size );
+
+#if defined ( STM32H7 )
+    assert(( width & ( ~SPI_DMA_mask )) != SPI_32_BIT );
+#endif
+
+    UHSDR_SPI_SetBitWidth( uhsdr_spi, settings );
+    UHSDR_SPI_SetDMA_Settings( uhsdr_spi, settings );
+
+    HAL_SPI_Transmit_DMA ( SPI_HW_CAST_TYPE (uhsdr_spi->hw->handler), source, size );
+}
+
+// We are not using HDMA to RX over SPI. Maybe will implement later.
+static void UHSDR_SPI_Receive_DMA ( UHSDR_INTERFACE_t* uhsdr_spi, uint8_t* source, uint16_t size,
+        uint32_t width )
+{
+    (void) (uhsdr_spi);
+    (void) (source);
+    (void) (size);
+    (void) (width);
+    assert( false ); // Failed if called
+}
+
+static const IO_t SPI_IO = {
+    .Init               = UHSDR_SPI_Init,
+    .DeInit             = UHSDR_SPI_DeInit,
+    .RequestTransaction = UHSDR_SPI_RequestTransaction,
+    .CloseTransaction   = UHSDR_SPI_CloseTransaction,
+    .Send_DMA           = UHSDR_SPI_Send_DMA,
+    .Send_Polling       = UHSDR_SPI_Send_Polling,
+    .Receive_Polling    = UHSDR_SPI_Receive_Polling,
+    .Receive_DMA        = UHSDR_SPI_Receive_DMA,
+    // FIXME remove this one after replace call of this to regular send and receive in
+    // touch driver.
+    .SendReceive_Polling= UHSDR_SPI_SendReceive_Polling,
+};
+
+void UHSDR_SPI_GetInstance ( UHSDR_INTERFACE_t* uhsdr_spi, spi_e spi_name )
+{
+    assert( uhsdr_spi );
+
+    uhsdr_spi->IO = &SPI_IO;
+    uhsdr_spi->hw = &available_spi[ spi_name ];
+}
+
+spi_speed_clock_e UHSDR_SPI_ChangeClockSpeed ( UHSDR_INTERFACE_t* uhsdr_spi, spi_speed_clock_e speed )
+{
+    assert( uhsdr_spi );
+
+    spi_speed_clock_e retval;
+    #if defined ( STM32F4 ) || defined ( STM32F7 ) || defined ( STM32H7 )
+        retval = ( SPI_HW_CAST_TYPE uhsdr_spi->hw->handler)->Init.BaudRatePrescaler;
+        ( SPI_HW_CAST_TYPE uhsdr_spi->hw->handler)->Init.BaudRatePrescaler = speed;
+
+        // FIXME not checked that SPI is disabled and value of register can be adjusted.
+        // However, RequestTransaction() before calling this one protects from changing
+        // at not proper time.
+        #if defined ( STM32F4 )
+            MODIFY_REG(( SPI_HW_CAST_TYPE uhsdr_spi->hw->handler)->Instance->CR1,
+                    SPI_CR1_BR, speed );
+        #elif defined ( STM32F7 )
+            #warning "Changing SPI clock is not tested on F7."
+            MODIFY_REG(( SPI_HW_CAST_TYPE uhsdr_spi->hw->handler)->Instance->CR1,
+                    SPI_CR1_BR, speed );
+        #elif defined ( STM32H7 )
+            #warning "Changing SPI clock is not tested on H7."
+            MODIFY_REG(( SPI_HW_CAST_TYPE uhsdr_spi->hw->handler)->Instance->CFG1,
+                    ( 0x7U << ( 28U )), speed );
+        #endif
+
+    #else // defined ( STM32F4 ) || defined ( STM32F7 ) || defined ( STM32H7 )
+        #error "For now! UHSDR supports only stm32 MCU."
+    #endif // defined ( STM32F4 ) || defined ( STM32F7 ) || defined ( STM32H7 )
+    return retval; // Return previous value
+}
+
+inline void UHSDR_SPI_SetTimeout ( UHSDR_INTERFACE_t* uhsdr_spi, uint32_t time_out )
+{
+    assert( uhsdr_spi );
+    assert( uhsdr_spi->hw );
+    uhsdr_spi->hw->time_out = time_out;
+}
+
+inline void UHSDR_SPI_SetChipSelectPin ( UHSDR_INTERFACE_t* uhsdr_spi, dio_t* cs )
+{
+    assert( uhsdr_spi );
+    uhsdr_spi->extra_parameter.spi.cs = *cs;
+}

--- a/mchf-eclipse/hardware/uhsdr_hw_spi.h
+++ b/mchf-eclipse/hardware/uhsdr_hw_spi.h
@@ -1,0 +1,170 @@
+/*  -*-  mode: c; tab-width: 4; indent-tabs-mode: t; c-basic-offset: 4; coding: utf-8  -*-  */
+/*************************************************************************************
+ **                                                                                 **
+ **                                        UHSDR                                    **
+ **               a powerful firmware for STM32 based SDR transceivers              **
+ **                                                                                 **
+ **---------------------------------------------------------------------------------**
+ **  Description:    SPI boundary. Provides wrappers for HW depended functions.     **
+ **  Last Modified:  rv9yw - m.chichikalov@outlook.com                              **
+ **                  2018-12-20 : Added this file and initial implementation.       **
+ **                                                                                 **
+ **  License:        GNU GPLv3                                                      **
+ ************************************************************************************/
+
+#ifndef __MCHF_HW_SPI_H
+#define __MCHF_HW_SPI_H
+
+#include "uhsdr_types.h"
+#include "uhsdr_structs.h"
+
+// FIXME temporary workaround to avoid including uhsdr_mcu.h and all HAL_STM32 with it
+// TODO needs to be moved to config file, after it will have been refactoring
+#if defined( CORTEX_M7 )
+    #ifdef STM32H743xx
+        #define STM32H7
+    #else
+        #define STM32F7
+    #endif
+#elif defined( CORTEX_M4 )
+    #define STM32F4
+#else
+    #error "CORTEX_M7 or CORTEX_M4 should be defined."
+#endif
+
+// SPI_BAUDRATEs redefined to NOT expose the STM32HAL library to every one who includes this...
+// TODO -> try to find more elegant way.
+#if !defined ( SPI_BAUDRATEPRESCALER_2 ) && ( defined ( STM32F4 ) || defined ( STM32F7 ))
+    #define SPI_BAUDRATEPRESCALER_2         ((uint32_t)0x00000000U)
+    #define SPI_BAUDRATEPRESCALER_4         ((uint32_t)0x00000008U)
+    #define SPI_BAUDRATEPRESCALER_8         ((uint32_t)0x00000010U)
+    #define SPI_BAUDRATEPRESCALER_16        ((uint32_t)0x00000018U)
+    #define SPI_BAUDRATEPRESCALER_32        ((uint32_t)0x00000020U)
+    #define SPI_BAUDRATEPRESCALER_64        ((uint32_t)0x00000028U)
+    #define SPI_BAUDRATEPRESCALER_128       ((uint32_t)0x00000030U)
+    #define SPI_BAUDRATEPRESCALER_256       ((uint32_t)0x00000038U)
+#elif !defined ( SPI_BAUDRATEPRESCALER_2 ) && defined ( STM32H7 )
+    #define SPI_BAUDRATEPRESCALER_2         (0x00000000U)
+    #define SPI_BAUDRATEPRESCALER_4         (0x10000000U)
+    #define SPI_BAUDRATEPRESCALER_8         (0x20000000U)
+    #define SPI_BAUDRATEPRESCALER_16        (0x30000000U)
+    #define SPI_BAUDRATEPRESCALER_32        (0x40000000U)
+    #define SPI_BAUDRATEPRESCALER_64        (0x50000000U)
+    #define SPI_BAUDRATEPRESCALER_128       (0x60000000U)
+    #define SPI_BAUDRATEPRESCALER_256       (0x70000000U)
+#endif
+
+typedef enum
+{
+#if defined ( STM32F4 )
+    SPI_clock_VeryFast = SPI_BAUDRATEPRESCALER_2,
+    SPI_clock_Medium   = SPI_BAUDRATEPRESCALER_4,
+    SPI_clock_VerySlow = SPI_BAUDRATEPRESCALER_64,
+#elif defined ( STM32F7 )
+    SPI_clock_VeryFast = SPI_BAUDRATEPRESCALER_4,
+    SPI_clock_Medium   = SPI_BAUDRATEPRESCALER_8,
+    SPI_clock_VerySlow = SPI_BAUDRATEPRESCALER_128,
+#elif defined ( STM32H7 )
+    SPI_clock_VeryFast = SPI_BAUDRATEPRESCALER_4,
+    SPI_clock_Medium   = SPI_BAUDRATEPRESCALER_8,
+    SPI_clock_VerySlow = SPI_BAUDRATEPRESCALER_32,
+#endif
+} spi_speed_clock_e;
+
+// TODO -> try to find more elegant way.
+#if !defined ( SPI_DATASIZE_8BIT ) && defined ( STM32F4 )
+    #define SPI_DATASIZE_8BIT               ((uint32_t)0x00000000U)
+    #define SPI_DATASIZE_16BIT              ((uint32_t)(0x1U << ( 11U )))
+#elif !defined ( SPI_BAUDRATEPRESCALER_2 ) && defined ( STM32F7 )
+    #define SPI_DATASIZE_8BIT               ((uint32_t)0x00000700U)
+    #define SPI_DATASIZE_16BIT              ((uint32_t)0x00000F00U)
+#elif !defined ( SPI_BAUDRATEPRESCALER_2 ) && defined ( STM32H7 )
+    #define SPI_DATASIZE_8BIT               ((uint32_t)(0x00000007U))
+    #define SPI_DATASIZE_16BIT              ((uint32_t)(0x0000000FU))
+    #define SPI_DATASIZE_32BIT              ((uint32_t)(0x0000001FU))
+#endif
+
+#if !defined ( DMA_MINC_ENABLE ) && ( defined(STM32F4) || defined(STM32F7) ||defined(STM32H7))
+    #define DMA_MINC_ENABLE         ((uint32_t)(0x1U << 10 ))  /*!< Memory increment mode enable  */
+    #define DMA_MINC_DISABLE        ((uint32_t)0x00000000U)     /*!< Memory increment mode disable */
+#endif
+
+/*
+ * \brief Described the SPI dma mode
+ */
+typedef enum
+{
+#if defined ( STM32F4 )
+    SPI_8_BIT   = SPI_DATASIZE_8BIT,
+    SPI_16_BIT  = SPI_DATASIZE_16BIT,
+    SPI_DATASIZE_mask = SPI_DATASIZE_16BIT,
+#endif
+#if defined ( STM32F7 )
+    SPI_8_BIT   = SPI_DATASIZE_8BIT,
+    SPI_16_BIT  = SPI_DATASIZE_16BIT,
+    SPI_DATASIZE_mask = SPI_DATASIZE_16BIT,
+#endif
+#if defined ( STM32H7 )
+    SPI_8_BIT   = SPI_DATASIZE_8BIT,
+    SPI_16_BIT  = SPI_DATASIZE_16BIT,
+    SPI_32_BIT  = SPI_DATASIZE_32BIT,
+    SPI_DATASIZE_mask = SPI_DATASIZE_32BIT,
+#endif
+} SPI_bitwidth_e;
+
+/*
+ * \brief Described the SPI dma mode
+ */
+typedef enum
+{
+#if defined ( STM32F4 ) || defined ( STM32F7 ) || defined ( STM32H7 )
+    SPI_DMA_NORMAL_MODE    = DMA_MINC_ENABLE,
+    SPI_DMA_CIRCULAR_MODE  = DMA_MINC_DISABLE,
+    SPI_DMA_mask           = DMA_MINC_ENABLE,
+#endif
+} SPI_DMA_mode_e;
+
+typedef enum
+{
+#if defined ( STM32F4 ) || defined ( STM32F7 ) || defined ( STM32H7 )
+    __UHSDR_SPI2_DISPLAY__ = 0,
+#endif
+#if defined ( STM32F7 ) || defined ( STM32H7 )
+    __UHSDR_SPI3__,
+    __UHSDR_SPI6__,
+#endif
+
+    NUMBER_OF_USED_SPI, // should be the last in enum.
+} spi_e;
+
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*
+ * TODO
+ */
+void UHSDR_SPI_GetInstance ( UHSDR_INTERFACE_t* uhsdr_spi, spi_e spi_name );
+
+/*
+ * TODO
+ */
+void UHSDR_SPI_SetTimeout ( UHSDR_INTERFACE_t* uhsdr_spi, uint32_t time_out );
+
+/*
+ * TODO
+ */
+void UHSDR_SPI_SetChipSelectPin ( UHSDR_INTERFACE_t* uhsdr_spi, dio_t* cs );
+
+/*
+ * Changing SPI clock speed.
+ * @return previous value.
+ */
+spi_speed_clock_e UHSDR_SPI_ChangeClockSpeed ( UHSDR_INTERFACE_t* uhsdr_spi, spi_speed_clock_e speed );
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __MCHF_HW_SPI_H

--- a/mchf-eclipse/hardware/uhsdr_structs.h
+++ b/mchf-eclipse/hardware/uhsdr_structs.h
@@ -1,0 +1,155 @@
+/*  -*-  mode: c; tab-width: 4; indent-tabs-mode: t; c-basic-offset: 4; coding: utf-8  -*-  */
+/*************************************************************************************
+ **                                                                                 **
+ **                                        UHSDR                                    **
+ **               a powerful firmware for STM32 based SDR transceivers              **
+ **                                                                                 **
+ **---------------------------------------------------------------------------------**
+**                                                                                 **
+**  File name:      uhsdr_structs.h                                                **
+**  Description:    Collect globally used structs and types.                       **
+**  Created by:     m-chichikalov (rv9yw)                                          **
+**  Licence:		GNU GPLv3                                                      **
+**                                                                                 **
+**  Last Modified:  2018-14-12: added display_t struct & display_interafce_e enum. **
+**                                                                                 **
+************************************************************************************/
+
+#ifndef __MCHF_STRUCTS_H
+#define __MCHF_STRUCTS_H
+
+#include "uhsdr_types.h"
+
+/*
+ * \brief Described direction of line or something that have parameter such direction.
+ */
+typedef enum
+{
+	VERTICAL = 0,
+	HORIZONTAL,
+} direction_e;
+
+/*
+ * \brief Described the display interface.
+ */
+typedef enum
+{
+	SPI = 0,
+	PARALLEL,
+} display_interafce_e;
+
+/*
+ * \brief Described the bandwidth of interface.
+ */
+typedef enum
+{
+	DATA_8_BIT = 0,
+	DATA_16_BIT,
+	DATA_32_BIT,
+} IO_bitwidth_e;
+
+typedef struct
+{
+	void*  GPIO_port;
+	ushort GPIO_pin;
+} dio_t;
+
+// forward declaration
+struct UHSDR_INTERFACE;
+typedef struct UHSDR_INTERFACE UHSDR_INTERFACE_t;
+
+typedef struct IO_
+{
+	int32_t ( *Init)( UHSDR_INTERFACE_t* uhsdr_IF );
+	int32_t ( *DeInit)( UHSDR_INTERFACE_t* uhsdr_IF );
+	int32_t ( *RequestTransaction)( UHSDR_INTERFACE_t* uhsdr_IF, uint32_t TimeOut );
+	void ( *CloseTransaction)( UHSDR_INTERFACE_t* uhsdr_IF );
+	void ( *Receive_Polling)( UHSDR_INTERFACE_t* uhsdr_IF, uint8_t* Buffer, uint16_t Size, uint32_t Settings );
+	void ( *Send_Polling)( UHSDR_INTERFACE_t* uhsdr_IF, uint8_t* Source, uint16_t Size, uint32_t Settings );
+	void ( *Receive_DMA)( UHSDR_INTERFACE_t* uhsdr_IF, uint8_t* Source, uint16_t Size, uint32_t Settings );
+	void ( *Send_DMA)( UHSDR_INTERFACE_t* uhsdr_IF, uint8_t* Source, uint16_t Size, uint32_t Settings );
+	// going remove later this one below
+	void (*SendReceive_Polling)( UHSDR_INTERFACE_t* uhsdr_IF, uint8_t* Source, uint8_t* Destination, uint16_t Size, uint32_t Settings );
+} IO_t;
+
+// FIXME maybe reorganize as UNION to be specific for each interface?
+typedef struct HW_INTERFACE
+{
+    void* handler;
+    volatile bool lock;
+    uint32_t time_out;
+    UHSDR_INTERFACE_t* parent;
+    void (*Init) ( void );
+    void (*DeInit) ( void );
+} HW_INTERFACE_t;
+
+typedef struct HW_SPI_SPECIFIC
+{
+    dio_t cs;
+} HW_SPI_SPECIFIC_t;
+
+typedef struct HW_FMC_SPECIFIC
+{
+} HW_FMC_SPECIFIC_t;
+
+typedef struct HW_I2C_SPECIFIC
+{
+} HW_I2C_SPECIFIC_t;
+
+typedef struct HW_I2S_SPECIFIC
+{
+} HW_I2S_SPECIFIC_t;
+
+typedef struct UHSDR_INTERFACE
+{
+    const IO_t* IO;
+    HW_INTERFACE_t* hw;
+    union
+    {
+        HW_SPI_SPECIFIC_t spi;
+        HW_FMC_SPECIFIC_t fmc;
+        HW_I2C_SPECIFIC_t i2c;
+        HW_I2S_SPECIFIC_t i2s;
+    } extra_parameter;
+} UHSDR_INTERFACE_t;
+
+/*
+ * \brief display_t contains pointers to functions of driver and driver specific data.
+ */
+// Forward declaration
+struct display_;
+typedef struct display_ display_t;
+
+typedef struct display_
+{
+//	uchar  display_type;           // existence/identification of display type
+	const char* name;                        // pointer to name string
+	display_interafce_e display_inteface;    // LCD interface
+	ushort device_code;                      // LCD ident code
+
+	void   ( *StartTransaction)( display_t* Display );
+	void   ( *PrepareGRAM)( display_t* Display, ushort Xpos, ushort Width, ushort Ypos, ushort Height );
+	void   ( *WriteBuffer)( display_t* Display, ushort* Buffer, uint Len );
+	void   ( *CloseTransaction)( display_t* Display );
+
+	// Display specific functions implementation, if not needed leave them as NULL.
+	void   ( *DrawColorPoint)( display_t* Display, ushort Xpos, ushort Ypos, ushort Color );
+	void   ( *DrawFullRect)( display_t* Display, ushort Xpos, ushort Ypos, ushort Height, ushort Width, ushort Color );
+	void   ( *DrawStraightLine)( display_t* Display, ushort Xpos, ushort Ypos, ushort Length, uchar Direction, ushort Color);
+
+	// private functions, used only by drivers, for parallel I/F they set needed address into FMC.
+	void   ( *PrepareData)( display_t* Display );
+	void   ( *PrepareCmd)( display_t* Display );
+
+	ushort MAX_X;
+	ushort MAX_Y;
+
+	dio_t spi_dc;     // data/command DIO
+	dio_t lcd_reset;  // reset LCD DIO
+
+	volatile bool semaphore; // display mutex, protects buffers.
+	UHSDR_INTERFACE_t IF;
+} display_t;
+
+
+#endif // __MCHF_STRUCTS_H

--- a/mchf-eclipse/misc/locks.c
+++ b/mchf-eclipse/misc/locks.c
@@ -1,0 +1,54 @@
+/*  -*-  mode: c; tab-width: 4; indent-tabs-mode: t; c-basic-offset: 4; coding: utf-8  -*-  */
+/*************************************************************************************
+ **                                                                                 **
+ **                                        UHSDR                                    **
+ **               a powerful firmware for STM32 based SDR transceivers              **
+ **                                                                                 **
+ **---------------------------------------------------------------------------------**
+ **  Description:    Simple boolean locks for further adopting RTOS                 **
+ **  Last Modified:  m-chichikalov (rv9yw) Implemented LOCKs as a step toward RTOS. **
+ **  License:         GNU GPLv3                                                     **
+ ************************************************************************************/
+
+#include "locks.h"
+#include <assert.h>
+/* Semaphore is a bool type, should be initiated as volatile */
+
+/**
+ * Semaphore give
+ */
+void sem_give( volatile bool* sem )
+{
+    assert( sem );
+
+	*sem = false;
+//	xSemaphoreGiveFromISR( *sem, pdFALSE );
+}
+
+/**
+ * Semaphore take, may suspend the caller thread
+ */
+int32_t sem_take( volatile bool* sem, uint32_t timeout )
+{
+    assert( sem );
+    assert( timeout );
+
+	(void)( timeout );
+	// As long as we do not have any concurrency,
+	// there is no way that semaphore is already taken by someone.
+	// The below implementation for DMA or interrupt driven Functions,
+	// they should give back semaphore after it's done.
+	if ( !*sem )
+	{
+		*sem = true;
+		return UHSDR_ERR_NONE;
+	}
+	while ( *sem )
+	{
+		//FIXME maybe add timeout for more robust code?
+		asm("nop");
+	}
+	*sem = true; // take semaphore after it's released...
+	return UHSDR_ERR_NONE;
+//	return xSemaphoreTake( *sem, timeout ) ? UHSDR_ERR_NONE : UHSDR_ERR_TIMEOUT;
+}

--- a/mchf-eclipse/misc/locks.h
+++ b/mchf-eclipse/misc/locks.h
@@ -1,0 +1,32 @@
+/*  -*-  mode: c; tab-width: 4; indent-tabs-mode: t; c-basic-offset: 4; coding: utf-8  -*-  */
+/*************************************************************************************
+ **                                                                                 **
+ **                                        UHSDR                                    **
+ **               a powerful firmware for STM32 based SDR transceivers              **
+ **                                                                                 **
+ **---------------------------------------------------------------------------------**
+ **  Description:    Simple boolean locks for further adopting RTOS                 **
+ **  Last Modified:  m-chichikalov (rv9yw) Implemented LOCKs as a step toward RTOS. **
+ **  License:         GNU GPLv3                                                     **
+ ************************************************************************************/
+
+#ifndef __LOCKS_H
+#define __LOCKS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "uhsdr_types.h"
+
+// FIXME dedicate file (header) with defined UHSDR specific return statuses.
+#define UHSDR_ERR_NONE 0
+
+void sem_give( volatile bool* sem );
+
+int32_t sem_take( volatile bool* sem, uint32_t timeout );
+
+#ifdef __cplusplus
+}
+#endif
+#endif // __LOCKS_H


### PR DESCRIPTION
- locks.
- uhsdr_hw_spi
- uhsdr_hw_fmc
- uhsdr_structs

@db4ple , @df8oe could you review, do not accept it yet. I pushed it for reviewing because it's very important to choose proper interface to stick with it.

The main advantage is we can slowly go to the point where main aplication code even doesn't know about existing stm32_hal or whatever is in use...

Pay attention to name of functions name of fields in structs and so on... Not everything is done, so...

for example rewriten functions for touch looks like this

``` C
static UHSDR_INTERFACE_t touch_IF;

void UiLcdHy28_TouchscreenInit( uchar mirror )
{
	mchf_touchscreen.xraw = 0;
	mchf_touchscreen.yraw = 0;

	mchf_touchscreen.hr_x = 0x7FFF;                        // invalid position
	mchf_touchscreen.hr_y = 0x7FFF;                        // invalid position

	UHSDR_SPI_GetInstance ( &touch_IF, __UHSDR_SPI2_DISPLAY__ );
	touch_IF.IO->Init( &touch_IF ); // Initiate the HW, in this case SPI

	dio_t cs = { .GPIO_port = TP_CS_PIO, .GPIO_pin = TP_CS };
	UHSDR_SPI_SetChipSelectPin ( &touch_IF, &cs );

	mchf_touchscreen.present = UiLcdHy28_TouchscreenPresenceDetection();
}

static void UiLcdHy28_TouchscreenReadData ( uuint16_t* x_p, uint16_t* y_p )
{
    uchar xpt_response[ XPT2046_COMMAND_LEN ];

    touch_IF.IO->RequestTransaction ( &touch_IF, 100 /*FIXME*/);
    spi_speed_clock_e temp_speed = UHSDR_SPI_ChangeClockSpeed ( &touch_IF, SPI_clock_VerySlow );

    touch_IF.IO->SendReceive_Polling ( &touch_IF, (uint8_t*)xpt2046_command, xpt_response,
            XPT2046_COMMAND_LEN, DATA_8_BIT );

    UHSDR_SPI_ChangeClockSpeed ( &touch_IF, temp_speed );
    touch_IF.IO->CloseTransaction ( &touch_IF );

    *x_p = (xpt_response[ 5 ] << 8 | xpt_response[ 6 ]) >> 3;
    *y_p = (xpt_response[ 3 ] << 8 | xpt_response[ 4 ]) >> 3;
}
```

This code doesn't know about HAL at all, for me it's good sign.