### PR TITLE
Refactored/Fixed/Added inputing by CW paddles & USB keyboard & F-butt…

### DIFF
--- a/mchf-eclipse/basesw/mcHF/Middlewares/ST/STM32_USB_Host_Library/Class/HID/Inc/usbh_hid_keybd.h
+++ b/mchf-eclipse/basesw/mcHF/Middlewares/ST/STM32_USB_Host_Library/Class/HID/Inc/usbh_hid_keybd.h
@@ -295,7 +295,7 @@ HID_KEYBD_Info_TypeDef;
 
 USBH_StatusTypeDef USBH_HID_KeybdInit(USBH_HandleTypeDef *phost);
 HID_KEYBD_Info_TypeDef *USBH_HID_GetKeybdInfo(USBH_HandleTypeDef *phost);
-uint8_t USBH_HID_GetASCIICode(HID_KEYBD_Info_TypeDef *info);
+uint8_t USBH_HID_GetASCIICode(HID_KEYBD_Info_TypeDef *info, uint32_t idx);
 
 /**
   * @}

--- a/mchf-eclipse/basesw/mcHF/Middlewares/ST/STM32_USB_Host_Library/Class/HID/Src/usbh_hid_keybd.c
+++ b/mchf-eclipse/basesw/mcHF/Middlewares/ST/STM32_USB_Host_Library/Class/HID/Src/usbh_hid_keybd.c
@@ -401,16 +401,16 @@ static USBH_StatusTypeDef USBH_HID_KeybdDecode(USBH_HandleTypeDef *phost)
   * @param  info: Keyboard information
   * @retval ASCII code
   */
-uint8_t USBH_HID_GetASCIICode(HID_KEYBD_Info_TypeDef *info)
+uint8_t USBH_HID_GetASCIICode(HID_KEYBD_Info_TypeDef *info, uint32_t idx)
 {
   uint8_t   output;  
   if((info->lshift == 1) || (info->rshift))
   {
-  output =  HID_KEYBRD_ShiftKey[HID_KEYBRD_Codes[info->keys[0]]];
+  output =  HID_KEYBRD_ShiftKey[HID_KEYBRD_Codes[info->keys[idx]]];
   }
   else
   {
-  output =  HID_KEYBRD_Key[HID_KEYBRD_Codes[info->keys[0]]];
+  output =  HID_KEYBRD_Key[HID_KEYBRD_Codes[info->keys[idx]]];
   }
   return output;  
 }

--- a/mchf-eclipse/basesw/ovi40-h7/Middlewares/ST/STM32_USB_Host_Library/Class/HID/Inc/usbh_hid_keybd.h
+++ b/mchf-eclipse/basesw/ovi40-h7/Middlewares/ST/STM32_USB_Host_Library/Class/HID/Inc/usbh_hid_keybd.h
@@ -295,7 +295,7 @@ HID_KEYBD_Info_TypeDef;
 
 USBH_StatusTypeDef USBH_HID_KeybdInit(USBH_HandleTypeDef *phost);
 HID_KEYBD_Info_TypeDef *USBH_HID_GetKeybdInfo(USBH_HandleTypeDef *phost);
-uint8_t USBH_HID_GetASCIICode(HID_KEYBD_Info_TypeDef *info);
+uint8_t USBH_HID_GetASCIICode(HID_KEYBD_Info_TypeDef *info, uint32_t idx);
 
 /**
   * @}

--- a/mchf-eclipse/basesw/ovi40-h7/Middlewares/ST/STM32_USB_Host_Library/Class/HID/Src/usbh_hid_keybd.c
+++ b/mchf-eclipse/basesw/ovi40-h7/Middlewares/ST/STM32_USB_Host_Library/Class/HID/Src/usbh_hid_keybd.c
@@ -401,16 +401,16 @@ static USBH_StatusTypeDef USBH_HID_KeybdDecode(USBH_HandleTypeDef *phost)
   * @param  info: Keyboard information
   * @retval ASCII code
   */
-uint8_t USBH_HID_GetASCIICode(HID_KEYBD_Info_TypeDef *info)
+uint8_t USBH_HID_GetASCIICode(HID_KEYBD_Info_TypeDef *info, uint32_t idx)
 {
   uint8_t   output;  
   if((info->lshift == 1) || (info->rshift))
   {
-  output =  HID_KEYBRD_ShiftKey[HID_KEYBRD_Codes[info->keys[0]]];
+  output =  HID_KEYBRD_ShiftKey[HID_KEYBRD_Codes[info->keys[idx]]];
   }
   else
   {
-  output =  HID_KEYBRD_Key[HID_KEYBRD_Codes[info->keys[0]]];
+  output =  HID_KEYBRD_Key[HID_KEYBRD_Codes[info->keys[idx]]];
   }
   return output;  
 }

--- a/mchf-eclipse/basesw/ovi40/Middlewares/ST/STM32_USB_Host_Library/Class/HID/Inc/usbh_hid_keybd.h
+++ b/mchf-eclipse/basesw/ovi40/Middlewares/ST/STM32_USB_Host_Library/Class/HID/Inc/usbh_hid_keybd.h
@@ -295,7 +295,7 @@ HID_KEYBD_Info_TypeDef;
 
 USBH_StatusTypeDef USBH_HID_KeybdInit(USBH_HandleTypeDef *phost);
 HID_KEYBD_Info_TypeDef *USBH_HID_GetKeybdInfo(USBH_HandleTypeDef *phost);
-uint8_t USBH_HID_GetASCIICode(HID_KEYBD_Info_TypeDef *info);
+uint8_t USBH_HID_GetASCIICode(HID_KEYBD_Info_TypeDef *info, uint32_t idx);
 
 /**
   * @}

--- a/mchf-eclipse/basesw/ovi40/Middlewares/ST/STM32_USB_Host_Library/Class/HID/Src/usbh_hid_keybd.c
+++ b/mchf-eclipse/basesw/ovi40/Middlewares/ST/STM32_USB_Host_Library/Class/HID/Src/usbh_hid_keybd.c
@@ -401,16 +401,16 @@ static USBH_StatusTypeDef USBH_HID_KeybdDecode(USBH_HandleTypeDef *phost)
   * @param  info: Keyboard information
   * @retval ASCII code
   */
