### PR TITLE
 Fixed not properly handled value of Audio PA when TX not configured. - Added sidetone for RTTY and BPSK.

### DIFF
--- a/mchf-eclipse/drivers/audio/codec/codec.c
+++ b/mchf-eclipse/drivers/audio/codec/codec.c
@@ -446,7 +446,11 @@ void Codec_TxSidetoneSetgain(uint8_t txrx_mode)
 
         if(ts.cw_sidetone_gain)	 	// calculate if the sidetone gain is non-zero
         {
-            const float32_t pf = ts.tx_power_factor;	// get TX scaling power factor
+            float32_t pf = ts.tx_power_factor;	// get TX scaling power factor
+            if ( pf == 0 )
+            {
+                pf = 0.001; // Almost zero but prevent from NoNe (1/0) in the next equation.
+            }
 
             float32_t signal_level_db = 10* log10f(1/(pf*pf));
             // we invert the square of power_factor (aka the signal energy)

--- a/mchf-eclipse/src/uhsdr_main.c
+++ b/mchf-eclipse/src/uhsdr_main.c
@@ -73,14 +73,14 @@ void HAL_GPIO_EXTI_Callback (uint16_t GPIO_Pin)
             if (Board_PttDahLinePressed() && RadioManagement_IsTxDisabledBy(TX_DISABLE_RXMODE) == false)
             {  // was PTT line low? Is it not a RX only mode
                 RadioManagement_Request_TxOn();     // yes - ONLY then do we activate PTT!  (e.g. prevent hardware bug from keying PTT!)
-                if(ts.dmod_mode == DEMOD_CW || is_demod_rtty() || ts.cw_text_entry)
+                if(ts.dmod_mode == DEMOD_CW || is_demod_rtty() || is_demod_psk() || ts.cw_text_entry)
                 {
                     CwGen_DahIRQ();     // Yes - go to CW state machine
                 }
             }
             break;
         case PADDLE_DIT:
-            if((ts.dmod_mode == DEMOD_CW || is_demod_rtty() || ts.cw_text_entry) && Board_DitLinePressed())
+            if((ts.dmod_mode == DEMOD_CW || is_demod_rtty() || is_demod_psk() || ts.cw_text_entry) && Board_DitLinePressed())
             {
                 RadioManagement_Request_TxOn();
                 CwGen_DitIRQ();


### PR DESCRIPTION
When the PA not configured and tx_power_factor = 0 there is no ANY sidetone in ANY mode. So, I think red square with power indication not enough and this should be handled in some of the ways:

- We do NOT turn on TX at all and write something on the screen that PA is not configured.
- We do turn on TX, play Sidetone (People can practice CW even only with UI).
- ... some other ways, any proposals?

My humble opinion that right now it's not consistent, it's going to TX, no Sidetone... I spent two hours to understand why.

TODO/FIXME :
* [ ] The value of sidetone in RTTY and BPSK can be adjusted only in CW mode, (STG) should be available also in RTTY and BPSK.
* [x] DO not understand part of the code, @db4ple take a look comments below.
* [ ] When pressed Tune in BPSK, not every time, but sometimes the tone of BPSK signal with distortion, do we have the same in TX output?

Looking forward to comments ;)