### PR TITLE
Refactor RX filtering

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_filter.h
+++ b/mchf-eclipse/drivers/audio/audio_filter.h
@@ -31,10 +31,11 @@ extern arm_fir_instance_f32    Fir_Rx_Hilbert_Q;
 extern arm_fir_instance_f32    Fir_Rx_Hilbert_I;
 extern arm_fir_instance_f32    Fir_TxFreeDV_Interpolate_Q;
 extern arm_fir_instance_f32    Fir_TxFreeDV_Interpolate_I;
-extern arm_fir_decimate_instance_f32 FirDecim_RxSam_I;
-extern arm_fir_decimate_instance_f32 FirDecim_RxSam_Q;
+extern arm_fir_decimate_instance_f32 DECIMATE_RX_I;
+extern arm_fir_decimate_instance_f32 DECIMATE_RX_Q;
 
-void 	AudioFilter_InitRxHilbertFIR(uint8_t dmod_mode);
+
+void 	AudioFilter_InitRxHilbertAndDecimationFIR(uint8_t dmod_mode);
 void 	AudioFilter_InitTxHilbertFIR(void);
 
 enum
@@ -173,6 +174,5 @@ typedef struct
 void AudioFilter_CalcGoertzel(Goertzel* g, float32_t freq, const uint32_t size, const float goertzel_coeff, float32_t samplerate);
 void AudioFilter_GoertzelInput(Goertzel* goertzel, float32_t in);
 float32_t AudioFilter_GoertzelEnergy(Goertzel* goertzel);
-
 
 #endif /* DRIVERS_AUDIO_AUDIO_FILTER_H_ */

--- a/mchf-eclipse/drivers/audio/freq_shift.c
+++ b/mchf-eclipse/drivers/audio/freq_shift.c
@@ -9,7 +9,7 @@
 
 #include <assert.h>
 #include "freq_shift.h"
-#include "audio_driver.h"
+#include "audio_driver.h" // only for IQ_BLOCK_SIZE and IQ_SAMPLE_RATE_F
 #include <math.h>
 #include <stdlib.h>
 
@@ -263,7 +263,10 @@ static void FreqShift_QuarterFs(float32_t* I_buffer, float32_t* Q_buffer, int16_
 
 /**
  * Frequency shift using the best available algorithm. Handles changes to the shift frequency on the fly. This is
- * the front end for all the shift algorithms.
+ * the front end for all the shift algorithms. Sample rate is fixed to IQ_SAMPLE_RATE, max buffer is IQ_BLOCK_SIZE
+ * It cannot be called twice at the same time (i.e. must not be used in code running in different interrupt levels
+ * which may interrupt each other or mixed in normal code and interrupt code)
+ *
  * @param I_buffer incoming i data
  * @param Q_buffer incoming q data
  * @param blockSize size of data to be processed

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -908,7 +908,8 @@ void UiDriver_Init()
 
 	AudioManagement_CalcTxCompLevel();      // calculate current settings for TX speech compressor
 
-	AudioFilter_InitRxHilbertFIR(ts.dmod_mode);
+	// FIXME: These are also called via AudioDriver_Init(), why call them here earlier?
+	AudioFilter_InitRxHilbertAndDecimationFIR(ts.dmod_mode);
 	AudioFilter_InitTxHilbertFIR();
 
 	AudioManagement_SetSidetoneForDemodMode(ts.dmod_mode,false);


### PR DESCRIPTION
- Aligned filter setup so that all demod mode use the same decimation filter
instances (not the same filter, the actual filter is as before, though)
- this freed up some RAM in the CCM on the F4 (not much, about a 1k)
- Moved a few math functions around to prepare for extraction