### PR TITLE
Refactored PSK and minor other changes

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -620,8 +620,8 @@ void AudioDriver_Init(void)
     // CW module init
     CwGen_Init();
 
-    RttyDecoder_Init();
-    PskDecoder_Init();
+    Rtty_Modem_Init();
+    Psk_Modem_Init(ts.samp_rate);
 
     // Audio filter disabled
     ts.dsp_inhibit = 1;
@@ -1677,7 +1677,7 @@ static void AudioDriver_RxProcessor_Rtty(float32_t * const src, int16_t blockSiz
 
     for (uint16_t idx = 0; idx < blockSize; idx++)
     {
-        RttyDecoder_ProcessSample(src[idx]);
+        Rtty_Demodulator_ProcessSample(src[idx]);
     }
 }
 #endif
@@ -1687,7 +1687,7 @@ static void AudioDriver_RxProcessor_Bpsk(float32_t * const src, int16_t blockSiz
 
     for (uint16_t idx = 0; idx < blockSize; idx++)
     {
-        BpskDecoder_ProcessSample(src[idx]);
+        Psk_Demodulator_ProcessSample(src[idx]);
     }
 }
 

--- a/mchf-eclipse/drivers/audio/audio_driver.h
+++ b/mchf-eclipse/drivers/audio/audio_driver.h
@@ -599,8 +599,6 @@ int32_t AudioDriver_GetTranslateFreq();
 void AudioDriver_SetSamPllParameters ();
 float log10f_fast(float X);
 
-void RttyDecoder_Init();
-
 
 void AudioDriver_I2SCallback(AudioSample_t *audio, IqSample_t *iq, AudioSample_t *audioDst, int16_t size);
 

