### PR TITLE
Refactored uhsdr_keypad module + prepared canary module to clean uhsdr_main.c

### DIFF
--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -5377,7 +5377,7 @@ static void UiDriver_KeyTestScreen()
 
 			if (idxFirstPressedButton < BUTTON_NUM)
 			{
-				txt = buttons[idxFirstPressedButton].label;
+				txt = Keypad_GetLabelOfButton( idxFirstPressedButton );
 			}
 			else
 			{

--- a/mchf-eclipse/hardware/uhsdr_board.c
+++ b/mchf-eclipse/hardware/uhsdr_board.c
@@ -348,12 +348,12 @@ void Board_InitFull()
     // in order to know which one to use.
     if (ts.rtc_present)
     {
-        hwKeys.map = &bm_set_rtc[0];
+        Keypad_SetLayoutRTC_MCHF();
     }
 #endif
 
     // Init keypad hw based on button map bm
-    Keypad_KeypadInit(&hwKeys);
+    Keypad_KeypadInit();
 
     // Encoders init
     UiRotaryFreqEncoderInit();

--- a/mchf-eclipse/hardware/uhsdr_keypad.c
+++ b/mchf-eclipse/hardware/uhsdr_keypad.c
@@ -6,13 +6,42 @@
  **                                                                                 **
  **---------------------------------------------------------------------------------**
  **                                                                                 **
- **  Licence:       GNU GPLv3                                                      **
+ **  Licence:       GNU GPLv3                                                       **
  ************************************************************************************/
-#ifndef USE_HAL_DRIVER
-    #define USE_HAL_DRIVER
-#endif
-#include "uhsdr_board.h"
+#include <assert.h>
+
+#include "uhsdr_board_config.h"
 #include "uhsdr_keypad.h"
+#include "gpio.h"
+
+// Key map structure
+// represents a physical key which can be pressed (via GPIO)
+typedef struct
+{
+    GPIO_TypeDef*   keyPort;
+    uint16_t        keyPin;
+    uint16_t        button_id;
+    const char*     label;
+
+} Keypad_KeyPhys_t;
+
+// represents a logical button
+typedef struct
+{
+    uint16_t        button_id;
+    const char*     label;
+} UhsdrButtonLogical_t;
+
+typedef struct
+{
+    const Keypad_KeyPhys_t* map;
+    uint32_t num;
+} UhsdrHwKey_t;
+
+const Keypad_KeyPhys_t* bm_set_normal;
+#ifdef UI_BRD_MCHF
+const Keypad_KeyPhys_t* bm_set_rtc;
+#endif
 
 // -------------------------------------------------------
 // Constant declaration of the buttons map across ports
@@ -46,7 +75,6 @@ const Keypad_KeyPhys_t bm_set_normal_arr[] =
         {BUTTON_S18_PIO,    BUTTON_S18,     BUTTON_NOP,             "S18"},
         {BUTTON_S19_PIO,    BUTTON_S19,     BUTTON_F6_PRESSED,      "S19"},
 #endif
-
         // this must be the last entry
         {NULL,              0,              0,                      NULL}
 };
@@ -55,7 +83,6 @@ const Keypad_KeyPhys_t* bm_set_normal = &bm_set_normal_arr[0];
 
 #ifdef UI_BRD_MCHF
 const Keypad_KeyPhys_t bm_set_rtc_arr[] =
-
 {
         // alternative mapping for RTC Modification
         {BUTTON_M2_PIO,         BUTTON_M2,      BUTTON_M2_PRESSED,      "S3"},
@@ -116,11 +143,20 @@ const UhsdrButtonLogical_t buttons[BUTTON_NUM] =
 #endif
 };
 
-// the inital button map is the default one
+// the initial button map is the default one
 UhsdrHwKey_t hwKeys = { .map = &bm_set_normal_arr[0], .num = 0 };
 
+// FIXME? Do we change state of these in IRQ? Maybe more save mark them as volatile?
 uint32_t buttonStates; // logical buttons
 uint32_t keyStates; // hw scan keys
