### PR TITLE
PA Level Control refactoring

### DIFF
--- a/mchf-eclipse/drivers/ui/menu/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu.c
@@ -699,8 +699,7 @@ const char* UiMenu_GetSystemInfo(uint32_t* m_clr_ptr, int info_item)
 
 bool __attribute__ ((noinline)) UiDriverMenuBandPowerAdjust(int var, MenuProcessingMode_t mode, uint8_t band_mode, uint8_t pa_level, char* options, uint32_t* clr_ptr)
 {
-    volatile uint8_t* adj_ptr;
-    adj_ptr = &ts.pwr_adj[pa_level == PA_LEVEL_FULL?ADJ_FULL_POWER:ADJ_5W][band_mode];
+     volatile uint8_t* adj_ptr = &ts.pwr_adj[pa_level == PA_LEVEL_FULL?ADJ_FULL_POWER:ADJ_REF_PWR][band_mode];
 
     bool tchange = false;
     if((band_mode == RadioManagement_GetBand(df.tune_old)) && (ts.power_level == pa_level))
@@ -714,16 +713,15 @@ bool __attribute__ ((noinline)) UiDriverMenuBandPowerAdjust(int var, MenuProcess
 
         if(tchange)	 		// did something change?
         {
-            RadioManagement_SetBandPowerFactor(ts.band);	// yes, update the power factor
-            if(!ts.iq_freq_mode)	// Is translate mode *NOT* active?
-            {
-                Codec_TxSidetoneSetgain(ts.txrx_mode);				// adjust the sidetone gain
-            }
+            RadioManagement_SetPowerLevel(band_mode, pa_level);	// yes, update the power factor
         }
     }
-    else	// not enabled
+    else
+    {
+        // not enabled
         *clr_ptr = Orange;
-    //
+    }
+
     sprintf(options, "  %u", *adj_ptr);
     return tchange;
 }

--- a/mchf-eclipse/drivers/ui/radio_management.h
+++ b/mchf-eclipse/drivers/ui/radio_management.h
@@ -94,32 +94,60 @@ inline bool RadioManagement_TcxoIsFahrenheit()
     return (df.temp_enabled & TCXO_UNIT_MASK) == TCXO_UNIT_F;
 }
 
-// Total bands supported
-//
+// PA power level setting enumeration
+// this order MUST match the order of entries in power_levels in radio_management.c !
+typedef enum
+{
+    PA_LEVEL_FULL = 0,
+    PA_LEVEL_5W,
+    PA_LEVEL_2W,
+    PA_LEVEL_1W,
+    PA_LEVEL_0_5W,
+    PA_LEVEL_TUNE_KEEP_CURRENT
+} power_level_t;
+
+
+typedef struct {
+    power_level_t id;
+    char* name;
+    float32_t power_factor;
+    int32_t   mW;
+} power_level_desc_t;
+
+typedef struct {
+    const power_level_desc_t* levels;
+    const uint32_t count;
+} pa_power_levels_info_t;
+
+extern const pa_power_levels_info_t mchf_power_levelsInfo;
+
+
+#define PA_LEVEL_DEFAULT        PA_LEVEL_2W     // Default power level
 
 #define DEFAULT_FREQ_OFFSET     3000              // Amount of offset (at LO freq) when loading "default" frequency
 
-
 // this list MUST fit the order in the bandInfo structure defined in RadioManagement.h
-#define BAND_MODE_80            0
-#define BAND_MODE_60            1
-#define BAND_MODE_40            2
-#define BAND_MODE_30            3
-#define BAND_MODE_20            4
-#define BAND_MODE_17            5
-#define BAND_MODE_15            6
-#define BAND_MODE_12            7
-#define BAND_MODE_10            8
-#define BAND_MODE_6             9
-#define BAND_MODE_4             10
-#define BAND_MODE_2             11
-#define BAND_MODE_70            12
-#define BAND_MODE_23            13
-#define BAND_MODE_2200          14
-#define BAND_MODE_630           15
-#define BAND_MODE_160           16
-#define BAND_MODE_GEN           17          // General Coverage
-
+typedef enum
+{
+    BAND_MODE_80 = 0,
+    BAND_MODE_60 = 1,
+    BAND_MODE_40 = 2,
+    BAND_MODE_30 = 3,
+    BAND_MODE_20 = 4,
+    BAND_MODE_17 = 5,
+    BAND_MODE_15 = 6,
+    BAND_MODE_12 = 7,
+    BAND_MODE_10 = 8,
+    BAND_MODE_6 =  9,
+    BAND_MODE_4 =  10,
+    BAND_MODE_2 =  11,
+    BAND_MODE_70 = 12,
+    BAND_MODE_23 = 13,
+    BAND_MODE_2200 = 14,
+    BAND_MODE_630 = 15,
+    BAND_MODE_160 = 16,
+    BAND_MODE_GEN = 17          // General Coverage
+} band_mode_t;
 
 
 typedef enum