--- a/mchf-eclipse/drivers/audio/cw/uhsdr_digi_buffer.c
+++ b/mchf-eclipse/drivers/audio/cw/uhsdr_digi_buffer.c
@@ -77,7 +77,7 @@ bool DigiModes_TxBufferRemove( uint8_t* c_ptr, digi_buff_consumer_t consumer )
 /* no room left in the buffer returns 0 */
 int32_t DigiModes_TxBufferPutChar( uint8_t c, digi_buff_consumer_t source )
 {
-    assert((source & CW) || (source & KeyBoard));
+    assert((source & CW) || (source & KeyBoard) || (source & UI));
 
     int32_t ret = 0;
     /*

--- a/mchf-eclipse/drivers/audio/psk.h
+++ b/mchf-eclipse/drivers/audio/psk.h
@@ -12,18 +12,11 @@
 #define __PSK_H
 
 #include "uhsdr_types.h"
-#include "softdds.h"
 
+// externally defined for UiSpectrum markers
 #define PSK_OFFSET 500
 #define PSK_SNAP_RANGE 100 // defines the range within which the SNAP algorithm in spectrum.c searches for the PSK carrier
-#define PSK_SAMPLE_RATE 12000 // TODO This should come from elsewhere, to be fixed
-#define PSK_BND_FLT_LEN 5
-#define PSK_BUF_LEN (PSK_SAMPLE_RATE / PSK_OFFSET)
-#define PSK_SHIFT_DIFF (1.0 * PSK_OFFSET / PSK_SAMPLE_RATE)
-#define PSK_SHIFT_90 (PSK_BUF_LEN / 4)
-#define SAMPLE_MAX 32766
-#define PSK_COS_DDS_LEN 64
-// #define PSK_MAX_SYMBOL_BUF 384 // Maximum for 12000 sample rate and 31.25; for higher sample rate should value be increased
+
 
 typedef enum {
     PSK_SPEED_31,
@@ -36,50 +29,14 @@ typedef struct
 {
     psk_speed_t id;
     float32_t value;
-    uint16_t zeros;
     const float32_t* bpf_b;
     const float32_t* bpf_a;
     uint16_t rate;
     char* label;
 } psk_speed_item_t;
 
-typedef struct
-{
-	uint16_t rate;
-
-	uint16_t tx_idx;
-	uint8_t tx_char;
-	uint16_t tx_bits;
-	int16_t tx_wave_sign_next;
-	int16_t tx_wave_sign_current;
-	uint16_t tx_bit_phase;
-	uint32_t tx_bit_len;
-	int16_t tx_zeros;
-	int16_t tx_ones;
-	bool tx_ending;
-	bool tx_win;
-
-	float32_t rx_phase;
-	float32_t rx_samples_in[PSK_BND_FLT_LEN];
-	float32_t rx_samples[PSK_BND_FLT_LEN];
-	int16_t rx_bnd_idx;
-	float32_t rx_vco[PSK_BUF_LEN];
-	float32_t rx_sin_prod[PSK_BUF_LEN];
-	float32_t rx_cos_prod[PSK_BUF_LEN];
-	float32_t rx_scmix[PSK_BUF_LEN];
-	int32_t rx_idx;
-	int8_t rx_last_bit;
-	// float32_t rx_err;
-	float32_t rx_last_symbol;
-	int16_t rx_symbol_len;
-	int16_t rx_symbol_idx;
-	// float32_t rx_symbol_buf[PSK_MAX_SYMBOL_BUF];
-	uint32_t rx_word;
-
-} PskState;
 
 extern const psk_speed_item_t psk_speeds[PSK_SPEED_NUM];
-extern PskState psk_state;
 
 typedef struct
 {
@@ -88,9 +45,21 @@ typedef struct
 
 extern psk_ctrl_t psk_ctrl_config;
 
-void PskDecoder_Init(void);
-void Bpsk_ModulatorInit(void);
-void BpskDecoder_ProcessSample(float32_t sample);
+typedef enum {
+    PSK_MOD_OFF,
+    PSK_MOD_PREAMBLE,
+    PSK_MOD_ACTIVE,
+    PSK_MOD_POSTAMBLE,
+    PSK_MOD_INACTIVE
+} psk_modulator_t;
+
+psk_modulator_t Psk_Modulator_GetState();
+psk_modulator_t Psk_Modulator_SetState(psk_modulator_t newState);
+
+
+void Psk_Modem_Init(uint32_t output_sample_rate);
+void Psk_Modulator_PrepareTx();
+void Psk_Demodulator_ProcessSample(float32_t sample);
 int16_t Psk_Modulator_GenSample();
 
 #endif

--- a/mchf-eclipse/drivers/audio/rtty.h
+++ b/mchf-eclipse/drivers/audio/rtty.h
@@ -76,8 +76,8 @@ typedef struct
 }  rtty_ctrl_t;
 
 extern rtty_ctrl_t rtty_ctrl_config;
-void RttyDecoder_Init();
-void RttyDecoder_ProcessSample(float32_t sample);
+void Rtty_Modem_Init();
+void Rtty_Demodulator_ProcessSample(float32_t sample);
 int16_t Rtty_Modulator_GenSample();
 
 #endif

--- a/mchf-eclipse/drivers/ui/radio_management.c
+++ b/mchf-eclipse/drivers/ui/radio_management.c
@@ -793,7 +793,7 @@ void RadioManagement_SwitchTxRx(uint8_t txrx_mode, bool tune_mode)
 
         if (is_demod_psk())
         {
-        	Bpsk_ModulatorInit();
+        	Psk_Modulator_PrepareTx();
         }
     }
 
@@ -1246,14 +1246,18 @@ void RadioManagement_HandlePttOnOff()
         else if (CatDriver_CatPttActive() == false)
         {
             // When CAT driver "pressed" PTT skip auto return to RX
-        	if (ts.tx_stop_req && is_demod_psk() && !psk_state.tx_ending)
+        	if (ts.tx_stop_req == true && is_demod_psk() && Psk_Modulator_GetState() == PSK_MOD_ACTIVE)
         	{
-        		psk_state.tx_ending = true;
+        		Psk_Modulator_SetState(PSK_MOD_POSTAMBLE);
         		ts.tx_stop_req = false;
         	}
         	else if(!(ts.dmod_mode == DEMOD_CW || is_demod_rtty() || is_demod_psk() || ts.cw_text_entry) || ts.tx_stop_req == true)
             {
-                // If we are in TX and ...
+        	    // we get here either if there is an explicit request to stop transmission no matter which mode we are in
+        	    // or if the mode relies on us to switch off after PTT has been released (we defines this by exclusion
+        	    // of modes which control transmission state via paddles or keyboard)
+
+        	    // If we are in TX
                 if(ts.txrx_mode == TRX_MODE_TX)
                 {
                     // ... the PTT line is released ...

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -3355,7 +3355,7 @@ static void UiDriver_CheckEncoderOne()
 		case ENC_ONE_MODE_RTTY_SPEED:
 			// Convert to Audio Gain incr/decr
 			rtty_ctrl_config.speed_idx = change_and_limit_int(rtty_ctrl_config.speed_idx,pot_diff_step,0,RTTY_SPEED_NUM-1);
-			RttyDecoder_Init();
+			Rtty_Modem_Init();
 			UiDriver_DisplayRttySpeed(true);
 			break;
 			// Update audio volume
@@ -3473,7 +3473,7 @@ static void UiDriver_CheckEncoderTwo()
 				{
 				case ENC_TWO_MODE_RTTY_SHIFT:
 					rtty_ctrl_config.shift_idx = change_and_limit_int(rtty_ctrl_config.shift_idx,pot_diff_step,0,RTTY_SHIFT_NUM-1);
-					RttyDecoder_Init();
+					Rtty_Modem_Init();
 					UiDriver_DisplayRttyShift(1);
 					break;
 				case ENC_TWO_MODE_RF_GAIN:
@@ -3690,7 +3690,7 @@ static void UiDriver_CheckEncoderThree()
 			case ENC_THREE_MODE_PSK_SPEED:
 				psk_ctrl_config.speed_idx = change_and_limit_int(psk_ctrl_config.speed_idx,pot_diff_step,0,PSK_SPEED_NUM-1);
 				UiDriver_TextMsgClear();
-				PskDecoder_Init();
+				Psk_Modem_Init(ts.samp_rate);
 				UiDriver_DisplayPskSpeed(true);
 				break;
 				// Update audio volume
@@ -6387,6 +6387,12 @@ static void UiAction_PlayKeyerBtnN(int8_t n)
 			while (*pmacro != '\0')
 			{
 				DigiModes_TxBufferPutChar( *pmacro++, UI );
+			}
+			if (ts.buffered_tx)
+			{
+			    DigiModes_TxBufferPutChar( 0x04, UI );
+			    // we put an EOT in the buffer, which tells the respective consumer
+			    // to return to receive after transmitting all characters before this
 			}
 
 			if ((ts.dmod_mode == DEMOD_CW


### PR DESCRIPTION
- PSK extensively commented
- PSK transmit now sends a preamble and postamble, works nice.
- PSK receive reworked to be easier to understand (but not working better, yet).
  Needs very (!) precise tune.
- Small changes to RTTY and PSK if used in combination with digibuffer
  buffered TX. In this case EOT is inserted automatically in the buffer
  and after transmission TX returns to RX properly.
- PSK code has less dependencies to rest of system. Also cleaned includes of
  RTTY.
- Fixed a small issue in digibuffer if keyer was used with PSK and full debug