### PR TITLE
Fixed Sidetone Gain not immediately applied after change / Canary Move / warn refactor

### DIFF
--- a/mchf-eclipse/drivers/audio/codec/codec.c
+++ b/mchf-eclipse/drivers/audio/codec/codec.c
@@ -399,8 +399,7 @@ void Codec_SwitchTxRxMode(uint8_t txrx_mode)
     }
     else		// It is transmit
     {
-        if(ts.dmod_mode == DEMOD_CW || is_demod_rtty() || is_demod_psk() || (ts.tune && !ts.iq_freq_mode))
-        // Turn sidetone on for CW or TUNE mode without freq translation
+        if(RadioManagement_UsesTxSidetone())
         {
             Codec_TxSidetoneSetgain(txrx_mode);	// set sidetone level
         }

--- a/mchf-eclipse/drivers/freedv/freedv_api.c
+++ b/mchf-eclipse/drivers/freedv/freedv_api.c
@@ -1517,6 +1517,9 @@ static int freedv_comprx_700(struct freedv *f, COMP demod_in_8kHz[], int *valid)
                     break;
                 default:
                     assert(0);
+                    nspare = 0;
+                    // this is to silence the compiler
+                    // in case assert is not enabled.
                 }
 
                 for(k=0; k<nspare; k++)  {

--- a/mchf-eclipse/drivers/ui/radio_management.c
+++ b/mchf-eclipse/drivers/ui/radio_management.c
@@ -282,6 +282,16 @@ static bool RadioManagement_SetBandPowerFactor(band_mode_t band)
     return ts.tx_power_factor != old_pf;
 }
 
+/**
+ * Is the currently active modulation / transceiver mode able to generate a side tone during transmit
+ * Can be called during RX and TX
+ *
+ * @return true if the selected modulation mode permits the use of a side tone
+ */
+bool RadioManagement_UsesTxSidetone()
+{
+    return ts.dmod_mode == DEMOD_CW || is_demod_rtty() || is_demod_psk() || (ts.tune && !ts.iq_freq_mode);
+}
 
 /**
  * @brief API Function, implements application logic for changing the power level including filter changes
@@ -338,7 +348,8 @@ bool RadioManagement_SetPowerLevel(band_mode_t band, power_level_t power_level)
             ts.power_level = power_level;
             ts.power = power;
             ts.power_modified = power_modified;
-            if(ts.tune && !ts.iq_freq_mode)         // recalculate sidetone gain only if transmitting/tune mode
+
+            if (RadioManagement_UsesTxSidetone())
             {
                 Codec_TxSidetoneSetgain(ts.txrx_mode);
             }

--- a/mchf-eclipse/drivers/ui/radio_management.h
+++ b/mchf-eclipse/drivers/ui/radio_management.h
@@ -318,6 +318,7 @@ const cw_mode_map_entry_t* RadioManagement_CWConfigValueToModeEntry(uint8_t cw_o
 uint8_t RadioManagement_CWModeEntryToConfigValue(const cw_mode_map_entry_t* mode_entry);
 bool RadioManagement_UsesBothSidebands(uint16_t dmod_mode);
 bool RadioManagement_IsPowerFactorReduce(uint32_t freq);
+bool RadioManagement_UsesTxSidetone();
 void RadioManagement_ToggleVfoAB();
 
 bool RadioManagement_FmDevIs5khz();

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -3388,7 +3388,14 @@ static void UiDriver_CheckEncoderOne()
 			break;
 		case ENC_ONE_MODE_ST_GAIN:
 			ts.cw_sidetone_gain = change_and_limit_uint(ts.cw_sidetone_gain,pot_diff_step,0,SIDETONE_MAX_GAIN);
-			Codec_TxSidetoneSetgain(ts.txrx_mode);
+
+			// we only set a side tone if it would have an effect in the current mode
+			// TODO: Should we even disable changes or at least display the box differently if  side tone is not support in currently
+			// active mode?
+			if (RadioManagement_UsesTxSidetone())
+			{
+			    Codec_TxSidetoneSetgain(ts.txrx_mode);
+			}
 			UiDriver_DisplaySidetoneGain(true);
 			break;
 		case ENC_ONE_MODE_CMP_LEVEL:

--- a/mchf-eclipse/files.mak
+++ b/mchf-eclipse/files.mak
@@ -5,6 +5,7 @@ misc/config_storage.c \
 misc/TestCPlusPlusBuild.cpp \
 misc/profiling.c \
 misc/serial_eeprom.c \
+misc/uhsdr_canary.c \
 hardware/uhsdr_board.c \
 hardware/uhsdr_hw_i2c.c \
 hardware/uhsdr_hmc1023.c \

--- a/mchf-eclipse/misc/uhsdr_canary.c
+++ b/mchf-eclipse/misc/uhsdr_canary.c
@@ -13,21 +13,29 @@
 #include <assert.h>
 #include "uhsdr_canary.h"
 
-static const uint8_t canary_word[ 12 ] = { 'D', 'O', ' ', 'G', 'N', 'U', ' ', 'G', 'P', 'L', 'v', '3' };
+static const uint8_t canary_word[] = { 'D', 'O', ' ', 'G', 'N', 'U', ' ', 'G', 'P', 'L', 'v', '3' };
 uint8_t* canary_word_ptr;
 
-// this has to be called after all dynamic memory allocation has happened
+/**
+ * this has to be called after all dynamic memory allocation has happened
+ */
 void Canary_Create( void )
 {
     canary_word_ptr = (uint8_t*)malloc( sizeof( canary_word ));
     assert( canary_word_ptr );
-    memcpy ( canary_word_ptr, canary_word, 16 );
+    memcpy ( canary_word_ptr, canary_word, sizeof(canary_word) );
 }
 
