### PR TITLE
Somehow related to #1675.

### DIFF
--- a/mchf-eclipse/misc/config_storage.c
+++ b/mchf-eclipse/misc/config_storage.c
@@ -142,14 +142,26 @@ uint16_t ConfigStorage_WriteVariable(uint16_t addr, uint16_t value)
     }
     else if(ts.configstore_in_use == CONFIGSTORE_IN_USE_RAMCACHE)
     {
-        uint8_t lowbyte;
-        uint8_t highbyte;
+        /**
+         * Was found that during saving settings,
+         * first two cells was corrupted.
+         * Just temp. protection...
+         */
+        if ( addr == 0 )
+        {
+            status = HAL_ERROR;
+        }
+        else
+        {
+            uint8_t lowbyte;
+            uint8_t highbyte;
 
-        lowbyte = (uint8_t)((0x00FF)&value);
-        highbyte = (uint8_t)((0x00FF)&(value >> 8));
-        config_ramcache[addr*2] = highbyte;
-        config_ramcache[addr*2+1] = lowbyte;
-        status = HAL_OK;
+            lowbyte = (uint8_t)((0x00FF)&value);
+            highbyte = (uint8_t)((0x00FF)&(value >> 8));
+            config_ramcache[addr*2] = highbyte;
+            config_ramcache[addr*2+1] = lowbyte;
+            status = HAL_OK;
+        }
     }
     return status;
 }

--- a/mchf-eclipse/misc/serial_eeprom.c
+++ b/mchf-eclipse/misc/serial_eeprom.c
@@ -549,6 +549,7 @@ void  SerialEEPROM_Clear_AllVariables()
 void  SerialEEPROM_Clear_Signature()
 {
     // variable 0 is the reserved signature variable
+    ts.ser_eeprom_type = SerialEEPROM_24Cxx_DetectProbeHardware();
     SerialEEPROM_Clear_Variable(0);
 }
 


### PR DESCRIPTION
Read comments under commits.

it's start - reading from eeprom to ram
![](https://s8.hostingkartinok.com/uploads/images/2019/01/55968ec4e679a30e1498ea375e3aad01.jpg)

it's copying back within changes applied
![](https://s8.hostingkartinok.com/uploads/images/2019/01/282480c571d0d13259a288d92f31fb1e.jpg) 

Do you see, it's writing back 0x00 and 0x00 to first two bytes.
I did not find what and where did not have time. almost night...
Added simple protection as a temp fix.