### PR TITLE
Fixes to permit compile with USE_HAL_DRIVER and Makefile refactoring

### DIFF
--- a/mchf-eclipse/Makefile
+++ b/mchf-eclipse/Makefile
@@ -25,19 +25,25 @@ ifndef BUILDFOR
   BUILDFOR=F4
 endif
 
+# We have to use "override" since we pass some of these things from
+# the commandline but then change / append to it
+# see https://www.gnu.org/software/make/manual/html_node/Override-Directive.html#Override-Directive
+# BUILDFOR, CONFIGFLAGS are affected by this
+
+
 # F4-512KB results in "small build for F4"
 ifeq ($(BUILDFOR),F4-512KB)
   FW_LINKERFILE_F4=arm-gcc-link_f4_flash512k.ld
-  BUILDFOR=F4
-  CONFIGFLAGS +="-DIS_SMALL_BUILD"
+  override BUILDFOR=F4
+  override CONFIGFLAGS +=-DIS_SMALL_BUILD
 else
   FW_LINKERFILE_F4=arm-gcc-link_f4_flash1024k.ld
 endif
 
 ifdef DEBUG
-  CONFIGFLAGS += -DDEBUG -DUSE_FULL_ASSERT -DTRACE
+  override CONFIGFLAGS += -DDEBUG -DUSE_FULL_ASSERT -DTRACE
 else
-  CONFIGFLAGS += -DNDEBUG
+  override CONFIGFLAGS += -DNDEBUG
 endif
 
 ifeq ($(BUILDFOR),F7)
@@ -76,9 +82,9 @@ endif
 # OPT_GCC_ARM=
 
 ifdef OPT_GCC_ARM
-  PREFIX = $(OPT_GCC_ARM)
+  PREFIX = $(OPT_GCC_ARM)/bin/
 else
-  PREFIX = /usr
+  PREFIX = 
 endif
 
 # Under MacOS we have to use gsed instead of sed
@@ -194,27 +200,17 @@ endif
 
 INC_DIRS = $(foreach d, $(SUBDIRS) $(HAL_SUBDIRS), -I$(ROOTLOC)/$d)
 
-CC = @${PREFIX}/bin/arm-none-eabi-gcc
-CXX = @${PREFIX}/bin/arm-none-eabi-g++
-OC = @${PREFIX}/bin/arm-none-eabi-objcopy
-OS = @${PREFIX}/bin/arm-none-eabi-size
-HEX2DFU = $(ROOTLOC)/support/hex2dfu/hex2dfu.py
-
-ifdef SystemRoot  # WINxx
-    HEX2DFU = python $(ROOTLOC)/support/hex2dfu/hex2dfu.py
-    CC = arm-none-eabi-gcc
-    CXX = arm-none-eabi-g++
-    OC = arm-none-eabi-objcopy
-    OS = arm-none-eabi-size
+ifdef VERBOSE
+	VPRE:=
+else
+	VPRE:=@
 endif
 
-ifdef MSYSTEM
-    HEX2DFU = python $(ROOTLOC)/support/hex2dfu/hex2dfu.py
-    CC = arm-none-eabi-gcc
-    CXX = arm-none-eabi-g++
-    OC = arm-none-eabi-objcopy
-    OS = arm-none-eabi-size
-endif
+CC      = $(VPRE)$(PREFIX)arm-none-eabi-gcc
+CXX     = $(VPRE)$(PREFIX)arm-none-eabi-g++
+OC      = $(VPRE)$(PREFIX)arm-none-eabi-objcopy
+SZ      = $(VPRE)$(PREFIX)arm-none-eabi-size
+HEX2DFU = $(VPRE)python $(ROOTLOC)/support/hex2dfu/hex2dfu.py
 
 
 ECHO = @echo
@@ -222,15 +218,6 @@ ECHO = @echo
 ifdef SystemRoot  # WINxx
     RM = del /Q
     FixPath = $(subst /,\,$1)
-else ifeq ($(shell uname), Linux)
-    RM = rm --force
-    FixPath = $1
-else ifeq ($(shell uname), Darwin)
-    RM = rm -f
-    FixPath = $1
-else ifeq ($(shell uname), CYGWIN_NT-10.0)
-    RM = rm -f
-    FixPath = $1
 else
     RM = rm -f
     FixPath = $1
@@ -248,6 +235,9 @@ basesw/%/usbh_mtp.o: CFLAGS += -Wno-implicit-fallthrough
 basesw/%/usbh_msc.o: CFLAGS += -Wno-implicit-fallthrough
 basesw/%/usbh_hid.o: CFLAGS += -Wno-implicit-fallthrough
 basesw/%stm32h7xx_hal_spi.o: CFLAGS += -Wno-strict-aliasing
+basesw/%stm32f4xx_ll_usb.o: CFLAGS += -Wno-attributes
+basesw/%stm32f7xx_ll_usb.o: CFLAGS += -Wno-attributes
+basesw/%stm32h7xx_ll_usb.o: CFLAGS += -Wno-attributes
 
 .S.o:
 	$(ECHO) "  [CC] $@"
@@ -270,17 +260,17 @@ basesw/%stm32h7xx_hal_spi.o: CFLAGS += -Wno-strict-aliasing
 
 %.bin: %.elf
 	$(ECHO) "  [OBJC] $@"
