### PR TITLE
Fixed nasty buffer not clear issue causing strange noises on mcHF in CW

### DIFF
--- a/mchf-eclipse/drivers/audio/tx_processor.c
+++ b/mchf-eclipse/drivers/audio/tx_processor.c
@@ -877,7 +877,7 @@ void AudioDriver_TxProcessor(AudioSample_t * const srcCodec, IqSample_t * const 
     {
     case STREAM_TX_AUDIO_OFF:
         break;
-    case STREAM_TX_AUDIO_DIGIQ:
+    case STREAM_TX_AUDIO_GENIQ:
         for(int i = 0; i < blockSize; i++)
         {
 
@@ -908,4 +908,16 @@ void AudioDriver_TxProcessor(AudioSample_t * const srcCodec, IqSample_t * const 
 
     // now do the final processing including adjusting the IQ according to the calibration data
     AudioDriver_TxIqProcessingFinal(iq_gain_comp, false, &adb.iq_buf, dst, blockSize);
+
+    if (ts.stream_tx_audio == STREAM_TX_AUDIO_DIGIQ)
+    {
+        for(int i = 0; i < blockSize; i++)
+        {
+            // 16 bit format - convert to float and increment
+            // we collect our I/Q samples for USB transmission if TX_AUDIO_DIGIQ
+            audio_in_put_buffer(correctHalfWord(dst[i].r) >> IQ_BIT_SHIFT);
+            audio_in_put_buffer(correctHalfWord(dst[i].l) >> IQ_BIT_SHIFT);
+        }
+    }
+
 }

--- a/mchf-eclipse/drivers/ui/menu/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu.c
@@ -3605,16 +3605,19 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
         switch(ts.stream_tx_audio)
         {
         case STREAM_TX_AUDIO_OFF:
-            txt_ptr = "     OFF";
+            txt_ptr = "         OFF";
             break;
         case STREAM_TX_AUDIO_SRC:
-            txt_ptr = "  Source";
+            txt_ptr = "      Source";
             break;
         case STREAM_TX_AUDIO_FILT:
-            txt_ptr = "Filtered";
+            txt_ptr = "    Filtered";
             break;
         case STREAM_TX_AUDIO_DIGIQ:
-            txt_ptr = "Final IQ";
+            txt_ptr = "    Final IQ";
+            break;
+        case STREAM_TX_AUDIO_GENIQ:
+            txt_ptr = "Generated IQ";
             break;
         }
         break;

--- a/mchf-eclipse/hardware/uhsdr_board.h
+++ b/mchf-eclipse/hardware/uhsdr_board.h
@@ -677,7 +677,8 @@ typedef struct TransceiverState
 #define STREAM_TX_AUDIO_SRC     1  // send source audio stream (from CODEC)
 #define STREAM_TX_AUDIO_FILT    2  // send processed audio stream (after filtering)
 #define STREAM_TX_AUDIO_DIGIQ   3  // send final IQ signal
-#define STREAM_TX_AUDIO_NUM   4  // how many choices
+#define STREAM_TX_AUDIO_GENIQ   4  // generated "clean" IQ signal before final scaling and IQ phase/balance adjust
+#define STREAM_TX_AUDIO_NUM     5  // how many choices
 
 	// Freedv Test DL2FW
 	bool	FDV_TX_encode_ready;

--- a/mchf-eclipse/src/uhsdr_main.c
+++ b/mchf-eclipse/src/uhsdr_main.c
@@ -82,7 +82,10 @@ void HAL_GPIO_EXTI_Callback (uint16_t GPIO_Pin)
         case PADDLE_DIT:
             if((ts.dmod_mode == DEMOD_CW || is_demod_rtty() || is_demod_psk() || ts.cw_text_entry) && Board_DitLinePressed())
             {
-                RadioManagement_Request_TxOn();
+                if (ts.cw_keyer_mode != CW_KEYER_MODE_STRAIGHT)
+                {
+                    RadioManagement_Request_TxOn();
+                }
                 CwGen_DitIRQ();
             }
             break;


### PR DESCRIPTION
- we did not clear the right buffer (issue introduce with tx_processor).
  Since we moved final iq production to the very end, clearing it before
  does not make sense and caused a high pitched noise in CW straight key
  and with FreeDV at startup.
- CW paddle 2 (the one which is not PTT) is no longer triggering switch to
  TX without signal if the keyer is set to Straight Key.
  Unclear if this (unintended) turning on has been used by someone.