-uint8_t USBH_HID_GetASCIICode(HID_KEYBD_Info_TypeDef *info)
+uint8_t USBH_HID_GetASCIICode(HID_KEYBD_Info_TypeDef *info, uint32_t idx)
 {
   uint8_t   output;  
   if((info->lshift == 1) || (info->rshift))
   {
-  output =  HID_KEYBRD_ShiftKey[HID_KEYBRD_Codes[info->keys[0]]];
+  output =  HID_KEYBRD_ShiftKey[HID_KEYBRD_Codes[info->keys[idx]]];
   }
   else
   {
-  output =  HID_KEYBRD_Key[HID_KEYBRD_Codes[info->keys[0]]];
+  output =  HID_KEYBRD_Key[HID_KEYBRD_Codes[info->keys[idx]]];
   }
   return output;  
 }

--- a/mchf-eclipse/drivers/audio/cw/cw_gen.c
+++ b/mchf-eclipse/drivers/audio/cw/cw_gen.c
@@ -42,10 +42,7 @@
 #include "cw_gen.h"
 #include "cat_driver.h"
 #include "ui_driver.h"
-
-// FIXME: will need to be changed to  "digimodes.h" later
-#include "rtty.h"
-
+#include "uhsdr_digi_buffer.h"
 
 // States
 #define CW_IDLE             0
@@ -94,7 +91,6 @@ typedef struct PaddleState
 
 	uint32_t   cw_char;
 	uint32_t   sending_char;
-
 } PaddleState;
 
 // Public paddle state
@@ -103,6 +99,7 @@ PaddleState  ps;
 static bool   CwGen_ProcessStraightKey(float32_t *i_buffer,float32_t *q_buffer,ulong size);
 static bool   CwGen_ProcessIambic(float32_t *i_buffer,float32_t *q_buffer,ulong size);
 static void   CwGen_TestFirstPaddle();
+static void   CwGen_ResetBufferSending();
 
 #define CW_SPACE_CHAR		1
 
@@ -420,7 +417,6 @@ static void CwGen_SetBreakTime()
  */
 void CwGen_Init(void)
 {
-
 	CwGen_SetSpeed();
 
 	if (ts.txrx_mode != TRX_MODE_TX  ||  ts.dmod_mode != DEMOD_CW) //FIXME No point doing this check as the function is called during board init, the rest of initialization would fail anyway if called anywhere else
@@ -489,7 +485,7 @@ static void CwGen_RemoveClickOnFallingEdge(float *i_buffer,float *q_buffer,ulong
         ps.sm_tbl_ptr = (CW_SMOOTH_TBL_SIZE - 1);
     }
 
-    for(int i = 0,j = 0; i < size; i++) // iterate over the I&Q audio buffer elements
+    for( uint32_t i = 0,j = 0; i < size; i++) // iterate over the I&Q audio buffer elements
     {
         i_buffer[i] = i_buffer[i] * sm_table[ps.sm_tbl_ptr];
         q_buffer[i] = q_buffer[i] * sm_table[ps.sm_tbl_ptr];
@@ -506,7 +502,6 @@ static void CwGen_RemoveClickOnFallingEdge(float *i_buffer,float *q_buffer,ulong
         }
     }
 }