+
+#ifdef UI_BRD_MCHF
+// this function invoked only on the UI_MCHF_BRD with RTC as they have different buttons layout
+inline void Keypad_SetLayoutRTC_MCHF()
+{
+    hwKeys.map = &bm_set_rtc[0];
+}
+#endif
 
 bool Keypad_IsButtonPressed(uint32_t button_num)
 {
@@ -150,13 +186,13 @@ uint32_t Keypad_ButtonStates()
     return buttonStates;
 }
 
-
 /*
  * @brief keypad hardware initialization based on the given keyMap
  *
  */
-void Keypad_KeypadInit(UhsdrHwKey_t* keyMap)
+void Keypad_KeypadInit()
 {
+    UhsdrHwKey_t* keyMap = &hwKeys;
     GPIO_InitTypeDef GPIO_InitStructure;
 
     // Common init
@@ -172,7 +208,6 @@ void Keypad_KeypadInit(UhsdrHwKey_t* keyMap)
     }
 }
 
-
 /*
  *  @brief Keypad direct HW access reading returning if a key is pressed (or not)
  */
@@ -187,19 +222,24 @@ static bool Keypad_GetKeyGPIOState(const Keypad_KeyPhys_t* key)
  */
 void Keypad_Scan()
 {
-    for (int key_num = 0; key_num < hwKeys.num; key_num++)
+    for (uint32_t key_num = 0; key_num < hwKeys.num; key_num++)
     {
         if (Keypad_GetKeyGPIOState(&hwKeys.map[key_num]))
         {
             // in normal mode - return key value
-            buttonStates |= (1 << hwKeys.map[key_num].button_id);
-            keyStates |= (1 << key_num);
+            SET_BIT( buttonStates, ( 1 << hwKeys.map[key_num].button_id ));
+            SET_BIT( keyStates, ( 1 << key_num ));
         }
         else
         {
-            buttonStates &= ~(1 << hwKeys.map[key_num].button_id);
-            keyStates &= ~(1 << key_num);
-
+            CLEAR_BIT( buttonStates, ( 1 << hwKeys.map[key_num].button_id ));
+            CLEAR_BIT( keyStates, ( 1 << key_num ));
         }
     }
+}
+
+inline const char* Keypad_GetLabelOfButton( uint32_t id_button )
+{
+    assert( id_button < sizeof( buttons ) / sizeof( UhsdrButtonLogical_t ));
+    return buttons[ id_button ].label;
 }

--- a/mchf-eclipse/hardware/uhsdr_keypad.h
+++ b/mchf-eclipse/hardware/uhsdr_keypad.h
@@ -10,34 +10,8 @@
  ************************************************************************************/
 #ifndef __UHSDR_KEYPAD_H
 #define __UHSDR_KEYPAD_H
-#include "uhsdr_board.h"
-
-// Key map structure
-// represents a physical key which can be pressed (via GPIO)
-typedef struct
-{
-    GPIO_TypeDef    *keyPort;
-    uint16_t        keyPin;
-    uint16_t         button_id;
-    const char*     label;
-
-} Keypad_KeyPhys_t;
-
-// represents a logical button
-typedef struct
-{
-    uint16_t        button_id;
-    const char*     label;
-} UhsdrButtonLogical_t;
-
-typedef struct
-{
-    const Keypad_KeyPhys_t* map;
-    uint32_t num;
-} UhsdrHwKey_t;
 
 // Logical Button definitions
-//
 enum
 {
     BUTTON_M2_PRESSED = 0,  // 0
@@ -70,22 +44,22 @@ enum
     BUTTON_NOP // used for buttons with no function
 };
 
-extern UhsdrHwKey_t  hwKeys; // these buttons represent the gpio to logical button id mapping
-extern const UhsdrButtonLogical_t  buttons[]; // this array gives us the names of the available logical buttons
+void        Keypad_KeypadInit();
 
-const Keypad_KeyPhys_t* bm_set_normal;
 #ifdef UI_BRD_MCHF