@@ -263,9 +291,9 @@ inline bool RadioManagement_IsTxDisabledBy(uint8_t whom)
 }
 
 uint32_t RadioManagement_GetRealFreqTranslationMode(uint32_t txrx_mode, uint32_t dmod_mode, uint32_t iq_freq_mode);
-uint8_t RadioManagement_GetBand(ulong freq);
+band_mode_t RadioManagement_GetBand(ulong freq);
 bool RadioManagement_FreqIsInBand(const BandInfo* bandinfo, const uint32_t freq);
-bool RadioManagement_PowerLevelChange(uint8_t band, uint8_t power_level);
+bool RadioManagement_SetPowerLevel(band_mode_t band, power_level_t power_level);
 bool RadioManagement_Tune(bool tune);
 bool RadioManagement_UpdatePowerAndVSWR();
 void RadioManagement_SetHWFiltersForFrequency(ulong freq);
@@ -280,10 +308,8 @@ uint32_t RadioManagement_NextAlternativeDemodMode(uint32_t loc_mode);
 Oscillator_ResultCodes_t RadioManagement_ValidateFrequencyForTX(uint32_t dial_freq);
 bool RadioManagement_IsApplicableDemodMode(uint32_t demod_mode);
 void RadioManagement_SwitchTxRx(uint8_t txrx_mode, bool tune_mode);
-void RadioManagement_SetBandPowerFactor(uchar band);
 bool RadioManagement_LSBActive(uint16_t dmod_mode);
 bool RadioManagement_USBActive(uint16_t dmod_mode);
-void RadioManagement_SetBandPowerFactor(uchar band);
 void RadioManagement_SetPaBias();
 bool RadioManagement_CalculateCWSidebandMode(void);
 void RadioManagement_SetDemodMode(uint8_t new_mode);

--- a/mchf-eclipse/drivers/ui/ui_configuration.c
+++ b/mchf-eclipse/drivers/ui/ui_configuration.c
@@ -41,7 +41,7 @@ static uint16_t number_of_entries_cur_fw; // we need this to be able to read con
 
 #define CONFIG_UINT8x2_COMBINE(a,b) ((((a) << 8) | (b)))
 
-#define UI_C_EEPROM_BAND_5W_PF(bandNo,bandName1,bandName2) { ConfigEntry_UInt8 | Calib_Val, EEPROM_BAND##bandNo##_5W,&ts.pwr_adj[ADJ_5W][BAND_MODE_##bandName1],TX_POWER_FACTOR_##bandName1##_DEFAULT,0,TX_POWER_FACTOR_MAX },
+#define UI_C_EEPROM_BAND_5W_PF(bandNo,bandName1,bandName2) { ConfigEntry_UInt8 | Calib_Val, EEPROM_BAND##bandNo##_5W,&ts.pwr_adj[ADJ_REF_PWR][BAND_MODE_##bandName1],TX_POWER_FACTOR_##bandName1##_DEFAULT,0,TX_POWER_FACTOR_MAX },
 #define UI_C_EEPROM_BAND_FULL_PF(bandNo,bandName1,bandName2) { ConfigEntry_UInt8 | Calib_Val, EEPROM_BAND##bandNo##_FULL,&ts.pwr_adj[ADJ_FULL_POWER][BAND_MODE_##bandName1],TX_POWER_FACTOR_##bandName1##_DEFAULT,0,TX_POWER_FACTOR_MAX },
 
 // here all simple configuration values are defined