-
 
 /**
  * @brief Is the logically DIT pressed (may reverse logic of HW contacts)
@@ -562,10 +557,19 @@ uint32_t CwGen_ReverseCode(uint32_t code)
 	return result;
 }
 
+/*
+ * our lookup table has only UperCase letters,
+ * so convert every char from the buffer to UPER
+ */
+static inline uint8_t CwGen_TranslateToUperCase( uint8_t c )
+{
+    return ( c >= 'a' && c <= 'z' ) ? (c - 32) : c;
+}
+
 static void CwGen_CheckKeyerState(void)
 {
 	uint8_t c;
-	char prosign[2];
+//	char prosign[2];
 
 	if (CwGen_DahRequested())
 	{
@@ -577,65 +581,65 @@ static void CwGen_CheckKeyerState(void)
 		ps.port_state |= CW_DIT_L;
 	}
 
-	if (!ts.cw_text_entry && ps.cw_state == CW_IDLE)
+	if ( ps.cw_state == CW_IDLE )
 	{
-	    // FIXME: I am not sure how this is supposed to work, but without check for DEMOD_CW it happily eats
-	    // all keyboard input for modes such as RTTY or PSK...
-	    // it seems to be intended for transmitting morse via keyboard input...
-		if (ts.dmod_mode == DEMOD_CW && ts.txrx_mode == TRX_MODE_TX && DigiModes_TxBufferHasData() && !ps.sending_char &&
-				(! (ps.port_state & CW_END_PROC) && ps.space_timer < ps.space_time - ps.dah_time))
-		{
-			DigiModes_TxBufferRemove(&c);
-			if (c=='<')
-			{
-				DigiModes_TxBufferRemove(&c);
-				prosign[0] = c;
-				DigiModes_TxBufferRemove(&c);
-				prosign[1] = c;
-				DigiModes_TxBufferRemove(&c);
-				if (c != '>') // Something is wrong - prosign not closed by matching >, better use space then
-				{
-					ps.sending_char = CW_SPACE_CHAR;
-				}
-				else
-				{
-					for (int i = 0; i<CW_SIGN_CODES; i++)
-					{
-						if (cw_sign_chars[i][0] == prosign[0] && cw_sign_chars[i][1] == prosign[1])
-						{
-							ps.sending_char = CwGen_ReverseCode(cw_sign_codes[i]);
-							break;
-						}
-					}
-				}
+        if ( !(ps.sending_char) && (! (ps.port_state & CW_END_PROC)
+                && ps.space_timer < ps.space_time - ps.dah_time))
+        {
+//FIXME Add handling sending prosigns, seems like we need to scan
+//      from cw_sign_onechar[] and send related value from cw_sign_codes[]
+//          if (c=='<')
+//          {
+//              DigiModes_TxBufferRemove(&c);
+//              prosign[0] = CwGen_TranslateToUperCase( c );
+//              DigiModes_TxBufferRemove(&c);
+//              prosign[1] = CwGen_TranslateToUperCase( c );
+//              DigiModes_TxBufferRemove(&c);
+//              if (c != '>') // Something is wrong - prosign not closed by matching >, better use space then
+//              {
+//                  ps.sending_char = CW_SPACE_CHAR;
+//              }
+//              else
+//              {
+//                  for (int i = 0; i<CW_SIGN_CODES; i++)
+//                  {
+//                      if (cw_sign_chars[i][0] == prosign[0] && cw_sign_chars[i][1] == prosign[1])
+//                      {
+//                          ps.sending_char = CwGen_ReverseCode(cw_sign_codes[i]);
+//                          break;
+//                      }
+//                  }
+//              }
+//
+//          }
+            if ( DigiModes_TxBufferRemove( &c, CW ))
+            {
+                c = CwGen_TranslateToUperCase( c );
+                for (int i = 0; i<CW_CHAR_CODES; i++)
+                {
+                    if (cw_char_chars[i] == c)
+                    {
+                      RadioManagement_Request_TxOn();
+                      ps.sending_char = CwGen_ReverseCode(cw_char_codes[i]);
+                      break;
+                    }
+                }
+            }
+        }
 
-			}
-			else
-			{
-				for (int i = 0; i<CW_CHAR_CODES; i++)
-				{
-					if (cw_char_chars[i] == c)
-					{
-						ps.sending_char = CwGen_ReverseCode(cw_char_codes[i]);
-						break;
-					}
-				}
-			}
-		}
-
-		if (ps.sending_char > CW_SPACE_CHAR) // 1 is space
-		{
-			if (ps.sending_char % 4 == 3)
-			{
-				ps.port_state |= CW_DAH_L;
-			}
-			else
-			{
-				ps.port_state |= CW_DIT_L;
-			}
-			ps.sending_char /= 4;
-		}
-	}
+        if (ps.sending_char > CW_SPACE_CHAR) // 1 is space
+        {
+          if (ps.sending_char % 4 == 3)
+          {
+              ps.port_state |= CW_DAH_L;
+          }
+          else
+          {
+              ps.port_state |= CW_DIT_L;
+          }
+          ps.sending_char /= 4;
+        }
+    }
 }
 
 /**
@@ -645,7 +649,6 @@ static void CwGen_CheckKeyerState(void)
 bool CwGen_Process(float32_t *i_buffer,float32_t *q_buffer,ulong blockSize)
 {
 	bool retval;
-
 
 	if(ts.cw_keyer_mode == CW_KEYER_MODE_STRAIGHT || CatDriver_CatPttActive())
 	{
@@ -663,7 +666,6 @@ bool CwGen_Process(float32_t *i_buffer,float32_t *q_buffer,ulong blockSize)
 	}
 	return retval;
 }
-
 
 static bool CwGen_ProcessStraightKey(float32_t *i_buffer,float32_t *q_buffer,ulong blockSize)
 {
@@ -692,9 +694,7 @@ static bool CwGen_ProcessStraightKey(float32_t *i_buffer,float32_t *q_buffer,ulo
 	}
 	else
 	{
-
 		softdds_runIQ(i_buffer,q_buffer,blockSize);
-
 		// ----------------------------------------------------------------
 		// Raising slope
 		//
@@ -712,12 +712,10 @@ static bool CwGen_ProcessStraightKey(float32_t *i_buffer,float32_t *q_buffer,ulo
 				ps.key_timer = 2;	// at end of rising edge change to constant signal phase
 			}
 		}
-
 		// -----------------------------------------------------------------
 		// Middle of a symbol - no shaping, just
 		// pass soft DDS data (key_timer = 2)
 		// ..................
-
 		// -----------------------------------------------------------------
 		// Failing edge
 		//
@@ -796,59 +794,38 @@ uint8_t CwGen_CharacterIdFunc(uint32_t code)
 	return out;
 }
 
-
-// FIXME: HACK RTTY
-#include "radio_management.h"
-
-void CwGen_AddChar(ulong code)
+/*
+ * Pushed proper char into digi_buffer.
+ */
+static void CwGen_AddChar( uint32_t code )
 {
 	char result = '*';
 	// need to use a character which is both in morse and rtty
 
-	for (int i = 0; i<CW_CHAR_CODES; i++)
+	for ( uint32_t i = 0; i < CW_CHAR_CODES; i++ )
 	{
-		if (cw_char_codes[i] == code) {
+		if ( cw_char_codes[i] == code )
+		{
 			result = cw_char_chars[i];
-
-			// FIXME: HACK HACK FOR RTTY TX TESTING
-			// We can use the same buffer for all digimodes
-			if ((ts.txrx_mode == TRX_MODE_TX && (is_demod_rtty() || is_demod_psk())) || ts.cw_text_entry) // Can rtty rely just on cw_text_entry here?
-			{
-				DigiModes_TxBufferPutChar(result);
-			}
-			// HACK END
-
+            DigiModes_TxBufferPutChar( result, CW );
 			break;
 		}
 	}
 
-	if (result != '*')
+	if ( result == '*' )
 	{
-		UiDriver_TextMsgPutChar(result);
-	}
-	else
-	{
-		for (int i = 0; i<CW_SIGN_CODES; i++)
+		for ( uint32_t i = 0; i < CW_SIGN_CODES; i++ )
 		{
-			if (cw_sign_codes[i] == code) {
+			if (cw_sign_codes[i] == code)
+			{
 				result = '-';
-
-				UiDriver_TextMsgPutSign(cw_sign_chars[i]);
-
-				// FIXME: HACK HACK FOR RTTY TX TESTING
-				// We can use the same buffer for all digimodes
-				if ((ts.txrx_mode == TRX_MODE_TX && is_demod_rtty()) || ts.cw_text_entry) // Can rtty rely just on cw_text_entry here?
-				{
-					DigiModes_TxBufferPutSign(cw_sign_chars[i]);
-				}
-				// HACK END
-
+                DigiModes_TxBufferPutSign( cw_sign_chars[i], CW );
 				break;
 			}
 		}
-		if (result == '*')
+		if ( result == '*' )
 		{
-			UiDriver_TextMsgPutChar('*');
+		    DigiModes_TxBufferPutChar( '*', CW );
 		}
 	}
 
@@ -874,10 +851,10 @@ static bool CwGen_ProcessIambic(float32_t *i_buffer,float32_t *q_buffer,ulong bl
 
 			CwGen_CheckKeyerState();
 			// at least one paddle is still or has been recently pressed
-			if( (Board_DitLinePressed() || Board_PttDahLinePressed() || (ps.port_state & (CW_DAH_L|CW_DIT_L)))
-					&& (ts.txrx_mode == TRX_MODE_TX || ts.cw_text_entry))
+			if( ps.port_state & ( CW_DAH_L | CW_DIT_L ))
 			{
-				ps.cw_state = CW_WAIT;		// Note if Dit/Dah is discriminated in this function, it breaks the Iambic-ness!
+			    // Note if Dit/Dah is discriminated in this function, it breaks the Iambic-ness!
+				ps.cw_state = CW_WAIT;
 				rerunStateMachine = true;
 			}
 			else
@@ -913,11 +890,17 @@ static bool CwGen_ProcessIambic(float32_t *i_buffer,float32_t *q_buffer,ulong bl
 			}
 		}
 		break;
-		case CW_WAIT:		// This is an extra state called after detection of an element to allow the other state machines to settle.
+		// This is an extra state called after detection of an element to
+		// allow the other state machines to settle.
+		case CW_WAIT:
 		{
-			// It is NECESSARY to eliminate a "glitch" at the beginning of the first Iambic Morse DIT element in a string!
-			ps.cw_state = CW_DIT_CHECK;
-			rerunStateMachine = true;
+			// It is NECESSARY to eliminate a "glitch" at the beginning of the
+		    // first Iambic Morse DIT element in a string!
+		    if ( ts.txrx_mode == TRX_MODE_TX || ts.cw_text_entry )
+		    {
+                ps.cw_state = CW_DIT_CHECK;
+                rerunStateMachine = true;
+		    }
 		}
 		break;
 		case CW_DIT_CHECK:
@@ -1031,18 +1014,17 @@ static bool CwGen_ProcessIambic(float32_t *i_buffer,float32_t *q_buffer,ulong bl
 				else
 				{
 					CwGen_TestFirstPaddle();
-					//			if(cw_dah_requested() && ps.ultim == 0)
-						if((ps.port_state & CW_DAH_L) && ps.ultim == 0)
-						{
-							ps.port_state &= ~(CW_DIT_L + CW_DIT_PROC);
-							ps.cw_state   = CW_DAH_CHECK;
-						}
-						else
-						{
-							ps.port_state &= ~(CW_DAH_L);
-							CwGen_SetBreakTime();
-							ps.cw_state    = CW_IDLE;
-						}
+                    if((ps.port_state & CW_DAH_L) && ps.ultim == 0)
+                    {
+                        ps.port_state &= ~(CW_DIT_L + CW_DIT_PROC);
+                        ps.cw_state   = CW_DAH_CHECK;
+                    }
+                    else
+                    {
+                        ps.port_state &= ~(CW_DAH_L);
+                        CwGen_SetBreakTime();
+                        ps.cw_state    = CW_IDLE;
+                    }
 				}
 				rerunStateMachine = true;
 			}
@@ -1100,7 +1082,6 @@ void CwGen_DahIRQ(void)
 	{
 		CwGen_TestFirstPaddle();
 	}
-
 }
 
 /**
@@ -1115,5 +1096,4 @@ void CwGen_DitIRQ(void)
 	{
 		CwGen_TestFirstPaddle();
 	}
-
 }

--- a/mchf-eclipse/drivers/audio/cw/cw_gen.h
+++ b/mchf-eclipse/drivers/audio/cw/cw_gen.h
@@ -17,16 +17,17 @@
 #include "arm_math.h"
 
 // Exports
-void 	CwGen_Init();
+void    CwGen_Init();
+
 void    CwGen_PrepareTx();
 void    CwGen_SetSpeed();
 
 bool    CwGen_TimersActive();
-bool	CwGen_Process(float32_t *i_buffer,float32_t *q_buffer,ulong size);
+bool    CwGen_Process( float32_t *i_buffer, float32_t *q_buffer, uint32_t size );
 
-void 	CwGen_DahIRQ();
-void 	CwGen_DitIRQ();
+void    CwGen_DahIRQ();
+void    CwGen_DitIRQ();
 
-uint8_t CwGen_CharacterIdFunc(uint32_t);
+uint8_t CwGen_CharacterIdFunc( uint32_t );
 
 #endif

--- a/mchf-eclipse/drivers/audio/cw/uhsdr_digi_buffer.c
+++ b/mchf-eclipse/drivers/audio/cw/uhsdr_digi_buffer.c
@@ -1,0 +1,129 @@
+/*  -*-  mode: c; tab-width: 4; indent-tabs-mode: t; c-basic-offset: 4; coding: utf-8  -*-  */
+/************************************************************************************
+ **                                                                                **
+ **                                        UHSDR                                   **
+ **               a powerful firmware for STM32 based SDR transceivers             **
+ **                                                                                **
+ **--------------------------------------------------------------------------------**
+ **                                                                                **
+ **  Description:   Please provide one                                             **
+ **  Licence:       GNU GPLv3                                                      **
+ ************************************************************************************/
+#include "uhsdr_digi_buffer.h"
+#include "ui_driver.h" // for pushing into UI buffer
+#include <assert.h>
+
+#define DIGIMODES_TX_BUFFER_SIZE 128
+
+static __IO uint8_t digimodes_tx_buffer[DIGIMODES_TX_BUFFER_SIZE];
+static __IO int32_t digimodes_tx_buffer_head = 0;
+static __IO int32_t digimodes_tx_tail = 0;
+static __IO uint32_t active_consumer = 0;
+
+// keeps prev consumer to restore it by calling DigiModes_Restore_BufferConsumer();
+static __IO uint32_t prev_consumer = CW;
+
+void DigiModes_Restore_BufferConsumer()
+{
+    active_consumer = prev_consumer;
+}
+
+/*
+ * The UI consumer has higher priority to protect it by changing modes.
+ * UI should release buffer by calling DigiModes_Restore_BufferConsumer()
+ */
+digi_buff_consumer_t DigiModes_Set_BufferConsumer( digi_buff_consumer_t consumer )
+{
+    assert((consumer & RTTY) || (consumer & BPSK) || (consumer & CW) || (consumer & UI));
+    if ( prev_consumer == UI ) // <- UI has higher priority
+    {
+        prev_consumer = active_consumer; // in case we change mode
+        return active_consumer;
+    }
+    prev_consumer = active_consumer;
+    active_consumer = consumer;
+    return prev_consumer;
+}
+
+uint8_t DigiModes_TxBufferHasData()
+{
+    int32_t len = digimodes_tx_buffer_head - digimodes_tx_tail;
+    return len < 0 ? ( len + DIGIMODES_TX_BUFFER_SIZE ) : len;
+}
+
+bool DigiModes_TxBufferRemove( uint8_t* c_ptr, digi_buff_consumer_t consumer )
+{
+    assert( c_ptr );
+    assert((consumer & RTTY) || (consumer & BPSK) || (consumer & CW) || (consumer & UI));
+
+    bool retval = false;
+
+    if ( consumer == active_consumer && digimodes_tx_buffer_head != digimodes_tx_tail)
+    {
+        *c_ptr = digimodes_tx_buffer[digimodes_tx_tail];
+        digimodes_tx_tail = (digimodes_tx_tail + 1) % DIGIMODES_TX_BUFFER_SIZE;
+
+        // push removed char to UI buffer to display it on the screen.
+        // characters for UI and CW prints when they add to digi_buffer
+        if ( active_consumer == RTTY || active_consumer == BPSK )
+        {
+            UiDriver_TextMsgPutChar( *c_ptr );
+        }
+        retval = true;
+    }
+    return retval;
+}
+
+/* no room left in the buffer returns 0 */
+int32_t DigiModes_TxBufferPutChar( uint8_t c, digi_buff_consumer_t source )
+{
+    assert((source & CW) || (source & KeyBoard));
+
+    int32_t ret = 0;
+    /*
+     * In case when source and consumer are equal we just
+     * print on the screen without putting into digi_buffer
+     * to prevent from infinite loop
+     * ( CW working as a source and receiver at the same time )
+     */
+    if ( active_consumer == source )
+    {
+        UiDriver_TextMsgPutChar( c );
+    }
+    else
+    {
+        int32_t next_head = (digimodes_tx_buffer_head + 1) % DIGIMODES_TX_BUFFER_SIZE;
+        if (next_head != digimodes_tx_tail)
+        {
+            /* there is room */
+            digimodes_tx_buffer[digimodes_tx_buffer_head] = c;
+            digimodes_tx_buffer_head = next_head;
+            /*
+             * If the consumer is UI we print on the screen
+             * right the way on the inputing text into buffer
+             */
+            if ( active_consumer == UI )
+            {
+                UiDriver_TextMsgPutChar( c );
+            }
+            ret ++;
+        }
+    }
+    return ret;
+}
+
+void DigiModes_TxBufferPutSign( const char* s, digi_buff_consumer_t source )
+{
+    assert( s );
+    assert((source & CW) || (source & KeyBoard));
+
+    DigiModes_TxBufferPutChar( '<', source );
+    DigiModes_TxBufferPutChar( s[0], source );
+    DigiModes_TxBufferPutChar( s[1], source );
+    DigiModes_TxBufferPutChar( '>', source );
+}
+
+void DigiModes_TxBufferReset()
+{
+    digimodes_tx_tail = digimodes_tx_buffer_head;
+}

--- a/mchf-eclipse/drivers/audio/cw/uhsdr_digi_buffer.h
+++ b/mchf-eclipse/drivers/audio/cw/uhsdr_digi_buffer.h
@@ -1,0 +1,57 @@
+/*  -*-  mode: c; tab-width: 4; indent-tabs-mode: t; c-basic-offset: 4; coding: utf-8  -*-  */
+/************************************************************************************
+ **                                                                                **
+ **                                        UHSDR                                   **
+ **               a powerful firmware for STM32 based SDR transceivers             **
+ **                                                                                **
+ **--------------------------------------------------------------------------------**
+ **                                                                                **
+ **  Description:   Please provide one                                             **
+ **  Licence:       GNU GPLv3                                                      **
+ ************************************************************************************/
+
+#ifndef __UHSDR_DIGI_BUFFER_H
+#define __UHSDR_DIGI_BUFFER_H
+
+#include "uhsdr_types.h"
+
+typedef enum
+{
+    RTTY       = 1,
+    BPSK       = 2,
+    CW         = 4,
+    UI         = 8,
+    KeyBoard   = 16, // <- keyboard should be used as a source only
+} digi_buff_consumer_t;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+uint8_t DigiModes_TxBufferHasData();
+
+/*
+ * The Digi buffer has multi consumers, some of them trying to get an entry
+ * from the buffer at the same time.
+ * to organize it, the allowed consumer for buffer should be set before using it.
+ *
+ * @return - previous consumer
+ */
+digi_buff_consumer_t DigiModes_Set_BufferConsumer( digi_buff_consumer_t consumer );
+void                 DigiModes_Restore_BufferConsumer();
+
+/*
+ * @return - true if element was removed from buffer and available in c_ptr
+ *           false if there is no elements in buffer or this consumer not
+ *           allowed to remove elements from buffer.
+ */
+bool     DigiModes_TxBufferRemove( uint8_t* c_ptr, digi_buff_consumer_t consumer );
+
+int32_t  DigiModes_TxBufferPutChar( uint8_t c, digi_buff_consumer_t source );
+void     DigiModes_TxBufferPutSign( const char* s, digi_buff_consumer_t source );
+
+void     DigiModes_TxBufferReset( );
+#ifdef __cplusplus
+}
+#endif
+#endif // __UHSDR_DIGI_BUFFER_H

--- a/mchf-eclipse/drivers/audio/psk.c
+++ b/mchf-eclipse/drivers/audio/psk.c
@@ -13,6 +13,7 @@
 #include "radio_management.h"
 #include "rtty.h"
 #include <stdlib.h>
+#include "uhsdr_digi_buffer.h"
 
 // table courtesy of fldigi pskvaricode.cxx
 static uint16_t psk_varicode[] = {
@@ -620,11 +621,11 @@ int16_t Psk_Modulator_GenSample()
 			    // normal characters don't have 2 zeros following each other
 				psk_state.tx_zeros++;
 			}
-			else if (DigiModes_TxBufferRemove(&psk_state.tx_char))
+			else if ( DigiModes_TxBufferRemove( &psk_state.tx_char, BPSK ))
 			{
 			    // if all zeros have been sent, look for new
 			    // input from input buffer
-				psk_state.tx_bits = Bpsk_FindCharReversed(psk_state.tx_char);
+				psk_state.tx_bits = Bpsk_FindCharReversed( psk_state.tx_char );
 				// reset counter for trailing/leading zeros
 				psk_state.tx_zeros = 0;
 				// reset counter for trailing zeros

--- a/mchf-eclipse/drivers/audio/rtty.h
+++ b/mchf-eclipse/drivers/audio/rtty.h
@@ -80,10 +80,4 @@ void RttyDecoder_Init();
 void RttyDecoder_ProcessSample(float32_t sample);
 int16_t Rtty_Modulator_GenSample();
 
-int DigiModes_TxBufferPutChar(uint8_t c);
-void DigiModes_TxBufferPutSign(const char* s);
-uint8_t DigiModes_TxBufferHasData();
-int DigiModes_TxBufferRemove(uint8_t* c_ptr);
-void DigiModes_TxBufferReset();
-
 #endif

--- a/mchf-eclipse/drivers/ui/radio_management.c
+++ b/mchf-eclipse/drivers/ui/radio_management.c
@@ -49,6 +49,7 @@
 
 #include "psk.h"
 #include "rtty.h"
+#include "uhsdr_digi_buffer.h"
 
 #define SWR_SAMPLES_SKP             1   //5000
 #define SWR_SAMPLES_CNT             5//10
@@ -1066,9 +1067,6 @@ bool RadioManagement_IsPowerFactorReduce(uint32_t freq)
  */
 void RadioManagement_SetDemodMode(uint8_t new_mode)
 {
-
-	DigiModes_TxBufferReset();
-
     ts.dsp_inhibit++;
     ads.af_disabled++;
 

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -51,6 +51,7 @@
 #include "config_storage.h"
 
 #include "cw_gen.h"
+#include "uhsdr_digi_buffer.h"
 
 #include "radio_management.h"
 #include "soft_tcxo.h"
@@ -535,6 +536,7 @@ void UiDriver_TextMsgClear()
 	}
 	ui_txt_msg_buffer[fillcnt]='\0';
 
+	// FIXME there is more affective way to clear space on the screen.
     UiLcdHy28_PrintText(ts.Layout->TextMsgLine.x,ts.Layout->TextMsgLine.y, ui_txt_msg_buffer,Yellow,Black,ts.Layout->TextMsg_font);
     ui_txt_msg_idx = 0;
     ui_txt_msg_update = true;
@@ -3039,6 +3041,7 @@ void UiDriver_SetDemodMode(uint8_t new_mode)
 	};
 #endif
 
+	DigiModes_TxBufferReset();
 	switch(ts.dmod_mode)
 	{
 	case DEMOD_DIGI:
@@ -3046,6 +3049,7 @@ void UiDriver_SetDemodMode(uint8_t new_mode)
 		switch(ts.digital_mode)
 		{
 		case DigitalMode_RTTY:
+		    DigiModes_Set_BufferConsumer( RTTY );
 			if (ts.enc_one_mode != ENC_ONE_MODE_AUDIO_GAIN)
 			{
 				ts.enc_one_mode = ENC_ONE_MODE_RTTY_SPEED;
@@ -3058,6 +3062,7 @@ void UiDriver_SetDemodMode(uint8_t new_mode)
 			break;
 
 		case DigitalMode_BPSK:
+		    DigiModes_Set_BufferConsumer( BPSK );
 			if (ts.enc_thr_mode != ENC_THREE_MODE_RIT)
 			{
 				ts.enc_thr_mode = ENC_THREE_MODE_PSK_SPEED;
@@ -3069,6 +3074,7 @@ void UiDriver_SetDemodMode(uint8_t new_mode)
 
 	case DEMOD_CW:
 	{
+	    DigiModes_Set_BufferConsumer( CW );
 		if (ts.enc_one_mode != ENC_ONE_MODE_AUDIO_GAIN)
 		{
 			ts.enc_one_mode = ENC_ONE_MODE_ST_GAIN;
@@ -6370,46 +6376,53 @@ static void UiAction_ToggleTuneMode()
 
 static void UiAction_PlayKeyerBtnN(int8_t n)
 {
-	uint8_t *pmacro;
+	uint8_t* pmacro;
 	uint16_t c = 0;
 
 	if (ts.keyer_mode.button_recording == KEYER_BUTTON_NONE)
 	{
-		pmacro = (uint8_t *)ts.keyer_mode.macro[n];
+		pmacro = ( uint8_t* )ts.keyer_mode.macro[n];
 		if (*pmacro != '\0') // If there is a macro
 		{
 			while (*pmacro != '\0')
 			{
-				DigiModes_TxBufferPutChar(*pmacro++);
+				DigiModes_TxBufferPutChar( *pmacro++, UI );
 			}
 
-			if ((ts.dmod_mode == DEMOD_CW && ts.cw_keyer_mode != CW_KEYER_MODE_STRAIGHT) || is_demod_psk())
+			if ((ts.dmod_mode == DEMOD_CW
+			        && ts.cw_keyer_mode != CW_KEYER_MODE_STRAIGHT)
+			        || is_demod_psk()
+			        || is_demod_rtty())
 			{
 				RadioManagement_Request_TxOn();
 			}
 		}
-
 		UiDriver_TextMsgPutChar('>');
 	}
 	else if (ts.keyer_mode.button_recording == n)
 	{
-		ts.cw_text_entry = false;
+		ts.cw_text_entry = false; // FIXME looks like we can remove cw_text_entry
 		pmacro = (uint8_t *)ts.keyer_mode.macro[n];
 		c = 0;
-		while (DigiModes_TxBufferHasData())
-		{
-			if (++c > KEYER_MACRO_LEN - 1) {
-				break;
-			}
-			DigiModes_TxBufferRemove(pmacro++);
-		}
+		/*
+		 * Kind of trick. It will not check second condition if first is the false,
+		 * so it keeps pointer to the last available element in array for macro
+		 * to put there terminator
+		 */
+		while (( ++c <= KEYER_MACRO_LEN - 1) && DigiModes_TxBufferRemove( pmacro++, UI ))
+		{}
 		*pmacro = '\0';
 
 		UiConfiguration_UpdateMacroCap();
 		UiDriver_TextMsgPutChar('<');
 		ts.keyer_mode.button_recording = KEYER_BUTTON_NONE;
+
+		// setup back the previous consumer of digi buffer
+		// as UI has higher priority we can be sure that
+		// it's not changed by changing modes
+		DigiModes_Restore_BufferConsumer();
 	}
-	UiDriver_CreateFunctionButtons(false);
+	UiDriver_CreateFunctionButtons( false );
 }
 
 static void UiAction_PlayKeyerBtn1()
@@ -6429,10 +6442,17 @@ static void UiAction_PlayKeyerBtn3()
 
 static void UiAction_RecordKeyerBtnN(int8_t n)
 {
-	if (ts.keyer_mode.button_recording == KEYER_BUTTON_NONE && ts.txrx_mode == TRX_MODE_RX && !ts.cw_text_entry && ts.dmod_mode == DEMOD_CW)
+	if (ts.keyer_mode.button_recording == KEYER_BUTTON_NONE
+	        && ts.txrx_mode == TRX_MODE_RX
+	        && !ts.cw_text_entry
+	        && ( ts.dmod_mode == DEMOD_CW
+	        || is_demod_psk()
+	        || is_demod_rtty()))
 	{
-		ts.cw_text_entry = true;
+		ts.cw_text_entry = true; // FIXME can be removed later
+
 		ts.keyer_mode.button_recording = n;
+		DigiModes_Set_BufferConsumer( UI );
 		DigiModes_TxBufferReset();
 		UiDriver_TextMsgPutChar(':');
 		UiDriver_CreateFunctionButtons(false);
@@ -6940,6 +6960,103 @@ void UiDriver_TaskHandler_HighPrioTasks()
 
 }
 
+static void UiDriver_HandleUSB_Keyboard()
+{
+#ifdef USE_USBKEYBOARD
+    if(USBH_HID_GetDeviceType(&hUsbHostHS) == HID_KEYBOARD)
+    {
+        HID_KEYBD_Info_TypeDef *k_pinfo = USBH_HID_GetKeybdInfo(&hUsbHostHS);
+
+        const uint32_t kb_buffer_size = (sizeof(k_pinfo->keys)/sizeof(k_pinfo->keys[0]));
+        static uint8_t keys_buffer[sizeof(k_pinfo->keys)/sizeof(k_pinfo->keys[0])] = { 0 };
+
+        /*
+         * Regarding -> https://www.usb.org/sites/default/files/documents/hid1_11.pdf 72p.
+         *
+         * The order of keycodes in array fields has no significance. Order determination
+         * is done by the host software comparing the contents of the previous report to
+         * the current report. If two or more keys are reported in one report, their order is
+         * indeterminate. Keyboards may buffer events that would have otherwise
+         * resulted in multiple event in a single report.
+         *
+         * So, the code below is keeping the previous report from the keyboard to compare
+         * with the next one and filter out multi-pressed keys. Later this could be used
+         * to determine long press key or repeat key if it's holding - for example:
+         *
+         * Start recording F1-button if F5 was pressed for 2 sec...
+         */
+        if(k_pinfo != NULL)
+        {
+            for( uint32_t idx = 0; idx < kb_buffer_size; idx++ )
+            {
+                bool is_exist_in_buffer = false;
+                for( uint32_t i = 0; i < kb_buffer_size; i++ )
+                {
+                    if ( keys_buffer[i] == k_pinfo->keys[idx])
+                    {
+                        is_exist_in_buffer = true;
+                        break;
+                    }
+                }
+                if ( is_exist_in_buffer == true )
+                {
+                    /*
+                     * The same character was found in previous report,
+                     * so, Ignoring this one
+                     */
+                    continue;
+                }
+                else
+                {
+                    switch(k_pinfo->keys[idx])
+                    {
+                    case KEY_ESCAPE:
+                      DigiModes_TxBufferReset();
+                      break;
+                    case KEY_BACKSPACE:
+                        UiDriver_TextMsgClear();
+                      break;
+                    case KEY_F1:
+                      RadioManagement_Request_TxOn();
+                      break;
+                    case KEY_F2:
+                      RadioManagement_Request_TxOff();
+                      break;
+                    case KEY_F5:
+                      RadioManagement_Request_TxOn();
+                      UiAction_PlayKeyerBtn1();
+                      break;
+                    case KEY_F6:
+                      RadioManagement_Request_TxOn();
+                      UiAction_PlayKeyerBtn2();
+                      break;
+                    case KEY_F7:
+                      RadioManagement_Request_TxOn();
+                      UiAction_PlayKeyerBtn3();
+                      break;
+                    }
+
+                    uint8_t kbdChar = USBH_HID_GetASCIICode( k_pinfo, idx );
+                    if (kbdChar != '\0')
+                    {
+                      // FIXME seems we can push only into Digi_buffer....
+                      if (is_demod_rtty() || is_demod_psk() || ts.dmod_mode == DEMOD_CW)
+                      {
+                          DigiModes_TxBufferPutChar( kbdChar, KeyBoard );
+                      }
+                      else
+                      {
+                          UiDriver_TextMsgPutChar( kbdChar );
+                      }
+                    }
+                }
+            }
+            memcpy( keys_buffer, k_pinfo->keys, sizeof(k_pinfo->keys));
+        }
+    }
+#endif // USE_USBKEYBOARD
+}
+
 void UiDriver_TaskHandler_MainTasks()
 {
 
@@ -6953,41 +7070,6 @@ void UiDriver_TaskHandler_MainTasks()
 	UiDriver_TaskHandler_HighPrioTasks();
 #endif
 
-#ifdef USE_USBHOST
-	MX_USB_HOST_Process();
-
-#ifdef USE_USBKEYBOARD
-	if(USBH_HID_GetDeviceType(&hUsbHostHS) == HID_KEYBOARD)
-	{
-
-		HID_KEYBD_Info_TypeDef *k_pinfo;
-		char kbdChar;
-		k_pinfo = USBH_HID_GetKeybdInfo(&hUsbHostHS);
-
-		if(k_pinfo != NULL)
-		{
-			kbdChar = USBH_HID_GetASCIICode(k_pinfo);
-			switch(k_pinfo->keys[0])
-			{
-			case KEY_F1:
-			    RadioManagement_Request_TxOn();
-				break;
-			case KEY_F2:
-			    RadioManagement_Request_TxOff();
-				break;
-			}
-			if (kbdChar != '\0')
-			{
-				if (is_demod_rtty() || is_demod_psk())
-				{
-					DigiModes_TxBufferPutChar(kbdChar);
-				}
-				UiDriver_TextMsgPutChar(kbdChar);
-			}
-		}
-	}
-#endif
-#endif
     // START CALLED AS OFTEN AS POSSIBLE
 #ifndef USE_HIGH_PRIO_PTT
 	if (ts.tx_stop_req == true  || ts.ptt_req == true)
@@ -6996,6 +7078,10 @@ void UiDriver_TaskHandler_MainTasks()
 	}
 #endif
 	// END CALLED AS OFTEN AS POSSIBLE
+
+#ifdef USE_USBHOST
+    MX_USB_HOST_Process();
+#endif // USE_USBHOST
 
 	// BELOW ALL CALLING IS BASED ON SYSCLOCK 10ms clock
 	if (UiDriver_TimerExpireAndRewind(SCTimer_ENCODER_KEYS,now,1))
@@ -7020,6 +7106,7 @@ void UiDriver_TaskHandler_MainTasks()
 		    Codec_RestartI2S();
 		    ts.twinpeaks_tested = TWINPEAKS_WAIT;
 		}
+        UiDriver_HandleUSB_Keyboard();
 	}
 
 	UiSpectrum_Redraw();

--- a/mchf-eclipse/files.mak
+++ b/mchf-eclipse/files.mak
@@ -129,6 +129,7 @@ drivers/audio/filters/iir_antialias.c \
 drivers/audio/filters/iq_rx_filter.c \
 drivers/audio/filters/iq_rx_filter_am.c \
 drivers/audio/filters/iq_tx_filter.c \
+drivers/audio/cw/uhsdr_digi_buffer.c \
 drivers/audio/cw/cw_gen.c \
 drivers/audio/cw/cw_decoder.c \
 drivers/audio/codec/codec.c \


### PR DESCRIPTION
- Fixed issue with multi-button pressing on the keyboard.
- Added functionality into digi_buffer.
- To record F-buttons could be used Keyboard as well as CW.
- UI F-buttons assigned to F5,F6 and F7 on the keyboard.
- Digi_buffer might be reset by pressing ESC.
- UI buffer might be cleaned by pressing Backspace.

TODO:
- [ ] - Fix CW sending prosings from digi buffer. Seems it was done not right.  
- [ ] - Edit Iambic key state machine to use it for straight key.  (deprecate StraightKey handler)
- [ ] - Rename CW folder into digi_modes and move there rtty and psk modules.
- [ ] - ( need discussion) Two buffers, digi and ui can be combined into one, this gives us a chance to implement features like:
-- Display in different colors what was entered into the buffer and what was already transmitted.
--  handle "backspace" from keyboard to edit what was entered and not transmitted yet..
-- reduce size ;) and some others which I do not see now.