-const Keypad_KeyPhys_t* bm_set_rtc;
+// this function invoked only on the MCHF with RTC as they have different buttons layout
+void        Keypad_SetLayoutRTC_MCHF();
 #endif
 
-bool Keypad_IsButtonPressed(uint32_t button_num);
-bool Keypad_IsAnyButtonPressed();
-bool Keypad_IsKeyPressed(uint32_t key_num);
-bool Keypad_IsAnyKeyPressed();
-uint32_t Keypad_KeyStates();
-uint32_t Keypad_ButtonStates();
-void Keypad_Scan();
+bool        Keypad_IsButtonPressed( uint32_t button_num );
+bool        Keypad_IsAnyButtonPressed();
+bool        Keypad_IsKeyPressed( uint32_t key_num );
+bool        Keypad_IsAnyKeyPressed();
 
-void Keypad_KeypadInit(UhsdrHwKey_t* keyMap);
+void        Keypad_Scan();
+
+uint32_t    Keypad_KeyStates();
+uint32_t    Keypad_ButtonStates();
+const char* Keypad_GetLabelOfButton( uint32_t id_button );
 
 #endif

--- a/mchf-eclipse/misc/uhsdr_canary.c
+++ b/mchf-eclipse/misc/uhsdr_canary.c
@@ -1,0 +1,36 @@
+/*  -*-  mode: c; tab-width: 4; indent-tabs-mode: t; c-basic-offset: 4; coding: utf-8  -*-  */
+/************************************************************************************
+ **                                                                                 **
+ **                                        UHSDR                                    **
+ **               a powerful firmware for STM32 based SDR transceivers              **
+ **                                                                                 **
+ **---------------------------------------------------------------------------------**
+ **                                                                                 **
+ **  Licence:       GNU GPLv3                                                       **
+ ************************************************************************************/
+#include <malloc.h>
+#include <string.h>
+#include <assert.h>
+#include "uhsdr_canary.h"
+
+static const uint8_t canary_word[ 12 ] = { 'D', 'O', ' ', 'G', 'N', 'U', ' ', 'G', 'P', 'L', 'v', '3' };
+uint8_t* canary_word_ptr;
+
+// this has to be called after all dynamic memory allocation has happened
+void Canary_Create( void )
+{
+    canary_word_ptr = (uint8_t*)malloc( sizeof( canary_word ));
+    assert( canary_word_ptr );
+    memcpy ( canary_word_ptr, canary_word, 16 );
+}
+
+// this has to be called after all dynamic memory allocation has happened
+bool Canary_IsIntact( void )
+{
+    return memcmp ( canary_word_ptr, canary_word, 16 ) == 0;
+}
+
+uint8_t* Canary_GetAddr( void )
+{
+    return canary_word_ptr;
+}

--- a/mchf-eclipse/misc/uhsdr_canary.h
+++ b/mchf-eclipse/misc/uhsdr_canary.h
@@ -1,0 +1,20 @@
+/*  -*-  mode: c; tab-width: 4; indent-tabs-mode: t; c-basic-offset: 4; coding: utf-8  -*-  */
+/************************************************************************************
+ **                                                                                 **
+ **                                        UHSDR                                    **
+ **               a powerful firmware for STM32 based SDR transceivers              **
+ **                                                                                 **
+ **---------------------------------------------------------------------------------**
+ **                                                                                 **
+ **  Licence:       GNU GPLv3                                                       **
+ ************************************************************************************/
+#ifndef __UHSDR_CANARY_H
+#define __UHSDR_CANARY_H
+
+#include "uhsdr_types.h"
+
+void     Canary_Create ( void );
+bool     Canary_IsIntact ( void );
+uint8_t* Canary_GetAddr ( void );
+
+#endif // __UHSDR_CANARY_H


### PR DESCRIPTION
In uhsdr_keypad
- removed two globals
- cleaned header
- removed not needed includes
- replaced bitwise operations by macros from stm MCU headers.

No functional changes.