-	$(OS) $<
+	$(SZ) $<
 	$(OC) -v -O binary $< $@
 
 %.hex: %.elf
 	$(ECHO) "  [BIN] $@"
-	$(OS) $<
+	$(SZ) $<
 	$(OC) -v -O ihex $< $@
 
 %.dfu: %.hex
 	$(ECHO) "  [H2D] $@"
-	$(OS) $<
+	$(SZ) $<
 	$(HEX2DFU) $< $@
 
 # ---------------------------------------------------------
@@ -410,7 +400,7 @@ handy:
 
 release:  
 	# generate quick operating guide
-	@inkscape --export-png=$(ROOTLOC)/useful_manuals/mcHF-quick-manual.png $(ROOTLOC)/useful_manuals/mcHF-quick-manual.svg
+	/@inkscape --export-png=$(ROOTLOC)/useful_manuals/mcHF-quick-manual.png $(ROOTLOC)/useful_manuals/mcHF-quick-manual.svg
 	@inkscape --export-pdf=$(ROOTLOC)/useful_manuals/mcHF-quick-manual.pdf $(ROOTLOC)/useful_manuals/mcHF-quick-manual.svg
 
 # EOFILE

--- a/mchf-eclipse/drivers/audio/cw/cw_decoder.c
+++ b/mchf-eclipse/drivers/audio/cw/cw_decoder.c
@@ -46,6 +46,7 @@
 #include "audio_driver.h"
 #include "rtty.h"
 #include "cw_gen.h"
+#include <stdio.h>
 
 Goertzel cw_goertzel;
 

--- a/mchf-eclipse/drivers/ui/ui_vkeybrd.c
+++ b/mchf-eclipse/drivers/ui/ui_vkeybrd.c
@@ -15,7 +15,8 @@
 #include "uhsdr_board.h"
 #include "ui_spectrum.h"
 #include "ui_driver.h"
-#include "stdlib.h"
+#include <stdlib.h>
+#include <stdio.h>
 #include "radio_management.h"
 
 #define Col_BtnForeCol RGB(0x90,0x90,0x90)

--- a/mchf-eclipse/hardware/uhsdr_keypad.c
+++ b/mchf-eclipse/hardware/uhsdr_keypad.c
@@ -8,6 +8,9 @@
  **                                                                                 **
  **  Licence:       GNU GPLv3                                                      **
  ************************************************************************************/
+#ifndef USE_HAL_DRIVER
+    #define USE_HAL_DRIVER
+#endif
 #include "uhsdr_board.h"
 #include "uhsdr_keypad.h"
 

--- a/mchf-eclipse/misc/config_storage.c
+++ b/mchf-eclipse/misc/config_storage.c
@@ -11,8 +11,11 @@
  **  Last Modified:                                                                 **
  **  Licence:       GNU GPLv3                                                      **
  ************************************************************************************/
-#include "uhsdr_board_config.h"
-#include "stdint.h"
+#ifndef USE_HAL_DRIVER
+    #define USE_HAL_DRIVER
+#endif
+#include "uhsdr_board.h"
+#include <stdint.h>
 #include "config_storage.h"
 #include "ui_configuration.h"
 #include "serial_eeprom.h"

--- a/mchf-eclipse/misc/v_eprom/eeprom.c
+++ b/mchf-eclipse/misc/v_eprom/eeprom.c
@@ -26,6 +26,9 @@
 
 
 // Common
+#ifndef USE_HAL_DRIVER
+    #define USE_HAL_DRIVER
+#endif
 #include "uhsdr_board.h"
 #ifdef STM32F7
 #include "stm32f7xx_hal_flash_ex.h"

--- a/mchf-eclipse/src/bootloader/bootloader_main.c
+++ b/mchf-eclipse/src/bootloader/bootloader_main.c
@@ -202,7 +202,7 @@ static int Bootloader_UsbMSCDevice_Application(void)
         {}
 
         /* Jumps to user application code located in the internal Flash memory */
-        COMMAND_ResetMCU(BOOT_FIRMWARE);
+        COMMAND_ResetMCU(BOOT_REBOOT);
     }
 
     // this below is a trick to get sbrk() linked in at the right time so that

--- a/mchf-eclipse/src/bootloader/uhsdr_boot_hw.h
+++ b/mchf-eclipse/src/bootloader/uhsdr_boot_hw.h
@@ -18,6 +18,7 @@
 /* Includes ------------------------------------------------------------------*/
 #include "uhsdr_board_config.h"
 #include "uhsdr_board.h"
+#include "gpio.h"
 
 typedef enum
 {


### PR DESCRIPTION
- the code can now be compiled without USE_HAL_DRIVER globally defined
- the makefile now handles variables CONFIGFLAGS and BUILDFOR set
  via command line properly
- the makefile now supports a VERBOSE variable which turns on
  command call dumping (compiler, linker, ... )
- the makefile now handles all operating systems more or less equally
  Windows being a minor exception.
- Makefile if no PREFIX is set, searches commands in path, not hardcoded in
  /usr/bin, use OPT_ARM_GCC if you want to specify a fixed location