-// this has to be called after all dynamic memory allocation has happened
+/**
+ * Check if the canary was not destroyed (i.e. no additional allocation has happened and/or some code went wild.
+ *
+ * this has to be called after all dynamic memory allocation has happened AND Canary_Create has been called
+ *
+ * @return true if the previously written canary is still found in its location
+ */
 bool Canary_IsIntact( void )
 {
-    return memcmp ( canary_word_ptr, canary_word, 16 ) == 0;
+    return memcmp ( canary_word_ptr, canary_word, sizeof(canary_word) ) == 0;
 }
 
 uint8_t* Canary_GetAddr( void )

--- a/mchf-eclipse/src/uhsdr_main.c
+++ b/mchf-eclipse/src/uhsdr_main.c
@@ -15,7 +15,6 @@
 // Common
 #include "uhsdr_board.h"
 #include <stdio.h>
-#include <malloc.h>
 #include "uhsdr_rtc.h"
 #include "ui_spectrum.h"
 
@@ -46,6 +45,7 @@
 #include "drivers/ui/oscillator/osc_si570.h"
 #include "drivers/audio/codec/codec.h"
 #include "misc/profiling.h"
+#include "uhsdr_canary.h"
 // Keyboard Driver
 // #include "keyb_driver.h"
 
@@ -379,29 +379,6 @@ void MiscInit(void)
     // Init Soft DDS
     float freq[2] = { 0.0, 0.0 };
     softdds_configRunIQ(freq,ts.samp_rate,0);
-}
-
-
-static const uint8_t canary_word[16] = { 'D', 'O',' ' ,'N', 'O', 'T', ' ', 'O', 'V', 'E', 'R' , 'W', 'R' , 'I', 'T','E' };
-uint8_t* canary_word_ptr;
-
-// in hex 44 4f 20 4e 4f 54 20 4f 56 45 52 57 52 49 54 45
-// this has to be called after all dynamic memory allocation has happened
-void Canary_Create()
-{
-    canary_word_ptr = (uint8_t*)malloc(sizeof(canary_word));
-    memcpy(canary_word_ptr,canary_word,16);
-}
-// in hex 44 4f 20 4e 4f 54 20 4f 56 45 52 57 52 49 54 45
-// this has to be called after all dynamic memory allocation has happened
-bool Canary_IsIntact()
-{
-    return memcmp(canary_word_ptr,canary_word,16) == 0;
-}
-
-uint8_t* Canary_GetAddr()
-{
-    return canary_word_ptr;
 }
 
 


### PR DESCRIPTION
- Now in all modes which have side tone, the change of side tone volume
  is applied immediately (before only in Tune).
- The extracted canary methods are now used.
- added a variable init to keep the compiler silent in freedv_api