### PR TITLE
 Attempt to prevent #1675 (i2c eeprom signature corruption), add unaligned i2c eeprom bulk write, keyer macro extensions

### DIFF
--- a/mchf-eclipse/drivers/ui/ui_configuration.c
+++ b/mchf-eclipse/drivers/ui/ui_configuration.c
@@ -56,11 +56,11 @@ static uint16_t number_of_entries_cur_fw; // we need this to be able to read con
 // from eeprom, we read -1 from the new location and leave it there. Unless -1 is the default value or the range of the int configuration parameter does not include -1
 // we will not automatically set the default value, which can be a problem.
 
-static uint16_t dummy_value16;
-
 const ConfigEntryDescriptor ConfigEntryInfo[] =
 {
-    { ConfigEntry_UInt16, EEPROM_ZERO_LOC,&dummy_value16,0,0,0xffff},
+    // { ConfigEntry_UInt16, EEPROM_ZERO_LOC,&dummy_value16,0,0,0xffff},
+    // disable since we don't want to handle the eeprom signature here.
+
     { ConfigEntry_UInt16, EEPROM_FLAGS2,&ts.flags2,0,0,0xff},
     { ConfigEntry_UInt8, EEPROM_SPEC_SCOPE_SPEED,&ts.scope_speed,SPECTRUM_SCOPE_SPEED_DEFAULT,0,SPECTRUM_SCOPE_SPEED_MAX},
     { ConfigEntry_UInt32_16, EEPROM_FREQ_STEP,&df.selected_idx,3,0,T_STEP_MAX_STEPS-2},

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -7040,17 +7040,46 @@ static void UiDriver_HandleUSB_Keyboard()
                       RadioManagement_Request_TxOff();
                       break;
                     case KEY_F5:
-                      RadioManagement_Request_TxOn();
-                      UiAction_PlayKeyerBtn1();
-                      break;
+                        if (k_pinfo->lshift)
+                        {
+                            UiAction_RecordKeyerBtn1();
+                        }
+                        else
+                        {
+                            UiAction_PlayKeyerBtn1();
+                        }
+                        break;
                     case KEY_F6:
-                      RadioManagement_Request_TxOn();
-                      UiAction_PlayKeyerBtn2();
-                      break;
+                        if (k_pinfo->lshift)
+                        {
+                            UiAction_RecordKeyerBtn2();
+                        }
+                        else
+                        {
+                            UiAction_PlayKeyerBtn2();
+                        }
+                        break;
                     case KEY_F7:
-                      RadioManagement_Request_TxOn();
-                      UiAction_PlayKeyerBtn3();
+                        if (k_pinfo->lshift)
+                        {
+                            UiAction_RecordKeyerBtn3();
+                        }
+                        else
+                        {
+                            UiAction_PlayKeyerBtn3();
+                        }
+                        break;
+                    case KEY_F8:
+                        if (k_pinfo->lshift)
+                        {
+                            UiAction_ToggleBufferedTXMode();
+                        }
+                        else
+                        {
+                            UiAction_ToggleKeyerMode();
+                        }
                       break;
+
                     }
 
                     uint8_t kbdChar = USBH_HID_GetASCIICode( k_pinfo, idx );

--- a/mchf-eclipse/misc/config_storage.c
+++ b/mchf-eclipse/misc/config_storage.c
@@ -218,7 +218,8 @@ void ConfigStorage_CopySerial2RAMCache()
 
 uint16_t ConfigStorage_CopyRAMCache2Serial()
 {
-    uint16_t retval = SerialEEPROM_24Cxx_WriteBulk(0, config_ramcache, MAX_VAR_ADDR*2+2, ts.ser_eeprom_type);
+    // we start behind the signature, which we don't want to change
+    uint16_t retval = SerialEEPROM_24Cxx_WriteBulk(2, config_ramcache+2, MAX_VAR_ADDR*2, ts.ser_eeprom_type);
     if (retval == HAL_OK)
     {
         ts.configstore_in_use = CONFIGSTORE_IN_USE_I2C;


### PR DESCRIPTION
The main focus is the fix for #1675.  This complements the #1713 (which should be merged in too).
See commit message for details.

There is also more keyer functions on the keyboard, see commit messages for details. 