--- a/mchf-eclipse/hardware/uhsdr_board.h
+++ b/mchf-eclipse/hardware/uhsdr_board.h
@@ -83,19 +83,6 @@ typedef enum {
 #define CW_KEYER_MODE_ULTIMATE			3
 #define CW_KEYER_MAX_MODE				3
 
-// PA power level setting enumeration
-typedef enum
-{
-    PA_LEVEL_FULL = 0,
-    PA_LEVEL_5W,
-    PA_LEVEL_2W,
-    PA_LEVEL_1W,
-    PA_LEVEL_0_5W,
-    PA_LEVEL_TUNE_KEEP_CURRENT
-} mchf_power_level_t;
-//
-#define	PA_LEVEL_DEFAULT		PA_LEVEL_2W		// Default power level
-
 #define	SSB_TUNE_FREQ			750	// Frequency at which the SSB TX IQ gain and phase adjustment is to be done
 //
 #define VOICE_TX2RX_DELAY_DEFAULT			450	// Delay for switching when going from TX to RX (this is 0.66uS units)
@@ -268,7 +255,6 @@ typedef struct
         int tau_hang_decay;
 } agc_wdsp_param_t;
 
-
 // Transceiver state public structure
 typedef struct TransceiverState
 {
@@ -323,7 +309,9 @@ typedef struct TransceiverState
 
     // Ham band public flag
     // index of bands table in Flash
-    uint8_t 	band;
+    uint8_t 	band; // this band idx does not relate to the real frequency, it is a "just" a memory index.
+    uint8_t     band_effective; // the band the currently selected frequency is in (which may be different from the band memory idx);
+
     bool	rx_temp_mute;
     uint8_t	filter_band;		// filter selection band:  1= 80, 2= 60/40, 3=30/20, 4=17/15/12/10 - used for selection of power detector coefficient selection.
     //
@@ -405,7 +393,9 @@ typedef struct TransceiverState
 
     ulong	audio_spkr_unmute_delay_count;
 
-    uint8_t	power_level;
+    uint8_t	power_level; // an abstract power level id
+    int32_t power; // the actual request power in mW
+    bool    power_modified; // the actual power is lower than the requested power_level, e.g. because of out side band.
 
     uint8_t 	tx_audio_source;
     ulong	tx_mic_gain_mult;
@@ -449,7 +439,7 @@ typedef struct TransceiverState
     //
     // Calibration factors for output power, in percent (100 = 1.00)
     //
-#define ADJ_5W 0
+#define ADJ_REF_PWR 0
 #define ADJ_FULL_POWER 1
     uint8_t	pwr_adj[2][MAX_BAND_NUM];
     //

--- a/mchf-eclipse/src/uhsdr_main.c
+++ b/mchf-eclipse/src/uhsdr_main.c
@@ -171,12 +171,6 @@ void TransceiverStateInit(void)
     ts.refresh_freq_disp	= 1;					// TRUE if frequency/color display is to be refreshed when next called - NORMALLY LEFT AT 0 (FALSE)!!!
     // This is NOT reset by the LCD function, but must be enabled/disabled externally
 
-    for (int idx=0; idx<MAX_BANDS; idx++)
-    {
-        ts.pwr_adj[ADJ_5W][idx] = 1;
-        ts.pwr_adj[ADJ_FULL_POWER][idx] = 1;
-    }
-
     ts.filter_cw_wide_disable		= 0;			// TRUE if wide filters are to be disabled in CW mode
     ts.filter_ssb_narrow_disable	= 0;				// TRUE if narrow (CW) filters are to be disabled in SSB mode
     ts.demod_mode_disable			= 0;		// TRUE if AM mode is to be disabled


### PR DESCRIPTION
- tried to separate the PA power steps (which are more a UI thing)
from the calculation of the settings to control power output by the PA.
This makes it easier to connect different PA (with differing power levels)
using the same code (which is at the moment basically the calculation of a gain value to
interface the DSP output with the PA side of things).
- Also changed display code to dynamically calculate the power display.
Range 0mW to 100W will fit into existing box.

I also added color coding by background color of the nominal power output box:

Blue -> normal

Orange -> the effective power setting is lower than the requested value,
i.e. when switching to AM mode, we limit it to 2W, and now user can see this.
Also the reduced out-of-band TX power is shown this way. And we now have
a better (not good!) control here, as we limit the power out of band to 5/50mW.
This power estimation is poor but better than the fixed gain value before.

Red -> there is an problem in the calibration, output gain is 0,
i.e. no output is produced, this happens for uncalibrated machines.

Gray -> TX is disabled, hence no power output.

Essentially, anything not with blue background means you'll get
less or no output power than requested.

I will put this information in the Wiki once the PR is accepted here: https://github.com/df8oe/UHSDR/wiki/Operating-Manual

In case of issues, please go to #1682 