### PR TITLE
More audio_driver related refactorings

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_agc.h
+++ b/mchf-eclipse/drivers/audio/audio_agc.h
@@ -1,0 +1,46 @@
+/*  -*-  mode: c; tab-width: 4; indent-tabs-mode: t; c-basic-offset: 4; coding: utf-8  -*-  */
+/************************************************************************************
+ **                                                                                **
+ **                                        UHSDR                                   **
+ **               a powerful firmware for STM32 based SDR transceivers             **
+ **                                                                                **
+ **--------------------------------------------------------------------------------**
+ **                                                                                **
+ **  Description:   Code for automatic gain control based on the WDSP Lib          **
+ **  Licence:		GNU GPLv3                                                      **
+ ************************************************************************************/
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __AUDIO_AGC_H
+#define __AUDIO_AGC_H
+
+#include "uhsdr_board_config.h"
+#include "uhsdr_types.h"
+
+// these are the control parameter
+// for external runtime configuration
+// of the AGC
+typedef struct
+{
+    uint8_t mode;
+    uint8_t slope;
+    uint8_t hang_enable;
+    int     thresh;
+    int     hang_thresh;
+    int hang_time;
+    uint8_t action;
+    uint8_t switch_mode;
+    uint8_t hang_action;
+    int tau_decay[6];
+    int tau_hang_decay;
+} agc_wdsp_params_t;
+
+
+extern agc_wdsp_params_t agc_wdsp_conf;
+
+void AudioAgc_RunAgcWdsp(int16_t blockSize, float32_t (*agcbuffer)[AUDIO_BLOCK_SIZE], const bool use_stereo );
+void AudioAgc_SetupAgcWdsp(float32_t sample_rate, uint16_t dmod_mode);
+void AudioAgc_InitAgcWdsp();
+
+
+#endif

--- a/mchf-eclipse/drivers/audio/audio_driver.h
+++ b/mchf-eclipse/drivers/audio/audio_driver.h
@@ -24,10 +24,8 @@
 //#include "audio_convolution.h"
 
 
-#define IQ_SAMPLE_RATE (48000)
 #define IQ_SAMPLE_RATE_F ((float32_t)IQ_SAMPLE_RATE)
 
-#define AUDIO_SAMPLE_RATE (48000)
 #define AUDIO_SAMPLE_RATE_F ((float32_t)AUDIO_SAMPLE_RATE)
 
 
@@ -69,12 +67,6 @@ typedef struct {
 	#define FFT_IQ_BUFF_LEN		512
 #endif
 #define SPEC_BUFF_LEN (FFT_IQ_BUFF_LEN/2)
-
-//
-// we process one dma block of samples at once
-#define IQ_BLOCK_SIZE IQ_SAMPLES_PER_BLOCK
-#define AUDIO_BLOCK_SIZE AUDIO_SAMPLES_PER_BLOCK
-
 
 // twice the number of samples in the each iq block buffer
 // (which is half of the total dma buffer, since in each interrupt we get half of the total dma buffer)
@@ -706,8 +698,6 @@ void TxProcessor_Init();
 
 extern float32_t   audio_delay_buffer    [AUDIO_DELAY_BUFSIZE];
 
-// AGC
-void AudioDriver_RxAgcWdsp(int16_t blockSize, float32_t (*agcbuffer)[AUDIO_BLOCK_SIZE] );
 void AudioDriver_SetupAgcWdsp();
 
 #endif

--- a/mchf-eclipse/drivers/audio/audio_filter.c
+++ b/mchf-eclipse/drivers/audio/audio_filter.c
@@ -1144,14 +1144,14 @@ void 	AudioFilter_InitRxHilbertAndDecimationFIR(uint8_t dmod_mode)
 
     assert(ads.af_disabled != 0);
 
-    const uint32_t rx_iq_num_taps = FilterPathInfo[ts.filter_path].FIR_numTaps;
+    const uint32_t rx_iq_num_taps = ts.filters_p->FIR_numTaps;
 
     // in FilterPathInfo, we have stored the coefficients already, so no if . . . necessary
     // also applicable for FM case !
     for(int i = 0; i < rx_iq_num_taps; i++)
     {
-        fc.fir_rx_hilbert_taps_i[i] = FilterPathInfo[ts.filter_path].FIR_I_coeff_file[i];
-        fc.fir_rx_hilbert_taps_q[i] = FilterPathInfo[ts.filter_path].FIR_Q_coeff_file[i];
+        fc.fir_rx_hilbert_taps_i[i] = ts.filters_p->FIR_I_coeff_file[i];
+        fc.fir_rx_hilbert_taps_q[i] = ts.filters_p->FIR_Q_coeff_file[i];
     }
 
     // Initialization of the FIR/Hilbert filters
@@ -1167,17 +1167,17 @@ void 	AudioFilter_InitRxHilbertAndDecimationFIR(uint8_t dmod_mode)
     // Set up RX SAM decimation/filter
     if (dmod_mode == DEMOD_SAM || dmod_mode == DEMOD_AM)
     {
-        if (FilterPathInfo[ts.filter_path].FIR_numTaps != 0)
+        if (ts.filters_p->FIR_numTaps != 0)
         {
-            DECIMATE_RX_I.numTaps = FilterPathInfo[ts.filter_path].FIR_numTaps;
-            DECIMATE_RX_Q.numTaps = FilterPathInfo[ts.filter_path].FIR_numTaps;
+            DECIMATE_RX_I.numTaps = ts.filters_p->FIR_numTaps;
+            DECIMATE_RX_Q.numTaps = ts.filters_p->FIR_numTaps;
             DECIMATE_RX_I.pCoeffs = fc.fir_rx_hilbert_taps_i;
             DECIMATE_RX_Q.pCoeffs = fc.fir_rx_hilbert_taps_q;
         }
     }
-    else if (FilterPathInfo[ts.filter_path].dec != NULL)
+    else if (ts.filters_p->dec != NULL)
     {
-            const arm_fir_decimate_instance_f32* dec = FilterPathInfo[ts.filter_path].dec;
+            const arm_fir_decimate_instance_f32* dec = ts.filters_p->dec;
 
     #if defined(STM32F4) && defined(USE_LMS_AUTONOTCH)
             // FIXME: Better solution (e.g. improve graphics performance, better data structures ... )

--- a/mchf-eclipse/drivers/audio/audio_management.c
+++ b/mchf-eclipse/drivers/audio/audio_management.c
@@ -316,7 +316,7 @@ void AudioManagement_CalcSubaudibleGenFreq(void)
  */
 void AudioManagement_CalcSubaudibleDetFreq(void)
 {
-    const uint32_t size = AUDIO_SAMPLES_PER_BLOCK;
+    const uint32_t size = AUDIO_BLOCK_SIZE;
 
     ads.fm_conf.subaudible_tone_det_freq = fm_subaudible_tone_table[ts.fm_subaudible_tone_det_select];       // look up tone frequency (in Hz)
 

--- a/mchf-eclipse/drivers/audio/audio_nr.c
+++ b/mchf-eclipse/drivers/audio/audio_nr.c
@@ -8,7 +8,7 @@
  **  Licence:       GNU GPLv3                                                       **
  ************************************************************************************/
 
-#include "uhsdr_board.h"
+#include "uhsdr_board_config.h"
 #include "audio_nr.h"
 #include "arm_const_structs.h"
 #include "profiling.h"
@@ -16,6 +16,31 @@
 //#define debug_alternate_NR
 
 #ifdef USE_ALTERNATE_NR
+
+static void alt_noise_blanking();
+static void spectral_noise_reduction_3();
+static void AudioNr_RunNoiseReduction(float32_t* inputsamples, float32_t* outputsamples );
+
+typedef struct NoiseReduction // declaration
+{
+    float32_t                   last_iFFT_result [NR_FFT_L_2 / 2];
+    float32_t                   last_sample_buffer_L [NR_FFT_L_2 / 2];
+    float32_t                   FFT_buffer[NR_FFT_L_2 * 2];
+    float32_t                   Nest[NR_FFT_L_2 / 2][2]; // noise estimates for the current and the last FFT frame
+    float32_t                   vk; // saved 0.24kbytes
+    float32_t                   SNR_prio[NR_FFT_L_2 / 2];
+    float32_t                   SNR_post[NR_FFT_L_2 / 2];
+    float32_t                   SNR_post_pos; // saved 0.24kbytes
+    float32_t                   Hk_old[NR_FFT_L_2 / 2];
+//  float32_t                   VAD;
+//  float32_t                   VAD_Esch; // holds the VAD sum for the Esh & Vary 2009 type of VAD
+//  float32_t                   notch1_f;
+//  bool                        notch1_enable;
+//  float32_t                   notch2_f;
+//  bool                        notch2_enable;
+    //ulong                     long_tone_counter;
+} NoiseReduction;
+
 
 NoiseReduction __MCHF_SPECIALMEM 	NR; // definition
 NoiseReduction2 __MCHF_SPECIALMEM	NR2; // definition
@@ -47,6 +72,29 @@ NR_Buffer* NR_out_buffers[NR_BUFFER_FIFO_SIZE];
 */
 const float32_t SQRT_von_Hann_256[256] = {0,0.01231966,0.024637449,0.036951499,0.049259941,0.061560906,0.073852527,0.086132939,0.098400278,0.110652682,0.122888291,0.135105247,0.147301698,0.159475791,0.171625679,0.183749518,0.195845467,0.207911691,0.219946358,0.231947641,0.24391372,0.255842778,0.267733003,0.279582593,0.291389747,0.303152674,0.314869589,0.326538713,0.338158275,0.349726511,0.361241666,0.372701992,0.384105749,0.395451207,0.406736643,0.417960345,0.429120609,0.440215741,0.451244057,0.462203884,0.473093557,0.483911424,0.494655843,0.505325184,0.515917826,0.526432163,0.536866598,0.547219547,0.557489439,0.567674716,0.577773831,0.587785252,0.597707459,0.607538946,0.617278221,0.626923806,0.636474236,0.645928062,0.65528385,0.664540179,0.673695644,0.682748855,0.691698439,0.700543038,0.709281308,0.717911923,0.726433574,0.734844967,0.743144825,0.75133189,0.759404917,0.767362681,0.775203976,0.78292761,0.790532412,0.798017227,0.805380919,0.812622371,0.819740483,0.826734175,0.833602385,0.840344072,0.846958211,0.853443799,0.859799851,0.866025404,0.872119511,0.878081248,0.88390971,0.889604013,0.895163291,0.900586702,0.905873422,0.911022649,0.916033601,0.920905518,0.92563766,0.930229309,0.934679767,0.938988361,0.943154434,0.947177357,0.951056516,0.954791325,0.958381215,0.961825643,0.965124085,0.968276041,0.971281032,0.974138602,0.976848318,0.979409768,0.981822563,0.984086337,0.986200747,0.988165472,0.989980213,0.991644696,0.993158666,0.994521895,0.995734176,0.996795325,0.99770518,0.998463604,0.999070481,0.99952572,0.99982925,0.999981027,0.999981027,0.99982925,0.99952572,0.999070481,0.998463604,0.99770518,0.996795325,0.995734176,0.994521895,0.993158666,0.991644696,0.989980213,0.988165472,0.986200747,0.984086337,0.981822563,0.979409768,0.976848318,0.974138602,0.971281032,0.968276041,0.965124085,0.961825643,0.958381215,0.954791325,0.951056516,0.947177357,0.943154434,0.938988361,0.934679767,0.930229309,0.92563766,0.920905518,0.916033601,0.911022649,0.905873422,0.900586702,0.895163291,0.889604013,0.88390971,0.878081248,0.872119511,0.866025404,0.859799851,0.853443799,0.846958211,0.840344072,0.833602385,0.826734175,0.819740483,0.812622371,0.805380919,0.798017227,0.790532412,0.78292761,0.775203976,0.767362681,0.759404917,0.75133189,0.743144825,0.734844967,0.726433574,0.717911923,0.709281308,0.700543038,0.691698439,0.682748855,0.673695644,0.664540179,0.65528385,0.645928062,0.636474236,0.626923806,0.617278221,0.607538946,0.597707459,0.587785252,0.577773831,0.567674716,0.557489439,0.547219547,0.536866598,0.526432163,0.515917826,0.505325184,0.494655843,0.483911424,0.473093557,0.462203884,0.451244057,0.440215741,0.429120609,0.417960345,0.406736643,0.395451207,0.384105749,0.372701992,0.361241666,0.349726511,0.338158275,0.326538713,0.314869589,0.303152674,0.291389747,0.279582593,0.267733003,0.255842778,0.24391372,0.231947641,0.219946358,0.207911691,0.195845467,0.183749518,0.171625679,0.159475791,0.147301698,0.135105247,0.122888291,0.110652682,0.098400278,0.086132939,0.073852527,0.061560906,0.049259941,0.036951499,0.024637449,0.01231966,0};
 
+void NR_Init()
+{
+    nr_params.alpha = 0.94; // spectral noise reduction
+    nr_params.beta = 0.96;
+//  nr_params.vad_thresh = 4.0;
+    nr_params.enable = false;
+    nr_params.NR_FFT_L = 256;
+    nr_params.NR_FFT_LOOP_NO = 1;
+//  nr_params.gain_smooth_enable = false;
+//  nr_params.gain_smooth_alpha = 0.25;
+//  nr_params.long_tone_enable = false;
+//  nr_params.long_tone_alpha = 0.999;
+//  nr_params.long_tone_thresh = 10000;
+//  nr_params.long_tone_reset = true;
+    nr_params.first_time = 1;
+//  nr_params.vad_delay = 7;
+    nr_params.NR_decimation_enable = true;
+    nr_params.fft_256_enable = true;
+    ts.special_functions_enabled = 0;
+    NR2.width = 4;
+    NR2.power_threshold = 0.40;
+    NR2.asnr = 30;
+}
 
 #if 0
 // biquad IIR filter with a maximum of four notch filters
@@ -84,7 +132,7 @@ void AudioNr_CalculateAutoNotch(float32_t coeffs[6], uint8_t notch1_bin, bool no
     // formula taken from:
 	// DSP Audio-EQ-cookbook for generating the coeffs of the filters on the fly
     // www.musicdsp.org/files/Audio-EQ-Cookbook.txt  [by Robert Bristow-Johnson]
-	float32_t bin_BW = FS / ts.NR_FFT_L;
+	float32_t bin_BW = FS / nr_params.NR_FFT_L;
 	float32_t f0 = ((float32_t)notch1_bin + 0.5) * bin_BW; // where its happening, man ;-) centre f of the bin
     float32_t Q = 10; // larger Q gives narrower notch
     float32_t w0 = 6.28318530717958 * f0 / FS;
@@ -245,8 +293,12 @@ int32_t NR_out_has_room()
 }
 
 
-
-void alternateNR_handle()
+/**
+ * External "interface" of the noise reduction, handles the buffer communication and runs the actual processing algorithm
+ * Runs for a significant time (couple of milliseconds on a STM32F4) so must be run in an interruptible context.
+ * All "communication" with the outside world is through parameter and the input and output buffers.
+ */
+void AudioNr_HandleNoiseReduction()
 {
     static uint16_t NR_current_buffer_idx = 0;
     static bool NR_was_here = false;
@@ -275,7 +327,7 @@ void alternateNR_handle()
 
         //profileTimedEventStart(ProfileTP8);
 
-        do_alternate_NR(&input_buf->samples[0].real,&mmb.nr_audio_buff[NR_current_buffer_idx].samples[NR_FFT_SIZE].real);
+        AudioNr_RunNoiseReduction(&input_buf->samples[0].real,&mmb.nr_audio_buff[NR_current_buffer_idx].samples[NR_FFT_SIZE].real);
 
         //profileTimedEventStop(ProfileTP8);
 
@@ -286,27 +338,31 @@ void alternateNR_handle()
 
 }
 
-
-void do_alternate_NR(float32_t* inputsamples, float32_t* outputsamples )
+/**
+ * This is an internal function doing the actual noise reduction
+ * @param inputsamples buffer with input samples
+ * @param outputsamples buffer with processed output samples
+ */
+static void AudioNr_RunNoiseReduction(float32_t* inputsamples, float32_t* outputsamples )
 {
 
     float32_t* Energy=0;
 
-    if(ts.nb_setting > 0)
+    if(is_dsp_nb_active())
     {
         alt_noise_blanking(inputsamples,NR_FFT_SIZE,Energy);
     }
 
     //    if((ts.dsp_active & DSP_NR_ENABLE) || (ts.dsp_active & DSP_NOTCH_ENABLE))
-    if(ts.dsp_active & DSP_NR_ENABLE)
+    if(is_dsp_nr())
     {
 		profileTimedEventStart(ProfileTP8);
 
 		/*	// spectral_noise_reduction_2(inputsamples);
-		if (ts.nr_mode == 0)
+		if (nr_params.mode == 0)
 		  spectral_noise_reduction(inputsamples);
 		else
-		  if (ts.nr_mode == 1)
+		  if (nr_params.mode == 1)
 			spectral_noise_reduction_2(inputsamples);
 		  else
 			  */
@@ -326,7 +382,7 @@ void do_alternate_NR(float32_t* inputsamples, float32_t* outputsamples )
 // debugging switches
 //#define OLD_LONG_TONE_DETECTION
 //#define NR_NOTCHTEST
-//#define NR_FFT_256 // if you change this, also changts.NR_FFT_LFFT_L in audio_nr.h
+//#define NR_FFT_256 // if you change this, also changnr_params.NR_FFT_LFFT_L in audio_nr.h
 
 
 
@@ -427,7 +483,7 @@ void spectral_noise_reduction (float* in_buffer)
 	  0.0218677165, 0.0152200676, 0.0097587564, 0.0054971478, 0.0024456704, 0.0006117919, 0};
 */
 		float32_t NR_sample_rate = 12000.0;
-		if(ts.NR_decimation_enable)
+		if(nr_params.NR_decimation_enable)
 		{
 			NR_sample_rate = 6000.0;
 		}
@@ -438,16 +494,16 @@ static uint8_t NR_init_counter = 0;
 uint8_t VAD_low=0;
 uint8_t VAD_high=63;
 float32_t NR_temp_sum = 0.0;
-float32_t width = FilterInfo[FilterPathInfo[ts.filter_path].id].width;
-float32_t offset = FilterPathInfo[ts.filter_path].offset;
-float32_t lf_freq = (offset - width/2) / (NR_sample_rate / ts.NR_FFT_L); // bin BW is 93.75Hz [12000Hz / 128 bins]
-float32_t uf_freq = (offset + width/2) / (NR_sample_rate / ts.NR_FFT_L);
+float32_t width = FilterInfo[ts.filters_p->id].width;
+float32_t offset = ts.filters_p->offset;
+float32_t lf_freq = (offset - width/2) / (NR_sample_rate / nr_params.NR_FFT_L); // bin BW is 93.75Hz [12000Hz / 128 bins]
+float32_t uf_freq = (offset + width/2) / (NR_sample_rate / nr_params.NR_FFT_L);
 
-    if(ts.nr_first_time == 1)
+    if(nr_params.first_time == 1)
     { // TODO: properly initialize all the variables
-        for(int bindx = 0; bindx < ts.NR_FFT_L / 2; bindx++)
+        for(int bindx = 0; bindx < nr_params.NR_FFT_L / 2; bindx++)
         {
-          if (ts.nr_mode==0)
+          if (nr_params.mode==0)
            {
             NR.last_sample_buffer_L[bindx] = 20.0;
             NR.Hk_old[bindx] = 0.1; // old gain or xu in development mode
@@ -461,9 +517,9 @@ float32_t uf_freq = (offset + width/2) / (NR_sample_rate / ts.NR_FFT_L);
           else  //development mode
             {
               NR.last_sample_buffer_L[bindx] = 0.0;
-              NR.Hk[bindx] = 1.0;
+              NR2.Hk[bindx] = 1.0;
 			//xu[bindx] = 1.0;  //has to be replaced by other variable
-              NR.Hk_old[bindx] = 1.0; // old gain or xu in development mode
+              NR2.Hk_old[bindx] = 1.0; // old gain or xu in development mode
 	      NR.Nest[bindx][0] = 0.0;
 	      NR.Nest[bindx][1] = 1.0;
 	      //NR2.X[bindx][1] = 0.0;
@@ -472,18 +528,18 @@ float32_t uf_freq = (offset + width/2) / (NR_sample_rate / ts.NR_FFT_L);
 
             }
         }
-	ts.nr_first_time = 2; // we need to do some more a bit later down
+	nr_params.first_time = 2; // we need to do some more a bit later down
     }
 
 
-    if(ts.nr_long_tone_reset)
+    if(nr_params.long_tone_reset)
     {
-        for(int bindx = 0; bindx < ts.NR_FFT_L / 2; bindx++)
+        for(int bindx = 0; bindx < nr_params.NR_FFT_L / 2; bindx++)
         {
         	NR2.long_tone_gain[bindx] = 1.0;
         	NR2.long_tone_counter[bindx] = 10;
         }
-    	ts.nr_long_tone_reset = false;
+    	nr_params.long_tone_reset = false;
     	NR2.notch_change = false;
     	NR2.notch1_bin = 10; // frequency bin where notch filter 1 has to work
     	NR2.max_bin = 10; // holds the bin number of the strongest persistent tone during tone detection
@@ -494,33 +550,33 @@ float32_t uf_freq = (offset + width/2) / (NR_sample_rate / ts.NR_FFT_L);
     	NR2.notch4_active = false; // is notch4 active?
     }
 
-    for(int k = 0; k < ts.NR_FFT_LOOP_NO; k++)
+    for(int k = 0; k < nr_params.NR_FFT_LOOP_NO; k++)
     {
     // NR_FFT_buffer is 256 floats big
     // interleaved r, i, r, i . . .
     // fill first half of FFT_buffer with last events audio samples
-          for(int i = 0; i < ts.NR_FFT_L / 2; i++)
+          for(int i = 0; i < nr_params.NR_FFT_L / 2; i++)
           {
             NR.FFT_buffer[i * 2] = NR.last_sample_buffer_L[i]; // real
             NR.FFT_buffer[i * 2 + 1] = 0.0; // imaginary
           }
     // copy recent samples to last_sample_buffer for next time!
-          for(int i = 0; i < ts.NR_FFT_L  / 2; i++)
+          for(int i = 0; i < nr_params.NR_FFT_L  / 2; i++)
           {
-             NR.last_sample_buffer_L [i] = in_buffer[i + k * (ts.NR_FFT_L / 2)];
+             NR.last_sample_buffer_L [i] = in_buffer[i + k * (nr_params.NR_FFT_L / 2)];
           }
     // now fill recent audio samples into second half of FFT_buffer
-          for(int i = 0; i < ts.NR_FFT_L / 2; i++)
+          for(int i = 0; i < nr_params.NR_FFT_L / 2; i++)
           {
-              NR.FFT_buffer[ts.NR_FFT_L + i * 2] = in_buffer[i+ k * (ts.NR_FFT_L / 2)]; // real
-              NR.FFT_buffer[ts.NR_FFT_L + i * 2 + 1] = 0.0;
+              NR.FFT_buffer[nr_params.NR_FFT_L + i * 2] = in_buffer[i+ k * (nr_params.NR_FFT_L / 2)]; // real
+              NR.FFT_buffer[nr_params.NR_FFT_L + i * 2 + 1] = 0.0;
           }
     /////////////////////////////////7
     // WINDOWING
-                if(ts.nr_fft_256_enable)
+                if(nr_params.fft_256_enable)
                 {
                     arm_cfft_f32(&arm_cfft_sR_f32_len256, NR.FFT_buffer, 0, 1);
-              	  for (int idx = 0; idx < ts.NR_FFT_L; idx++)
+              	  for (int idx = 0; idx < nr_params.NR_FFT_L; idx++)
                     {
               	  	  NR.FFT_buffer[idx * 2] *= SQRT_von_Hann_256[idx];
                     }
@@ -528,7 +584,7 @@ float32_t uf_freq = (offset + width/2) / (NR_sample_rate / ts.NR_FFT_L);
                 else
                 {
                     arm_cfft_f32(&arm_cfft_sR_f32_len128, NR.FFT_buffer, 0, 1);
-                    for (int idx = 0; idx < ts.NR_FFT_L; idx++)
+                    for (int idx = 0; idx < nr_params.NR_FFT_L; idx++)
                     {
                   	  NR.FFT_buffer[idx * 2] *= SQRT_van_hann[idx];
                     }
@@ -536,28 +592,28 @@ float32_t uf_freq = (offset + width/2) / (NR_sample_rate / ts.NR_FFT_L);
 
     #ifdef NR_WINDOW_HANN
     // perform windowing on 128 real samples in the NR_FFT_buffer
-          for (int idx = 0; idx < ts.NR_FFT_L; idx++)
+          for (int idx = 0; idx < nr_params.NR_FFT_L; idx++)
           {     // Hann window
-             float32_t temp_sample = 0.5 * (float32_t)(1.0 - (cosf(PI* 2.0 * (float32_t)idx / (float32_t)((ts.NR_FFT_L) - 1))));
+             float32_t temp_sample = 0.5 * (float32_t)(1.0 - (cosf(PI* 2.0 * (float32_t)idx / (float32_t)((nr_params.NR_FFT_L) - 1))));
              NR.FFT_buffer[idx * 2] *= temp_sample;
           }
     #endif
 	#ifdef NR_WINDOW_SIN2
 // perform windowing on 128 real samples in the NR_FFT_buffer
-      for (int idx = 0; idx < ts.NR_FFT_L; idx++)
+      for (int idx = 0; idx < nr_params.NR_FFT_L; idx++)
       {
           // SIN^2 window
-                    float32_t SINF = (sinf(PI * (float32_t)idx / (float32_t)(ts.NR_FFT_L - 1)));
+                    float32_t SINF = (sinf(PI * (float32_t)idx / (float32_t)(nr_params.NR_FFT_L - 1)));
                     SINF = (SINF * SINF);
                     NR.FFT_buffer[idx * 2] *= SINF;
       }
 	#endif
 #ifdef NR_WINDOW_SIN4
 // perform windowing on 128 real samples in the NR_FFT_buffer
-  for (int idx = 0; idx < ts.NR_FFT_L; idx++)
+  for (int idx = 0; idx < nr_params.NR_FFT_L; idx++)
   {
       // SIN^2 window
-                float32_t SINF = (sinf(PI * (float32_t)idx / (float32_t)(ts.NR_FFT_L - 1)));
+                float32_t SINF = (sinf(PI * (float32_t)idx / (float32_t)(nr_params.NR_FFT_L - 1)));
                 SINF *= SINF;
                 SINF *= SINF;
                 NR.FFT_buffer[idx * 2] *= SINF;
@@ -565,20 +621,20 @@ float32_t uf_freq = (offset + width/2) / (NR_sample_rate / ts.NR_FFT_L);
 #endif
 
  #ifndef NR_NOTCHTEST
-              for(int bindx = 0; bindx < ts.NR_FFT_L / 2; bindx++)
+              for(int bindx = 0; bindx < nr_params.NR_FFT_L / 2; bindx++)
                     {
                         // this is magnitude for the current frame
-                  if (ts.nr_mode==0)
+                  if (nr_params.mode==0)
                     NR2.X[bindx][0] = sqrtf(NR.FFT_buffer[bindx * 2] * NR.FFT_buffer[bindx * 2] + NR.FFT_buffer[bindx * 2 + 1] * NR.FFT_buffer[bindx * 2 + 1]);
                   else   //here we need only the squared magnitude
                     NR2.X[bindx][0] = (NR.FFT_buffer[bindx * 2] * NR.FFT_buffer[bindx * 2] + NR.FFT_buffer[bindx * 2 + 1] * NR.FFT_buffer[bindx * 2 + 1]);
                     }
 
-   if(ts.nr_first_time == 2)
+   if(nr_params.first_time == 2)
       { // TODO: properly initialize all the variables
-		if (ts.nr_mode==1)
+		if (nr_params.mode==1)
 		{
-		 for(int bindx = 0; bindx < ts.NR_FFT_L / 2; bindx++)
+		 for(int bindx = 0; bindx < nr_params.NR_FFT_L / 2; bindx++)
                   {
                 	  NR.Nest[bindx][0] = NR.Nest[bindx][0] + 0.05* NR2.X[bindx][0];// we do it 20 times to average over 20 frames for app. 100ms only on NR_on/bandswitch/modeswitch,...
                   }
@@ -586,34 +642,34 @@ float32_t uf_freq = (offset + width/2) / (NR_sample_rate / ts.NR_FFT_L);
 		 if (NR_init_counter > 19)//average over 20 frames for app. 100ms
 		     {
 			  NR_init_counter = 0;
-			  ts.nr_first_time = 3;  // now we did all the necessary initialization to actually start the noise reduction
+			  nr_params.first_time = 3;  // now we did all the necessary initialization to actually start the noise reduction
 		     }
 		}
-		else ts.nr_first_time = 3;
+		else nr_params.first_time = 3;
 
       }
-   if (ts.nr_first_time == 3)
+   if (nr_params.first_time == 3)
      {
 
               if((ts.dsp_active & DSP_NOTCH_ENABLE))
               {
 // detection of long tones
-              for(int bindx = 0; bindx < ts.NR_FFT_L / 2; bindx++)
+              for(int bindx = 0; bindx < nr_params.NR_FFT_L / 2; bindx++)
                     {
-            	  	  	NR2.long_tone[bindx][0] = (ts.nr_long_tone_alpha) * NR2.long_tone[bindx][1] + (1.0 - ts.nr_long_tone_alpha) * NR2.X[bindx][0]; //
+            	  	  	NR2.long_tone[bindx][0] = (nr_params.long_tone_alpha) * NR2.long_tone[bindx][1] + (1.0 - nr_params.long_tone_alpha) * NR2.X[bindx][0]; //
             	  	  	NR2.long_tone[bindx][1] = NR2.long_tone[bindx][0];
                     }
               }
 
-      if (ts.nr_mode == 1) // in development mode we start here with the calculation of the SNRs
+      if (nr_params.mode == 1) // in development mode we start here with the calculation of the SNRs
 	{
 	        // 3    calculate gamma (SNRpost)
 	  	//      and also xi (SNRprio)
-	  	  for(int bindx = 0; bindx < ts.NR_FFT_L / 2; bindx++)
+	  	  for(int bindx = 0; bindx < nr_params.NR_FFT_L / 2; bindx++)
 	             {
 	               NR.SNR_post[bindx] = fmax(fmin(NR2.X[bindx][0] / NR.Nest[bindx][0],1000.0),0.001); // limited to +30 /-30 dB, might be still too much of reduction, let's try it?
 
-	               NR.SNR_prio[bindx] = fmax(ts.nr_alpha * NR.Hk_old[bindx] + (1.0 - ts.nr_alpha)*fmax(NR.SNR_post[bindx]-1.0,0.0),0.0);
+	               NR.SNR_prio[bindx] = fmax(nr_params.alpha * NR.Hk_old[bindx] + (1.0 - nr_params.alpha)*fmax(NR.SNR_post[bindx]-1.0,0.0),0.0);
 	             }
 
 	}
@@ -622,8 +678,8 @@ float32_t uf_freq = (offset + width/2) / (NR_sample_rate / ts.NR_FFT_L);
               // 2b.) voice activity detector
               // we restrict the calculation of the VAD to the bins in the filter bandwidth
               //    float32_t NR_temp_sum = 0.0;
-              //    float32_t width = FilterInfo[FilterPathInfo[ts.filter_path].id].width;
-              //    float32_t offset = FilterPathInfo[ts.filter_path].offset;
+              //    float32_t width = FilterInfo[ts.filters_p->id].width;
+              //    float32_t offset = ts.filters_p->offset;
 
                   if (offset == 0)
                   {
@@ -643,29 +699,29 @@ float32_t uf_freq = (offset + width/2) / (NR_sample_rate / ts.NR_FFT_L);
                 	  VAD_low = 1;
                   }
                   else
-                	  if(VAD_low > ts.NR_FFT_L / 2 - 2)
+                	  if(VAD_low > nr_params.NR_FFT_L / 2 - 2)
                 	  {
-                		  VAD_low = ts.NR_FFT_L / 2 - 2;
+                		  VAD_low = nr_params.NR_FFT_L / 2 - 2;
                 	  }
                   if(VAD_high < 1)
                   {
                 	  VAD_high = 1;
                   }
                   else
-                	  if(VAD_high > ts.NR_FFT_L / 2)
+                	  if(VAD_high > nr_params.NR_FFT_L / 2)
                 	  {
-                		  VAD_high = ts.NR_FFT_L / 2;
+                		  VAD_high = nr_params.NR_FFT_L / 2;
                 	  }
 
 // ******* alternative VAD trials
 
-if (ts.nr_mode == 0) //mode "0" is the older version
+if (nr_params.mode == 0) //mode "0" is the older version
   {
 
 	      zero_cross_count=0;
-	      for (int i = 1; i < ts.NR_FFT_L/2; i++)
+	      for (int i = 1; i < nr_params.NR_FFT_L/2; i++)
 	      {
-			  if ((in_buffer[i + k * (ts.NR_FFT_L / 2)] * in_buffer[ i-1 + k * (ts.NR_FFT_L / 2)]) < 0)
+			  if ((in_buffer[i + k * (nr_params.NR_FFT_L / 2)] * in_buffer[ i-1 + k * (nr_params.NR_FFT_L / 2)]) < 0)
 				{
 				  zero_cross_count++;  //if product of current sample with last sample is negative, we had a zero crossing
 				}
@@ -686,7 +742,7 @@ if (ts.nr_mode == 0) //mode "0" is the older version
 
 	      for(int bindx = VAD_low; bindx < VAD_high; bindx++)
 		  {
-	    	  if (ts.nr_mode == 0) //if mode=1, we need to take the squareroot to have the same performance - will later e fixed
+	    	  if (nr_params.mode == 0) //if mode=1, we need to take the squareroot to have the same performance - will later e fixed
 		   VAD_E = VAD_E + NR2.X[bindx][0];
 	    	  else
 	    	   VAD_E = VAD_E + sqrtf(NR2.X[bindx][0]);
@@ -694,7 +750,7 @@ if (ts.nr_mode == 0) //mode "0" is the older version
 
 	      VAD_energy_ratio = VAD_E / (VAD_high-VAD_low);
 
-	      if (VAD_energy_ratio > (350 * ts.nr_vad_thresh)) //ts.nr_vad_thresh is per default 1000/1000!!!
+	      if (VAD_energy_ratio > (350 * nr_params.vad_thresh)) //nr_params.vad_thresh is per default 1000/1000!!!
     	      {
 	      		  VAD_EN=true;
 	      		//Board_RedLed(LED_STATE_OFF);
@@ -755,7 +811,7 @@ if (ts.nr_mode == 0) //mode "0" is the older version
                   }
 
 
-         if((NR_VAD_temp < ts.nr_vad_thresh) || ts.nr_first_time == 2)
+         if((NR_VAD_temp < nr_params.vad_thresh) || nr_params.first_time == 2)
                       { // VAD has detected NOISE
 							  // noise estimation with exponential averager
 							 NR2.VAD_duration=0;
@@ -763,16 +819,16 @@ if (ts.nr_mode == 0) //mode "0" is the older version
 
 						 if (NR2.VAD_delay == 0) //update noise level after Speech is really over
 						   {
-							 for(int bindx = 0; bindx < ts.NR_FFT_L / 2; bindx++)
+							 for(int bindx = 0; bindx < nr_params.NR_FFT_L / 2; bindx++)
 									{   // exponential averager for current noise estimate
-										if (ts.nr_mode == 0)
+										if (nr_params.mode == 0)
 										  {
-										   NR.Nest[bindx][0] = (1.0 - ts.nr_beta) * NR2.X[bindx][0] + ts.nr_beta * NR.Nest[bindx][1]; //
+										   NR.Nest[bindx][0] = (1.0 - nr_params.beta) * NR2.X[bindx][0] + nr_params.beta * NR.Nest[bindx][1]; //
 										   NR.Nest[bindx][1] = NR.Nest[bindx][0];
 										  }
 										else
 										  {
-										    NR.Nest[bindx][0] = NR.Nest[bindx][0] * ts.nr_beta + (1.0 - ts.nr_beta) * NR2.X[bindx][0]; //already squared!
+										    NR.Nest[bindx][0] = NR.Nest[bindx][0] * nr_params.beta + (1.0 - nr_params.beta) * NR2.X[bindx][0]; //already squared!
 										  }
 									}
 
@@ -791,7 +847,7 @@ if (ts.nr_mode == 0) //mode "0" is the older version
                     		NR2.VAD_duration++;
                     		if (NR2.VAD_duration > 1) //a vowel should be longer than app. 20ms
                     		  {
-                    		     NR2.VAD_delay = ts.nr_vad_delay; // we wait 1 times app.  10ms before we start updating the noisefloor
+                    		     NR2.VAD_delay = nr_params.vad_delay; // we wait 1 times app.  10ms before we start updating the noisefloor
                     		     Board_RedLed(LED_STATE_ON);
                     		  }
                 	  }
@@ -800,7 +856,7 @@ if (ts.nr_mode == 0) //mode "0" is the older version
                       // this helps avoiding this
                       if(NR2.VAD_crash_detector > 100)
                       {
-							 for(int bindx = 0; bindx < ts.NR_FFT_L / 2; bindx++)
+							 for(int bindx = 0; bindx < nr_params.NR_FFT_L / 2; bindx++)
 									{   // increase noise estimate
 										  NR.Nest[bindx][0] = NR2.X[bindx][0] * 1.2; //
 										  NR.Nest[bindx][1] = NR.Nest[bindx][0];
@@ -809,7 +865,7 @@ if (ts.nr_mode == 0) //mode "0" is the older version
 
 
         // 3    calculate SNRpost (n, bin[i]) = (X(n, bin[i])^2 / Nest(n, bin[i])^2) - 1 (eq. 13 of Schmitt et al. 2002)
-              for(int bindx = 0; bindx < ts.NR_FFT_L / 2; bindx++)
+              for(int bindx = 0; bindx < nr_params.NR_FFT_L / 2; bindx++)
                     {
                         // (Yk)^2 / Dk (eq 11, Romanin et al. 2009)
                         if(NR.Nest[bindx][0] != 0.0)
@@ -830,11 +886,11 @@ if (ts.nr_mode == 0) //mode "0" is the older version
         // again: do we have to square the noise estimate NR_M[bindx] or not? Schmitt says yes, Romanin says no . . .
                         if(NR.Nest[bindx][0] != 0.0)
                         {
-                            NR.SNR_prio[bindx] = (1.0 - ts.nr_alpha) * NR.SNR_post_pos +
-//                                                 ts.nr_alpha * ((NR_Hk_old[bindx] * NR_Hk_old[bindx] * NR_X[bindx][1]) / (NR_Nest[bindx][0])); // no NR effect
-//                                    ts.nr_alpha * ((NR_Hk_old[bindx] * NR_Hk_old[bindx] * NR_X[bindx][1] * NR_X[bindx][1]) / (NR_Nest[bindx][0])); // no NR effect
-//                                    ts.nr_alpha * ((NR_Hk_old[bindx] * NR_Hk_old[bindx] * NR_X[bindx][1] * NR_X[bindx][1]) / (NR_Nest[bindx][0] * NR_Nest[bindx][0])); // very strong, but strange effect
-                                                 ts.nr_alpha * ((NR.Hk_old[bindx] * NR.Hk_old[bindx] * NR2.X[bindx][1]) / (NR.Nest[bindx][0])); // working
+                            NR.SNR_prio[bindx] = (1.0 - nr_params.alpha) * NR.SNR_post_pos +
+//                                                 nr_params.alpha * ((NR_Hk_old[bindx] * NR_Hk_old[bindx] * NR_X[bindx][1]) / (NR_Nest[bindx][0])); // no NR effect
+//                                    nr_params.alpha * ((NR_Hk_old[bindx] * NR_Hk_old[bindx] * NR_X[bindx][1] * NR_X[bindx][1]) / (NR_Nest[bindx][0])); // no NR effect
+//                                    nr_params.alpha * ((NR_Hk_old[bindx] * NR_Hk_old[bindx] * NR_X[bindx][1] * NR_X[bindx][1]) / (NR_Nest[bindx][0] * NR_Nest[bindx][0])); // very strong, but strange effect
+                                                 nr_params.alpha * ((NR.Hk_old[bindx] * NR.Hk_old[bindx] * NR2.X[bindx][1]) / (NR.Nest[bindx][0])); // working
                         }
         // 4    calculate vk = SNRprio(n, bin[i]) / (SNRprio(n, bin[i]) + 1) * SNRpost(n, bin[i]) (eq. 12 of Schmitt et al. 2002, eq. 9 of Romanin et al. 2009)
                         NR.vk =  NR.SNR_post[bindx] * NR.SNR_prio[bindx] / (1.0 + NR.SNR_prio[bindx]);
@@ -842,17 +898,17 @@ if (ts.nr_mode == 0) //mode "0" is the older version
         // 5    finally calculate the weighting function for each bin: Hk(n, bin[i]) = 1 / SNRpost(n, [i]) * sqrtf(0.7212 * vk + vk * vk) (eq. 26 of Romanin et al. 2009)
                         if(NR.vk > 0.0 && NR.SNR_post[bindx] != 0.0) // prevent sqrtf of negatives
                         {
-                            NR.Hk[bindx] = 1.0 / NR.SNR_post[bindx] * sqrtf(0.7212 * NR.vk + NR.vk * NR.vk);
+                            NR2.Hk[bindx] = 1.0 / NR.SNR_post[bindx] * sqrtf(0.7212 * NR.vk + NR.vk * NR.vk);
                         }
                         else
                         {
-                            NR.Hk[bindx] = 1.0;
+                            NR2.Hk[bindx] = 1.0;
                         }
                         if(!(ts.dsp_active & DSP_NR_ENABLE)) // if NR is not enabled (but notch is enabled !)
                         {
-                        	NR.Hk[bindx] = 1.0;
+                        	NR2.Hk[bindx] = 1.0;
                         }
-                        NR.Hk_old[bindx] = NR.Hk[bindx];
+                        NR.Hk_old[bindx] = NR2.Hk[bindx];
                         NR2.X[bindx][1] = NR2.X[bindx][0];
                     }
   }
@@ -873,9 +929,9 @@ else  //new mode under development,  following the same equations, sligthly diff
 
   	    {
   	    Board_RedLed(LED_STATE_OFF); //Noise!
-  	    for(int bindx = 0; bindx < ts.NR_FFT_L / 2; bindx++)  //update the noise estimate
+  	    for(int bindx = 0; bindx < nr_params.NR_FFT_L / 2; bindx++)  //update the noise estimate
   	      	     {
-  	      	         NR.Nest[bindx][0] = ts.nr_beta * NR.Nest[bindx][0] + (1.0 - ts.nr_beta) * NR2.X[bindx][0];
+  	      	         NR.Nest[bindx][0] = nr_params.beta * NR.Nest[bindx][0] + (1.0 - nr_params.beta) * NR2.X[bindx][0];
   	      	     }
   	    }
   	  else
@@ -891,14 +947,14 @@ else  //new mode under development,  following the same equations, sligthly diff
   	   {
   	      float32_t v = NR.SNR_prio[bindx] * NR.SNR_post[bindx] / (1.0 + NR.SNR_prio[bindx]);
 
-  	      NR.Hk[bindx] = 1.0 / NR.SNR_post[bindx] * sqrtf((0.7212 * v + v * v));
+  	      NR2.Hk[bindx] = 1.0 / NR.SNR_post[bindx] * sqrtf((0.7212 * v + v * v));
 
-  	      NR.Hk_old[bindx] = NR.SNR_post[bindx] * NR.Hk[bindx] * NR.Hk[bindx]; //
+  	      NR.Hk_old[bindx] = NR.SNR_post[bindx] * NR2.Hk[bindx] * NR2.Hk[bindx]; //
 
 
 	      if(!(ts.dsp_active & DSP_NR_ENABLE)) // if NR is not enabled (but notch is enabled !)
 	      {
-		      NR.Hk[bindx] = 1.0;
+		      NR2.Hk[bindx] = 1.0;
 	      }
 
   	   }
@@ -910,9 +966,9 @@ else  //new mode under development,  following the same equations, sligthly diff
               if((ts.dsp_active & DSP_NOTCH_ENABLE))
               {
 // long tone attenuation = automatic notch filter
-              for(int bindx = 0; bindx < ts.NR_FFT_L / 2; bindx++)
+              for(int bindx = 0; bindx < nr_params.NR_FFT_L / 2; bindx++)
                     {
-            	  	  	  if(NR2.long_tone[bindx][0] > (float32_t)ts.nr_long_tone_thresh)
+            	  	  	  if(NR2.long_tone[bindx][0] > (float32_t)nr_params.long_tone_thresh)
             	  	  	  {
             	  	  			  NR2.long_tone_gain[bindx] = NR2.long_tone_gain[bindx] * 0.99;
 
@@ -925,7 +981,7 @@ else  //new mode under development,  following the same equations, sligthly diff
                 	  	  			  }
             	  	  			  }
             	  	  			  else
-            	  	  			  if(bindx != (ts.NR_FFT_L / 2 - 1))
+            	  	  			  if(bindx != (nr_params.NR_FFT_L / 2 - 1))
             	  	  			  {
             	  	  				  NR2.long_tone_gain[bindx + 1] = NR2.long_tone_gain[bindx + 1] * 0.9995;
                 	  	  			  if(NR2.long_tone_gain[bindx + 1] < 0.2)
@@ -950,7 +1006,7 @@ else  //new mode under development,  following the same equations, sligthly diff
             	  	  			  }
         	  	  			  }
         	  	  			  else
-        	  	  			  if(bindx != (ts.NR_FFT_L / 2 - 1))
+        	  	  			  if(bindx != (nr_params.NR_FFT_L / 2 - 1))
         	  	  			  {
         	  	  				  NR2.long_tone_gain[bindx + 1] = NR2.long_tone_gain[bindx + 1] * 1.0005;
             	  	  			  if(NR2.long_tone_gain[bindx + 1] > 1.0)
@@ -971,11 +1027,11 @@ else  //new mode under development,  following the same equations, sligthly diff
             	  NR2.notch_change = false;
 // long tone attenuation = automatic notch filter
 // first version, only one notch implemented - finds the largest persisting signal and notches it with an IIR
-              for(int bindx = 0; bindx < ts.NR_FFT_L / 2; bindx++)
+              for(int bindx = 0; bindx < nr_params.NR_FFT_L / 2; bindx++)
                     {
             	  	  	  // if the (strongly time smoothed) signal in a bin exceeds the threshold,
             	  	  	  // increase the counter for that bin
-						  if(NR2.long_tone[bindx][0] > (float32_t)ts.nr_long_tone_thresh)
+						  if(NR2.long_tone[bindx][0] > (float32_t)nr_params.long_tone_thresh)
 						  {
 							  NR2.long_tone_counter[bindx]++;
 						  }
@@ -1017,7 +1073,7 @@ else  //new mode under development,  following the same equations, sligthly diff
 				  NR2.long_tone_max = 0.0;
 				  NR2.max_bin = -99; // -99 is the indication for reset value
 
-	              for(int bindx = 0; bindx < ts.NR_FFT_L / 2; bindx++)
+	              for(int bindx = 0; bindx < nr_params.NR_FFT_L / 2; bindx++)
                   {
 						  // look for new notches
 						  // if a tone persists strong for at least one second = 100 frames
@@ -1057,7 +1113,7 @@ else  //new mode under development,  following the same equations, sligthly diff
 #endif
 
 
-              if(ts.nr_gain_smooth_enable)
+              if(nr_params.gain_smooth_enable)
               {
 // we hear considerable distortion in the end result
 // this can be healed significantly by frequency smoothing the gain values
@@ -1066,16 +1122,16 @@ else  //new mode under development,  following the same equations, sligthly diff
 //remark: if we smooth the gains and really modify the HK's like here, the noise reduction algorithm might directly "fight" against this!
 // might be better to keep the HK's internaly and smooth a copy of the gains which are than working on the signal.
 
-				  for(int bindx = 1; bindx < (ts.NR_FFT_L / 2) - 1; bindx++)
+				  for(int bindx = 1; bindx < (nr_params.NR_FFT_L / 2) - 1; bindx++)
 				  {
-					  NR.Hk[bindx] = ts.nr_gain_smooth_alpha * NR.Hk[bindx - 1] + (1.0 - 2.0 * ts.nr_gain_smooth_alpha) * NR.Hk[bindx] + ts.nr_gain_smooth_alpha * NR.Hk[bindx + 1];
+					  NR2.Hk[bindx] = nr_params.gain_smooth_alpha * NR2.Hk[bindx - 1] + (1.0 - 2.0 * nr_params.gain_smooth_alpha) * NR2.Hk[bindx] + nr_params.gain_smooth_alpha * NR2.Hk[bindx + 1];
 
 				  }
-				  NR.Hk[0] = (1.0 - ts.nr_gain_smooth_alpha) * NR.Hk[0] + ts.nr_gain_smooth_alpha * NR.Hk[1];
-				  NR.Hk[(ts.NR_FFT_L / 2) - 1] = (1.0 - ts.nr_gain_smooth_alpha) * NR.Hk[(ts.NR_FFT_L / 2) - 1] + ts.nr_gain_smooth_alpha * NR.Hk[(ts.NR_FFT_L / 2) - 2];
+				  NR2.Hk[0] = (1.0 - nr_params.gain_smooth_alpha) * NR2.Hk[0] + nr_params.gain_smooth_alpha * NR2.Hk[1];
+				  NR2.Hk[(nr_params.NR_FFT_L / 2) - 1] = (1.0 - nr_params.gain_smooth_alpha) * NR2.Hk[(nr_params.NR_FFT_L / 2) - 1] + nr_params.gain_smooth_alpha * NR2.Hk[(nr_params.NR_FFT_L / 2) - 2];
               }
 
-	}	//end of "if ts.nr_first_time == 3"
+	}	//end of "if nr_params.first_time == 3"
 
 
 
@@ -1083,13 +1139,13 @@ else  //new mode under development,  following the same equations, sligthly diff
         // FINAL SPECTRAL WEIGHTING: Multiply current FFT results with NR_FFT_buffer for 64 bins with the 64 bin-specific gain factors
               // only do this for the bins inside the filter passband
               // if you do this for all the bins, you will get distorted audio: plopping !
-              //              for(int bindx = 0; bindx < ts.NR_FFT_L / 2; bindx++) // plopping !!!!
+              //              for(int bindx = 0; bindx < nr_params.NR_FFT_L / 2; bindx++) // plopping !!!!
                 for(int bindx = VAD_low; bindx < VAD_high; bindx++) // no plopping
               {
-                  NR.FFT_buffer[bindx * 2] = NR.FFT_buffer [bindx * 2] * NR.Hk[bindx] * NR2.long_tone_gain[bindx]; // real part
-                  NR.FFT_buffer[bindx * 2 + 1] = NR.FFT_buffer [bindx * 2 + 1] * NR.Hk[bindx] * NR2.long_tone_gain[bindx]; // imag part
-                  NR.FFT_buffer[ts.NR_FFT_L * 2 - bindx * 2 - 2] = NR.FFT_buffer[ts.NR_FFT_L * 2 - bindx * 2 - 2] * NR.Hk[bindx] * NR2.long_tone_gain[bindx]; // real part conjugate symmetric
-                  NR.FFT_buffer[ts.NR_FFT_L * 2 - bindx * 2 - 1] = NR.FFT_buffer[ts.NR_FFT_L * 2 - bindx * 2 - 1] * NR.Hk[bindx] * NR2.long_tone_gain[bindx]; // imag part conjugate symmetric
+                  NR.FFT_buffer[bindx * 2] = NR.FFT_buffer [bindx * 2] * NR2.Hk[bindx] * NR2.long_tone_gain[bindx]; // real part
+                  NR.FFT_buffer[bindx * 2 + 1] = NR.FFT_buffer [bindx * 2 + 1] * NR2.Hk[bindx] * NR2.long_tone_gain[bindx]; // imag part
+                  NR.FFT_buffer[nr_params.NR_FFT_L * 2 - bindx * 2 - 2] = NR.FFT_buffer[nr_params.NR_FFT_L * 2 - bindx * 2 - 2] * NR2.Hk[bindx] * NR2.long_tone_gain[bindx]; // real part conjugate symmetric
+                  NR.FFT_buffer[nr_params.NR_FFT_L * 2 - bindx * 2 - 1] = NR.FFT_buffer[nr_params.NR_FFT_L * 2 - bindx * 2 - 1] * NR2.Hk[bindx] * NR2.long_tone_gain[bindx]; // imag part conjugate symmetric
               }
 
 #endif
@@ -1103,7 +1159,7 @@ else  //new mode under development,  following the same equations, sligthly diff
 					float32_t NR_temp_sum2 = 0;
 					for(int bindx = VAD_low; bindx < VAD_high; bindx++)
 					{
-						NR_temp_sum += NR.Hk[bindx] * NR2.X[bindx][0];
+						NR_temp_sum += NR2.Hk[bindx] * NR2.X[bindx][0];
 						NR_temp_sum2 += NR2.X[bindx][0];
 					}
 					NR.VAD_Esch = NR_temp_sum / NR_temp_sum2;
@@ -1127,65 +1183,65 @@ else  //new mode under development,  following the same equations, sligthly diff
   // set real values to 0.1 of their original value
   {
       NR.FFT_buffer[bindx * 2] *= 0.1;
-//      NR_FFT_buffer[ts.NR_FFT_L * 2 - bindx * 2 - 2] *= 0.1; //NR_iFFT_buffer[idx] * 0.1;
+//      NR_FFT_buffer[nr_params.NR_FFT_L * 2 - bindx * 2 - 2] *= 0.1; //NR_iFFT_buffer[idx] * 0.1;
       NR.FFT_buffer[bindx * 2 + 1] *= 0.1; //NR_iFFT_buffer[idx] * 0.1;
-//      NR_FFT_buffer[ts.NR_FFT_L * 2 - bindx * 2 - 1] *= 0.1; //NR_iFFT_buffer[idx] * 0.1;
+//      NR_FFT_buffer[nr_params.NR_FFT_L * 2 - bindx * 2 - 1] *= 0.1; //NR_iFFT_buffer[idx] * 0.1;
   }
 #endif
 
 #ifdef NR_NOTCHTEST  // this is a test of a smoother notch filter
 	  // centre bin to be notched
   	  NR.FFT_buffer[				bin_c * 2] 		*= bin1_att; // real
-      NR.FFT_buffer[ts.NR_FFT_L * 2 - 	bin_c * 2 - 2]	*= bin1_att; // imaginary
+      NR.FFT_buffer[nr_params.NR_FFT_L * 2 - 	bin_c * 2 - 2]	*= bin1_att; // imaginary
       NR.FFT_buffer[				bin_c * 2 + 1] 	*= bin1_att; // real conjugate symmetric
-      NR.FFT_buffer[ts.NR_FFT_L * 2 - 	bin_c * 2 - 1] 	*= bin1_att; // imaginary conjugate symmetric
+      NR.FFT_buffer[nr_params.NR_FFT_L * 2 - 	bin_c * 2 - 1] 	*= bin1_att; // imaginary conjugate symmetric
       // centre_bin + 1 to be notched
   	  NR.FFT_buffer[				bin_p1 * 2] 	*= bin2_att;
-      NR.FFT_buffer[ts.NR_FFT_L * 2 - 	bin_p1 * 2 - 2]	*= bin2_att;
+      NR.FFT_buffer[nr_params.NR_FFT_L * 2 - 	bin_p1 * 2 - 2]	*= bin2_att;
       NR.FFT_buffer[				bin_p1 * 2 + 1] *= bin2_att;
-      NR.FFT_buffer[ts.NR_FFT_L * 2 - 	bin_p1 * 2 - 1] *= bin2_att;
+      NR.FFT_buffer[nr_params.NR_FFT_L * 2 - 	bin_p1 * 2 - 1] *= bin2_att;
       // centre_bin - 1 to be notched
   	  NR.FFT_buffer[				bin_m1 * 2] 	*= bin2_att;
-      NR.FFT_buffer[ts.NR_FFT_L * 2 - 	bin_m1 * 2 - 2]	*= bin2_att;
+      NR.FFT_buffer[nr_params.NR_FFT_L * 2 - 	bin_m1 * 2 - 2]	*= bin2_att;
       NR.FFT_buffer[				bin_m1 * 2 + 1] *= bin2_att;
-      NR.FFT_buffer[ts.NR_FFT_L * 2 - 	bin_m1 * 2 - 1] *= bin2_att;
+      NR.FFT_buffer[nr_params.NR_FFT_L * 2 - 	bin_m1 * 2 - 1] *= bin2_att;
       // centre_bin + 2 to be notched
   	  NR.FFT_buffer[				bin_p2 * 2] 	*= bin3_att;
-      NR.FFT_buffer[ts.NR_FFT_L * 2 - 	bin_p2 * 2 - 2]	*= bin3_att;
+      NR.FFT_buffer[nr_params.NR_FFT_L * 2 - 	bin_p2 * 2 - 2]	*= bin3_att;
       NR.FFT_buffer[				bin_p2 * 2 + 1] *= bin3_att;
-      NR.FFT_buffer[ts.NR_FFT_L * 2 - 	bin_p2 * 2 - 1] *= bin3_att;
+      NR.FFT_buffer[nr_params.NR_FFT_L * 2 - 	bin_p2 * 2 - 1] *= bin3_att;
       // centre_bin - 2 to be notched
   	  NR.FFT_buffer[				bin_m2 * 2] 	*= bin3_att;
-      NR.FFT_buffer[ts.NR_FFT_L * 2 - 	bin_m2 * 2 - 2]	*= bin3_att;
+      NR.FFT_buffer[nr_params.NR_FFT_L * 2 - 	bin_m2 * 2 - 2]	*= bin3_att;
       NR.FFT_buffer[				bin_m2 * 2 + 1] *= bin3_att;
-      NR.FFT_buffer[ts.NR_FFT_L * 2 - 	bin_m2 * 2 - 1] *= bin3_att;
+      NR.FFT_buffer[nr_params.NR_FFT_L * 2 - 	bin_m2 * 2 - 1] *= bin3_att;
       // centre_bin + 3 to be notched
   	  NR.FFT_buffer[				bin_p3 * 2] 	*= bin4_att;
-      NR.FFT_buffer[ts.NR_FFT_L * 2 - 	bin_p3 * 2 - 2]	*= bin4_att;
+      NR.FFT_buffer[nr_params.NR_FFT_L * 2 - 	bin_p3 * 2 - 2]	*= bin4_att;
       NR.FFT_buffer[				bin_p3 * 2 + 1] *= bin4_att;
-      NR.FFT_buffer[ts.NR_FFT_L * 2 - 	bin_p3 * 2 - 1] *= bin4_att;
+      NR.FFT_buffer[nr_params.NR_FFT_L * 2 - 	bin_p3 * 2 - 1] *= bin4_att;
       // centre_bin - 3 to be notched
   	  NR.FFT_buffer[				bin_m3 * 2] 	*= bin4_att;
-      NR.FFT_buffer[ts.NR_FFT_L * 2 - 	bin_m3 * 2 - 2]	*= bin4_att;
+      NR.FFT_buffer[nr_params.NR_FFT_L * 2 - 	bin_m3 * 2 - 2]	*= bin4_att;
       NR.FFT_buffer[				bin_m3 * 2 + 1] *= bin4_att;
-      NR.FFT_buffer[ts.NR_FFT_L * 2 - 	bin_m3 * 2 - 1] *= bin4_att;
+      NR.FFT_buffer[nr_params.NR_FFT_L * 2 - 	bin_m3 * 2 - 1] *= bin4_att;
       // centre_bin + 4 to be notched
   	  NR.FFT_buffer[				bin_p4 * 2] 	*= bin5_att;
-      NR.FFT_buffer[ts.NR_FFT_L * 2 - 	bin_p4 * 2 - 2]	*= bin5_att;
+      NR.FFT_buffer[nr_params.NR_FFT_L * 2 - 	bin_p4 * 2 - 2]	*= bin5_att;
       NR.FFT_buffer[				bin_p4 * 2 + 1] *= bin5_att;
-      NR.FFT_buffer[ts.NR_FFT_L * 2 - 	bin_p4 * 2 - 1] *= bin5_att;
+      NR.FFT_buffer[nr_params.NR_FFT_L * 2 - 	bin_p4 * 2 - 1] *= bin5_att;
       // centre_bin - 4 to be notched
   	  NR.FFT_buffer[				bin_m4 * 2] 	*= bin5_att;
-      NR.FFT_buffer[ts.NR_FFT_L * 2 - 	bin_m4 * 2 - 2]	*= bin5_att;
+      NR.FFT_buffer[nr_params.NR_FFT_L * 2 - 	bin_m4 * 2 - 2]	*= bin5_att;
       NR.FFT_buffer[				bin_m4 * 2 + 1] *= bin5_att;
-      NR.FFT_buffer[ts.NR_FFT_L * 2 - 	bin_m4 * 2 - 1] *= bin5_att;
+      NR.FFT_buffer[nr_params.NR_FFT_L * 2 - 	bin_m4 * 2 - 1] *= bin5_att;
 #endif
 
       // Window on exit!
-            if(ts.nr_fft_256_enable)
+            if(nr_params.fft_256_enable)
             {
                 arm_cfft_f32(&arm_cfft_sR_f32_len256, NR.FFT_buffer, 1, 1);
-          	  for (int idx = 0; idx < ts.NR_FFT_L; idx++)
+          	  for (int idx = 0; idx < nr_params.NR_FFT_L; idx++)
                 {
           	  	  NR.FFT_buffer[idx * 2] *= SQRT_von_Hann_256[idx];
                 }
@@ -1193,29 +1249,29 @@ else  //new mode under development,  following the same equations, sligthly diff
             else
             {
                 arm_cfft_f32(&arm_cfft_sR_f32_len128, NR.FFT_buffer, 1, 1);
-                for (int idx = 0; idx < ts.NR_FFT_L; idx++)
+                for (int idx = 0; idx < nr_params.NR_FFT_L; idx++)
                 {
               	  NR.FFT_buffer[idx * 2] *= SQRT_van_hann[idx];
                 }
             }
 
     // do the overlap & add
-          for(int i = 0; i < ts.NR_FFT_L / 2; i++)
+          for(int i = 0; i < nr_params.NR_FFT_L / 2; i++)
           { // take real part of first half of current iFFT result and add to 2nd half of last iFFT_result
-        	  //              NR_output_audio_buffer[i + k * (ts.NR_FFT_L / 2)] = NR_FFT_buffer[i * 2] + NR_last_iFFT_result[i];
-        	  in_buffer[i + k * (ts.NR_FFT_L / 2)] = NR.FFT_buffer[i * 2] + NR.last_iFFT_result[i];
+        	  //              NR_output_audio_buffer[i + k * (nr_params.NR_FFT_L / 2)] = NR_FFT_buffer[i * 2] + NR_last_iFFT_result[i];
+        	  in_buffer[i + k * (nr_params.NR_FFT_L / 2)] = NR.FFT_buffer[i * 2] + NR.last_iFFT_result[i];
 // FIXME: take out scaling !
-//        	  in_buffer[i + k * (ts.NR_FFT_L / 2)] *= 0.3;
+//        	  in_buffer[i + k * (nr_params.NR_FFT_L / 2)] *= 0.3;
           }
-          for(int i = 0; i < ts.NR_FFT_L / 2; i++)
+          for(int i = 0; i < nr_params.NR_FFT_L / 2; i++)
           {
-              NR.last_iFFT_result[i] = NR.FFT_buffer[ts.NR_FFT_L + i * 2];
+              NR.last_iFFT_result[i] = NR.FFT_buffer[nr_params.NR_FFT_L + i * 2];
           }
        // end of "for" loop which repeats the FFT_iFFT_chain two times !!!
     }
 
     // IIR biquad notch filter with four independent notches
-    // arm_biquad_cascade_df1_f32 (&NR_notch_biquad, in_buffer, in_buffer, ts.NR_FFT_L);
+    // arm_biquad_cascade_df1_f32 (&NR_notch_biquad, in_buffer, in_buffer, nr_params.NR_FFT_L);
 }
 
 
@@ -1243,7 +1299,7 @@ void spectral_noise_reduction_2 (float* in_buffer)
 // overlap-add
 
 	float32_t NR_sample_rate = 12000.0;
-	if(ts.NR_decimation_enable)
+	if(nr_params.NR_decimation_enable)
 	{
 		NR_sample_rate = 6000.0;
 	}
@@ -1252,33 +1308,33 @@ static uint8_t NR_init_counter = 0;
 uint8_t VAD_low=0;
 uint8_t VAD_high=63;
 //float32_t NR_temp_sum = 0.0;
-float32_t width = FilterInfo[FilterPathInfo[ts.filter_path].id].width;
-float32_t offset = FilterPathInfo[ts.filter_path].offset;
-float32_t lf_freq = (offset - width/2) / (NR_sample_rate / ts.NR_FFT_L); // bin BW is 93.75Hz [12000Hz / 128 bins]
-float32_t uf_freq = (offset + width/2) / (NR_sample_rate / ts.NR_FFT_L);
+float32_t width = FilterInfo[ts.filters_p->id].width;
+float32_t offset = ts.filters_p->offset;
+float32_t lf_freq = (offset - width/2) / (NR_sample_rate / nr_params.NR_FFT_L); // bin BW is 93.75Hz [12000Hz / 128 bins]
+float32_t uf_freq = (offset + width/2) / (NR_sample_rate / nr_params.NR_FFT_L);
 
-    if(ts.nr_first_time == 1)
+    if(nr_params.first_time == 1)
     { // TODO: properly initialize all the variables
-        for(int bindx = 0; bindx < ts.NR_FFT_L / 2; bindx++)
+        for(int bindx = 0; bindx < nr_params.NR_FFT_L / 2; bindx++)
         {
               NR.last_sample_buffer_L[bindx] = 0.0;
-              NR.Hk[bindx] = 1.0;
+              NR2.Hk[bindx] = 1.0;
 			//xu[bindx] = 1.0;  //has to be replaced by other variable
               NR.Hk_old[bindx] = 1.0; // old gain or xu in development mode
 	      NR.Nest[bindx][0] = 0.0;
 	      NR.Nest[bindx][1] = 1.0;
         }
-	ts.nr_first_time = 2; // we need to do some more a bit later down
+	nr_params.first_time = 2; // we need to do some more a bit later down
     }
 
-    if(ts.nr_long_tone_reset)
+    if(nr_params.long_tone_reset)
     {
-        for(int bindx = 0; bindx < ts.NR_FFT_L / 2; bindx++)
+        for(int bindx = 0; bindx < nr_params.NR_FFT_L / 2; bindx++)
         {
         	NR2.long_tone_gain[bindx] = 1.0;
         	NR2.long_tone_counter[bindx] = 10;
         }
-    	ts.nr_long_tone_reset = false;
+    	nr_params.long_tone_reset = false;
     	NR2.notch_change = false;
     	NR2.notch1_bin = 10; // frequency bin where notch filter 1 has to work
     	NR2.max_bin = 10; // holds the bin number of the strongest persistent tone during tone detection
@@ -1289,34 +1345,34 @@ float32_t uf_freq = (offset + width/2) / (NR_sample_rate / ts.NR_FFT_L);
     	NR2.notch4_active = false; // is notch4 active?
     }
 
-    for(int k = 0; k < ts.NR_FFT_LOOP_NO; k++)
+    for(int k = 0; k < nr_params.NR_FFT_LOOP_NO; k++)
     {
     // NR_FFT_buffer is 256 floats big
     // interleaved r, i, r, i . . .
     // fill first half of FFT_buffer with last events audio samples
-          for(int i = 0; i < ts.NR_FFT_L / 2; i++)
+          for(int i = 0; i < nr_params.NR_FFT_L / 2; i++)
           {
             NR.FFT_buffer[i * 2] = NR.last_sample_buffer_L[i]; // real
             NR.FFT_buffer[i * 2 + 1] = 0.0; // imaginary
           }
     // copy recent samples to last_sample_buffer for next time!
-          for(int i = 0; i < ts.NR_FFT_L  / 2; i++)
+          for(int i = 0; i < nr_params.NR_FFT_L  / 2; i++)
           {
-             NR.last_sample_buffer_L [i] = in_buffer[i + k * (ts.NR_FFT_L / 2)];
+             NR.last_sample_buffer_L [i] = in_buffer[i + k * (nr_params.NR_FFT_L / 2)];
           }
     // now fill recent audio samples into second half of FFT_buffer
-          for(int i = 0; i < ts.NR_FFT_L / 2; i++)
+          for(int i = 0; i < nr_params.NR_FFT_L / 2; i++)
           {
-              NR.FFT_buffer[ts.NR_FFT_L + i * 2] = in_buffer[i+ k * (ts.NR_FFT_L / 2)]; // real
-              NR.FFT_buffer[ts.NR_FFT_L + i * 2 + 1] = 0.0;
+              NR.FFT_buffer[nr_params.NR_FFT_L + i * 2] = in_buffer[i+ k * (nr_params.NR_FFT_L / 2)]; // real
+              NR.FFT_buffer[nr_params.NR_FFT_L + i * 2 + 1] = 0.0;
           }
 
 
 
-                if(ts.nr_fft_256_enable)
+                if(nr_params.fft_256_enable)
                 {
                     arm_cfft_f32(&arm_cfft_sR_f32_len256, NR.FFT_buffer, 0, 1);
-              	  for (int idx = 0; idx < ts.NR_FFT_L; idx++)
+              	  for (int idx = 0; idx < nr_params.NR_FFT_L; idx++)
                     {
               	  	  NR.FFT_buffer[idx * 2] *= SQRT_von_Hann_256[idx];
                     }
@@ -1324,27 +1380,27 @@ float32_t uf_freq = (offset + width/2) / (NR_sample_rate / ts.NR_FFT_L);
                 else
                 {
                     arm_cfft_f32(&arm_cfft_sR_f32_len128, NR.FFT_buffer, 0, 1);
-                    for (int idx = 0; idx < ts.NR_FFT_L; idx++)
+                    for (int idx = 0; idx < nr_params.NR_FFT_L; idx++)
                     {
                   	  NR.FFT_buffer[idx * 2] *= SQRT_van_hann[idx];
                     }
                 }
 
 #ifndef NR_NOTCHTEST
-              for(int bindx = 0; bindx < ts.NR_FFT_L / 2; bindx++)
+              for(int bindx = 0; bindx < nr_params.NR_FFT_L / 2; bindx++)
                     {
                         // this is magnitude for the current frame
-                  if (ts.nr_mode==0)
+                  if (nr_params.mode==0)
                     NR2.X[bindx][0] = sqrtf(NR.FFT_buffer[bindx * 2] * NR.FFT_buffer[bindx * 2] + NR.FFT_buffer[bindx * 2 + 1] * NR.FFT_buffer[bindx * 2 + 1]);
                   else   //here we need only the squared magnitude
                     NR2.X[bindx][0] = (NR.FFT_buffer[bindx * 2] * NR.FFT_buffer[bindx * 2] + NR.FFT_buffer[bindx * 2 + 1] * NR.FFT_buffer[bindx * 2 + 1]);
                     }
 
-   if(ts.nr_first_time == 2)
+   if(nr_params.first_time == 2)
       { // TODO: properly initialize all the variables
-		if (ts.nr_mode==1)
+		if (nr_params.mode==1)
 		{
-		 for(int bindx = 0; bindx < ts.NR_FFT_L / 2; bindx++)
+		 for(int bindx = 0; bindx < nr_params.NR_FFT_L / 2; bindx++)
                   {
                 	  NR.Nest[bindx][0] = NR.Nest[bindx][0] + 0.05* NR2.X[bindx][0];// we do it 20 times to average over 20 frames for app. 100ms only on NR_on/bandswitch/modeswitch,...
                   }
@@ -1352,30 +1408,30 @@ float32_t uf_freq = (offset + width/2) / (NR_sample_rate / ts.NR_FFT_L);
 		 if (NR_init_counter > 19)//average over 20 frames for app. 100ms
 		     {
 			  NR_init_counter = 0;
-			  ts.nr_first_time = 3;  // now we did all the necessary initialization to actually start the noise reduction
+			  nr_params.first_time = 3;  // now we did all the necessary initialization to actually start the noise reduction
 		     }
 		}
-		else ts.nr_first_time = 3;
+		else nr_params.first_time = 3;
 
       }
-   if (ts.nr_first_time == 3)
+   if (nr_params.first_time == 3)
      {
 
               if((ts.dsp_active & DSP_NOTCH_ENABLE))
               {
         	    // detection of long tones
-              for(int bindx = 0; bindx < ts.NR_FFT_L / 2; bindx++)
+              for(int bindx = 0; bindx < nr_params.NR_FFT_L / 2; bindx++)
                     {
-            	  	 NR2.long_tone[bindx][0] = (ts.nr_long_tone_alpha) * NR2.long_tone[bindx][1] + (1.0 - ts.nr_long_tone_alpha) * NR2.X[bindx][0]; //
+            	  	 NR2.long_tone[bindx][0] = (nr_params.long_tone_alpha) * NR2.long_tone[bindx][1] + (1.0 - nr_params.long_tone_alpha) * NR2.X[bindx][0]; //
             	  	 NR2.long_tone[bindx][1] = NR2.long_tone[bindx][0];
                     }
               }
 
-	  	  for(int bindx = 0; bindx < ts.NR_FFT_L / 2; bindx++)// 1. Step of NR - calculate the SNR's
+	  	  for(int bindx = 0; bindx < nr_params.NR_FFT_L / 2; bindx++)// 1. Step of NR - calculate the SNR's
 	             {
 	               NR.SNR_post[bindx] = fmax(fmin(NR2.X[bindx][0] / NR.Nest[bindx][0],1000.0),0.03); // limited to +30 /-15 dB, might be still too much of reduction, let's try it?
 
-	               NR.SNR_prio[bindx] = fmax(ts.nr_alpha * NR.Hk_old[bindx] + (1.0 - ts.nr_alpha)*fmax(NR.SNR_post[bindx]-1.0,0.0),0.0);
+	               NR.SNR_prio[bindx] = fmax(nr_params.alpha * NR.Hk_old[bindx] + (1.0 - nr_params.alpha)*fmax(NR.SNR_post[bindx]-1.0,0.0),0.0);
 	             }
 
 
@@ -1395,18 +1451,18 @@ float32_t uf_freq = (offset + width/2) / (NR_sample_rate / ts.NR_FFT_L);
                 	  VAD_low = 1;
                   }
                   else
-                	  if(VAD_low > ts.NR_FFT_L / 2 - 2)
+                	  if(VAD_low > nr_params.NR_FFT_L / 2 - 2)
                 	  {
-                		  VAD_low = ts.NR_FFT_L / 2 - 2;
+                		  VAD_low = nr_params.NR_FFT_L / 2 - 2;
                 	  }
                   if(VAD_high < 1)
                   {
                 	  VAD_high = 1;
                   }
                   else
-                	  if(VAD_high > ts.NR_FFT_L / 2)
+                	  if(VAD_high > nr_params.NR_FFT_L / 2)
                 	  {
-                		  VAD_high = ts.NR_FFT_L / 2;
+                		  VAD_high = nr_params.NR_FFT_L / 2;
                 	  }
 
 // ******* alternative VAD trials
@@ -1434,9 +1490,9 @@ float32_t uf_freq = (offset + width/2) / (NR_sample_rate / ts.NR_FFT_L);
   	    else
   	      {
   		Board_RedLed(LED_STATE_OFF); //Noise!
-  		for(int bindx = 0; bindx < ts.NR_FFT_L / 2; bindx++)  //update the noise estimate in dpi
+  		for(int bindx = 0; bindx < nr_params.NR_FFT_L / 2; bindx++)  //update the noise estimate in dpi
   	      	     {
-  	      	         NR.Nest[bindx][0] = NR.Nest[bindx][0] * ts.nr_beta + (1.0 - ts.nr_beta) * NR2.X[bindx][0];
+  	      	         NR.Nest[bindx][0] = NR.Nest[bindx][0] * nr_params.beta + (1.0 - nr_params.beta) * NR2.X[bindx][0];
   	      	     }
   	      }
   	    }
@@ -1445,7 +1501,7 @@ float32_t uf_freq = (offset + width/2) / (NR_sample_rate / ts.NR_FFT_L);
   	      NR2.VAD_duration++;
   	      if (NR2.VAD_duration > 1)
   		{
-  		 NR2.VAD_delay=ts.nr_vad_delay;
+  		 NR2.VAD_delay=nr_params.vad_delay;
 
 
   		  Board_RedLed(LED_STATE_ON);//Speech!
@@ -1459,14 +1515,14 @@ float32_t uf_freq = (offset + width/2) / (NR_sample_rate / ts.NR_FFT_L);
   	   {
   	      float32_t v = NR.SNR_prio[bindx] * NR.SNR_post[bindx] / (1.0 + NR.SNR_prio[bindx]);
 
-  	      NR.Hk[bindx] = 1.0 / NR.SNR_post[bindx] * sqrtf((0.7212 * v + v * v));
+  	      NR2.Hk[bindx] = 1.0 / NR.SNR_post[bindx] * sqrtf((0.7212 * v + v * v));
 
-  	      NR.Hk_old[bindx] = NR.SNR_post[bindx] * NR.Hk[bindx] * NR.Hk[bindx]; //
+  	      NR.Hk_old[bindx] = NR.SNR_post[bindx] * NR2.Hk[bindx] * NR2.Hk[bindx]; //
 
 
 	      if(!(ts.dsp_active & DSP_NR_ENABLE)) // if NR is not enabled (but notch is enabled !)
 	      {
-		      NR.Hk[bindx] = 1.0;
+		      NR2.Hk[bindx] = 1.0;
 	      }
 
   	   }
@@ -1478,9 +1534,9 @@ float32_t uf_freq = (offset + width/2) / (NR_sample_rate / ts.NR_FFT_L);
               if((ts.dsp_active & DSP_NOTCH_ENABLE))
               {
 // long tone attenuation = automatic notch filter
-              for(int bindx = 0; bindx < ts.NR_FFT_L / 2; bindx++)
+              for(int bindx = 0; bindx < nr_params.NR_FFT_L / 2; bindx++)
                     {
-            	  	  	  if(NR2.long_tone[bindx][0] > (float32_t)ts.nr_long_tone_thresh)
+            	  	  	  if(NR2.long_tone[bindx][0] > (float32_t)nr_params.long_tone_thresh)
             	  	  	  {
             	  	  			  NR2.long_tone_gain[bindx] = NR2.long_tone_gain[bindx] * 0.99;
 
@@ -1493,7 +1549,7 @@ float32_t uf_freq = (offset + width/2) / (NR_sample_rate / ts.NR_FFT_L);
                 	  	  			  }
             	  	  			  }
             	  	  			  else
-            	  	  			  if(bindx != (ts.NR_FFT_L / 2 - 1))
+            	  	  			  if(bindx != (nr_params.NR_FFT_L / 2 - 1))
             	  	  			  {
             	  	  				  NR2.long_tone_gain[bindx + 1] = NR2.long_tone_gain[bindx + 1] * 0.9995;
                 	  	  			  if(NR2.long_tone_gain[bindx + 1] < 0.2)
@@ -1518,7 +1574,7 @@ float32_t uf_freq = (offset + width/2) / (NR_sample_rate / ts.NR_FFT_L);
             	  	  			  }
         	  	  			  }
         	  	  			  else
-        	  	  			  if(bindx != (ts.NR_FFT_L / 2 - 1))
+        	  	  			  if(bindx != (nr_params.NR_FFT_L / 2 - 1))
         	  	  			  {
         	  	  				  NR2.long_tone_gain[bindx + 1] = NR2.long_tone_gain[bindx + 1] * 1.0005;
             	  	  			  if(NR2.long_tone_gain[bindx + 1] > 1.0)
@@ -1539,11 +1595,11 @@ float32_t uf_freq = (offset + width/2) / (NR_sample_rate / ts.NR_FFT_L);
             	  NR2.notch_change = false;
 // long tone attenuation = automatic notch filter
 // first version, only one notch implemented - finds the largest persisting signal and notches it with an IIR
-              for(int bindx = 0; bindx < ts.NR_FFT_L / 2; bindx++)
+              for(int bindx = 0; bindx < nr_params.NR_FFT_L / 2; bindx++)
                     {
             	  	  	  // if the (strongly time smoothed) signal in a bin exceeds the threshold,
             	  	  	  // increase the counter for that bin
-						  if(NR2.long_tone[bindx][0] > (float32_t)ts.nr_long_tone_thresh)
+						  if(NR2.long_tone[bindx][0] > (float32_t)nr_params.long_tone_thresh)
 						  {
 							  NR2.long_tone_counter[bindx]++;
 						  }
@@ -1585,7 +1641,7 @@ float32_t uf_freq = (offset + width/2) / (NR_sample_rate / ts.NR_FFT_L);
 				  NR2.long_tone_max = 0.0;
 				  NR2.max_bin = -99; // -99 is the indication for reset value
 
-	              for(int bindx = 0; bindx < ts.NR_FFT_L / 2; bindx++)
+	              for(int bindx = 0; bindx < nr_params.NR_FFT_L / 2; bindx++)
                   {
 						  // look for new notches
 						  // if a tone persists strong for at least one second = 100 frames
@@ -1625,7 +1681,7 @@ float32_t uf_freq = (offset + width/2) / (NR_sample_rate / ts.NR_FFT_L);
 #endif
 
 
-              if(ts.nr_gain_smooth_enable)
+              if(nr_params.gain_smooth_enable)
               {
 // we hear considerable distortion in the end result
 // this can be healed significantly by frequency smoothing the gain values
@@ -1634,29 +1690,29 @@ float32_t uf_freq = (offset + width/2) / (NR_sample_rate / ts.NR_FFT_L);
 //remark: if we smooth the gains and really modify the HK's like here, the noise reduction algorithm might directly "fight" against this!
 // might be better to keep the HK's internaly and smooth a copy of the gains which are than working on the signal.
 
-				  for(int bindx = 1; bindx < (ts.NR_FFT_L / 2) - 1; bindx++)
+				  for(int bindx = 1; bindx < (nr_params.NR_FFT_L / 2) - 1; bindx++)
 				  {
-					  NR.Hk[bindx] = ts.nr_gain_smooth_alpha * NR.Hk[bindx - 1] + (1.0 - 2.0 * ts.nr_gain_smooth_alpha) * NR.Hk[bindx] + ts.nr_gain_smooth_alpha * NR.Hk[bindx + 1];
+					  NR2.Hk[bindx] = nr_params.gain_smooth_alpha * NR2.Hk[bindx - 1] + (1.0 - 2.0 * nr_params.gain_smooth_alpha) * NR2.Hk[bindx] + nr_params.gain_smooth_alpha * NR2.Hk[bindx + 1];
 
 				  }
-				  NR.Hk[0] = (1.0 - ts.nr_gain_smooth_alpha) * NR.Hk[0] + ts.nr_gain_smooth_alpha * NR.Hk[1];
-				  NR.Hk[(ts.NR_FFT_L / 2) - 1] = (1.0 - ts.nr_gain_smooth_alpha) * NR.Hk[(ts.NR_FFT_L / 2) - 1] + ts.nr_gain_smooth_alpha * NR.Hk[(ts.NR_FFT_L / 2) - 2];
+				  NR2.Hk[0] = (1.0 - nr_params.gain_smooth_alpha) * NR2.Hk[0] + nr_params.gain_smooth_alpha * NR2.Hk[1];
+				  NR2.Hk[(nr_params.NR_FFT_L / 2) - 1] = (1.0 - nr_params.gain_smooth_alpha) * NR2.Hk[(nr_params.NR_FFT_L / 2) - 1] + nr_params.gain_smooth_alpha * NR2.Hk[(nr_params.NR_FFT_L / 2) - 2];
               }
 
-	}	//end of "if ts.nr_first_time == 3"
+	}	//end of "if nr_params.first_time == 3"
 
 
 
         // FINAL SPECTRAL WEIGHTING: Multiply current FFT results with NR_FFT_buffer for 64 bins with the 64 bin-specific gain factors
               // only do this for the bins inside the filter passband
               // if you do this for all the bins, you will get distorted audio: plopping !
-              //              for(int bindx = 0; bindx < ts.NR_FFT_L / 2; bindx++) // plopping !!!!
+              //              for(int bindx = 0; bindx < nr_params.NR_FFT_L / 2; bindx++) // plopping !!!!
                 for(int bindx = VAD_low; bindx < VAD_high; bindx++) // no plopping
               {
-                  NR.FFT_buffer[bindx * 2] = NR.FFT_buffer [bindx * 2] * NR.Hk[bindx] * NR2.long_tone_gain[bindx]; // real part
-                  NR.FFT_buffer[bindx * 2 + 1] = NR.FFT_buffer [bindx * 2 + 1] * NR.Hk[bindx] * NR2.long_tone_gain[bindx]; // imag part
-                  NR.FFT_buffer[ts.NR_FFT_L * 2 - bindx * 2 - 2] = NR.FFT_buffer[ts.NR_FFT_L * 2 - bindx * 2 - 2] * NR.Hk[bindx] * NR2.long_tone_gain[bindx]; // real part conjugate symmetric
-                  NR.FFT_buffer[ts.NR_FFT_L * 2 - bindx * 2 - 1] = NR.FFT_buffer[ts.NR_FFT_L * 2 - bindx * 2 - 1] * NR.Hk[bindx] * NR2.long_tone_gain[bindx]; // imag part conjugate symmetric
+                  NR.FFT_buffer[bindx * 2] = NR.FFT_buffer [bindx * 2] * NR2.Hk[bindx] * NR2.long_tone_gain[bindx]; // real part
+                  NR.FFT_buffer[bindx * 2 + 1] = NR.FFT_buffer [bindx * 2 + 1] * NR2.Hk[bindx] * NR2.long_tone_gain[bindx]; // imag part
+                  NR.FFT_buffer[nr_params.NR_FFT_L * 2 - bindx * 2 - 2] = NR.FFT_buffer[nr_params.NR_FFT_L * 2 - bindx * 2 - 2] * NR2.Hk[bindx] * NR2.long_tone_gain[bindx]; // real part conjugate symmetric
+                  NR.FFT_buffer[nr_params.NR_FFT_L * 2 - bindx * 2 - 1] = NR.FFT_buffer[nr_params.NR_FFT_L * 2 - bindx * 2 - 1] * NR2.Hk[bindx] * NR2.long_tone_gain[bindx]; // imag part conjugate symmetric
               }
 
 
@@ -1678,66 +1734,66 @@ float32_t uf_freq = (offset + width/2) / (NR_sample_rate / ts.NR_FFT_L);
   // set real values to 0.1 of their original value
   {
       NR.FFT_buffer[bindx * 2] *= 0.1;
-//      NR_FFT_buffer[ts.NR_FFT_L * 2 - bindx * 2 - 2] *= 0.1; //NR_iFFT_buffer[idx] * 0.1;
+//      NR_FFT_buffer[nr_params.NR_FFT_L * 2 - bindx * 2 - 2] *= 0.1; //NR_iFFT_buffer[idx] * 0.1;
       NR.FFT_buffer[bindx * 2 + 1] *= 0.1; //NR_iFFT_buffer[idx] * 0.1;
-//      NR_FFT_buffer[ts.NR_FFT_L * 2 - bindx * 2 - 1] *= 0.1; //NR_iFFT_buffer[idx] * 0.1;
+//      NR_FFT_buffer[nr_params.NR_FFT_L * 2 - bindx * 2 - 1] *= 0.1; //NR_iFFT_buffer[idx] * 0.1;
   }
 #endif
 
 #ifdef NR_NOTCHTEST  // this is a test of a smoother notch filter
 	  // centre bin to be notched
   	  NR.FFT_buffer[				bin_c * 2] 		*= bin1_att; // real
-      NR.FFT_buffer[ts.NR_FFT_L * 2 - 	bin_c * 2 - 2]	*= bin1_att; // imaginary
+      NR.FFT_buffer[nr_params.NR_FFT_L * 2 - 	bin_c * 2 - 2]	*= bin1_att; // imaginary
       NR.FFT_buffer[				bin_c * 2 + 1] 	*= bin1_att; // real conjugate symmetric
-      NR.FFT_buffer[ts.NR_FFT_L * 2 - 	bin_c * 2 - 1] 	*= bin1_att; // imaginary conjugate symmetric
+      NR.FFT_buffer[nr_params.NR_FFT_L * 2 - 	bin_c * 2 - 1] 	*= bin1_att; // imaginary conjugate symmetric
       // centre_bin + 1 to be notched
   	  NR.FFT_buffer[				bin_p1 * 2] 	*= bin2_att;
-      NR.FFT_buffer[ts.NR_FFT_L * 2 - 	bin_p1 * 2 - 2]	*= bin2_att;
+      NR.FFT_buffer[nr_params.NR_FFT_L * 2 - 	bin_p1 * 2 - 2]	*= bin2_att;
       NR.FFT_buffer[				bin_p1 * 2 + 1] *= bin2_att;
-      NR.FFT_buffer[ts.NR_FFT_L * 2 - 	bin_p1 * 2 - 1] *= bin2_att;
+      NR.FFT_buffer[nr_params.NR_FFT_L * 2 - 	bin_p1 * 2 - 1] *= bin2_att;
       // centre_bin - 1 to be notched
   	  NR.FFT_buffer[				bin_m1 * 2] 	*= bin2_att;
-      NR.FFT_buffer[ts.NR_FFT_L * 2 - 	bin_m1 * 2 - 2]	*= bin2_att;
+      NR.FFT_buffer[nr_params.NR_FFT_L * 2 - 	bin_m1 * 2 - 2]	*= bin2_att;
       NR.FFT_buffer[				bin_m1 * 2 + 1] *= bin2_att;
-      NR.FFT_buffer[ts.NR_FFT_L * 2 - 	bin_m1 * 2 - 1] *= bin2_att;
+      NR.FFT_buffer[nr_params.NR_FFT_L * 2 - 	bin_m1 * 2 - 1] *= bin2_att;
       // centre_bin + 2 to be notched
   	  NR.FFT_buffer[				bin_p2 * 2] 	*= bin3_att;
-      NR.FFT_buffer[ts.NR_FFT_L * 2 - 	bin_p2 * 2 - 2]	*= bin3_att;
+      NR.FFT_buffer[nr_params.NR_FFT_L * 2 - 	bin_p2 * 2 - 2]	*= bin3_att;
       NR.FFT_buffer[				bin_p2 * 2 + 1] *= bin3_att;
-      NR.FFT_buffer[ts.NR_FFT_L * 2 - 	bin_p2 * 2 - 1] *= bin3_att;
+      NR.FFT_buffer[nr_params.NR_FFT_L * 2 - 	bin_p2 * 2 - 1] *= bin3_att;
       // centre_bin - 2 to be notched
   	  NR.FFT_buffer[				bin_m2 * 2] 	*= bin3_att;
-      NR.FFT_buffer[ts.NR_FFT_L * 2 - 	bin_m2 * 2 - 2]	*= bin3_att;
+      NR.FFT_buffer[nr_params.NR_FFT_L * 2 - 	bin_m2 * 2 - 2]	*= bin3_att;
       NR.FFT_buffer[				bin_m2 * 2 + 1] *= bin3_att;
-      NR.FFT_buffer[ts.NR_FFT_L * 2 - 	bin_m2 * 2 - 1] *= bin3_att;
+      NR.FFT_buffer[nr_params.NR_FFT_L * 2 - 	bin_m2 * 2 - 1] *= bin3_att;
       // centre_bin + 3 to be notched
   	  NR.FFT_buffer[				bin_p3 * 2] 	*= bin4_att;
-      NR.FFT_buffer[ts.NR_FFT_L * 2 - 	bin_p3 * 2 - 2]	*= bin4_att;
+      NR.FFT_buffer[nr_params.NR_FFT_L * 2 - 	bin_p3 * 2 - 2]	*= bin4_att;
       NR.FFT_buffer[				bin_p3 * 2 + 1] *= bin4_att;
-      NR.FFT_buffer[ts.NR_FFT_L * 2 - 	bin_p3 * 2 - 1] *= bin4_att;
+      NR.FFT_buffer[nr_params.NR_FFT_L * 2 - 	bin_p3 * 2 - 1] *= bin4_att;
       // centre_bin - 3 to be notched
   	  NR.FFT_buffer[				bin_m3 * 2] 	*= bin4_att;
-      NR.FFT_buffer[ts.NR_FFT_L * 2 - 	bin_m3 * 2 - 2]	*= bin4_att;
+      NR.FFT_buffer[nr_params.NR_FFT_L * 2 - 	bin_m3 * 2 - 2]	*= bin4_att;
       NR.FFT_buffer[				bin_m3 * 2 + 1] *= bin4_att;
-      NR.FFT_buffer[ts.NR_FFT_L * 2 - 	bin_m3 * 2 - 1] *= bin4_att;
+      NR.FFT_buffer[nr_params.NR_FFT_L * 2 - 	bin_m3 * 2 - 1] *= bin4_att;
       // centre_bin + 4 to be notched
   	  NR.FFT_buffer[				bin_p4 * 2] 	*= bin5_att;
-      NR.FFT_buffer[ts.NR_FFT_L * 2 - 	bin_p4 * 2 - 2]	*= bin5_att;
+      NR.FFT_buffer[nr_params.NR_FFT_L * 2 - 	bin_p4 * 2 - 2]	*= bin5_att;
       NR.FFT_buffer[				bin_p4 * 2 + 1] *= bin5_att;
-      NR.FFT_buffer[ts.NR_FFT_L * 2 - 	bin_p4 * 2 - 1] *= bin5_att;
+      NR.FFT_buffer[nr_params.NR_FFT_L * 2 - 	bin_p4 * 2 - 1] *= bin5_att;
       // centre_bin - 4 to be notched
   	  NR.FFT_buffer[				bin_m4 * 2] 	*= bin5_att;
-      NR.FFT_buffer[ts.NR_FFT_L * 2 - 	bin_m4 * 2 - 2]	*= bin5_att;
+      NR.FFT_buffer[nr_params.NR_FFT_L * 2 - 	bin_m4 * 2 - 2]	*= bin5_att;
       NR.FFT_buffer[				bin_m4 * 2 + 1] *= bin5_att;
-      NR.FFT_buffer[ts.NR_FFT_L * 2 - 	bin_m4 * 2 - 1] *= bin5_att;
+      NR.FFT_buffer[nr_params.NR_FFT_L * 2 - 	bin_m4 * 2 - 1] *= bin5_att;
 #endif
 
 
       // Window on exit!
-            if(ts.nr_fft_256_enable)
+            if(nr_params.fft_256_enable)
             {
                 arm_cfft_f32(&arm_cfft_sR_f32_len256, NR.FFT_buffer, 1, 1);
-          	  for (int idx = 0; idx < ts.NR_FFT_L; idx++)
+          	  for (int idx = 0; idx < nr_params.NR_FFT_L; idx++)
                 {
           	  	  NR.FFT_buffer[idx * 2] *= SQRT_von_Hann_256[idx];
                 }
@@ -1745,29 +1801,29 @@ float32_t uf_freq = (offset + width/2) / (NR_sample_rate / ts.NR_FFT_L);
             else
             {
                 arm_cfft_f32(&arm_cfft_sR_f32_len128, NR.FFT_buffer, 1, 1);
-                for (int idx = 0; idx < ts.NR_FFT_L; idx++)
+                for (int idx = 0; idx < nr_params.NR_FFT_L; idx++)
                 {
               	  NR.FFT_buffer[idx * 2] *= SQRT_van_hann[idx];
                 }
             }
 
     // do the overlap & add
-          for(int i = 0; i < ts.NR_FFT_L / 2; i++)
+          for(int i = 0; i < nr_params.NR_FFT_L / 2; i++)
           { // take real part of first half of current iFFT result and add to 2nd half of last iFFT_result
-        	  //              NR_output_audio_buffer[i + k * (ts.NR_FFT_L / 2)] = NR_FFT_buffer[i * 2] + NR_last_iFFT_result[i];
-        	  in_buffer[i + k * (ts.NR_FFT_L / 2)] = NR.FFT_buffer[i * 2] + NR.last_iFFT_result[i];
+        	  //              NR_output_audio_buffer[i + k * (nr_params.NR_FFT_L / 2)] = NR_FFT_buffer[i * 2] + NR_last_iFFT_result[i];
+        	  in_buffer[i + k * (nr_params.NR_FFT_L / 2)] = NR.FFT_buffer[i * 2] + NR.last_iFFT_result[i];
 // FIXME: take out scaling !
-//        	  in_buffer[i + k * (ts.NR_FFT_L / 2)] *= 0.3;
+//        	  in_buffer[i + k * (nr_params.NR_FFT_L / 2)] *= 0.3;
           }
-          for(int i = 0; i < ts.NR_FFT_L / 2; i++)
+          for(int i = 0; i < nr_params.NR_FFT_L / 2; i++)
           {
-              NR.last_iFFT_result[i] = NR.FFT_buffer[ts.NR_FFT_L + i * 2];
+              NR.last_iFFT_result[i] = NR.FFT_buffer[nr_params.NR_FFT_L + i * 2];
           }
        // end of "for" loop which repeats the FFT_iFFT_chain two times !!!
     }
 
     // IIR biquad notch filter with four independent notches
-   // arm_biquad_cascade_df1_f32 (&NR_notch_biquad, in_buffer, in_buffer, ts.NR_FFT_L);
+   // arm_biquad_cascade_df1_f32 (&NR_notch_biquad, in_buffer, in_buffer, nr_params.NR_FFT_L);
 }
 #endif
 
@@ -1787,22 +1843,17 @@ void spectral_noise_reduction_3 (float* in_buffer)
 // FFT128 - inverse FFT128 or FFT256 / iFFT256
 // overlap-add
 
+const float32_t width = FilterInfo[ts.filters_p->id].width;
+const float32_t offset = ts.filters_p->offset;
 
-float32_t NR_sample_rate = 12000.0;
-// we use further decimation to 6ksps, when filter bandwidth is < 2701Hz
-if(ts.NR_decimation_enable && (FilterInfo[FilterPathInfo[ts.filter_path].id].width < 2701))
-{
-	NR_sample_rate = 6000.0;
-}
+float32_t NR_sample_rate = nr_params.NR_decimation_active? 6000.0: 12000.0;
 
 static uint8_t NR_init_counter = 0;
 uint8_t VAD_low=0;
 uint8_t VAD_high=63;
 
-float32_t width = FilterInfo[FilterPathInfo[ts.filter_path].id].width;
-float32_t offset = FilterPathInfo[ts.filter_path].offset;
-float32_t lf_freq = (offset - width/2) / (NR_sample_rate / ts.NR_FFT_L); // bin BW is 93.75Hz [12000Hz / 128 bins]
-float32_t uf_freq = (offset + width/2) / (NR_sample_rate / ts.NR_FFT_L);
+float32_t lf_freq = (offset - width/2) / (NR_sample_rate / nr_params.NR_FFT_L); // bin BW is 93.75Hz [12000Hz / 128 bins]
+float32_t uf_freq = (offset + width/2) / (NR_sample_rate / nr_params.NR_FFT_L);
 
 //const float32_t tinc = 0.00533333; // frame time 5.3333ms
 //const float32_t tax=0.071;	// noise output smoothing time constant - absolut value in seconds
@@ -1842,26 +1893,26 @@ float32_t ph1y[NR_FFT_SIZE];
 //		 6KS  |10.666		21.333
 
 
-/*if (ts.nr_fft_256_enable && ts.NR_decimation_enable)
+/*if (nr_params.fft_256_enable && nr_params.NR_decimation_enable)
   {
     NR2.ax = 0.7405;
     NR2.ap = 0.8691;
   }
 else
-  if (ts.nr_fft_256_enable || ts.NR_decimation_enable)
+  if (nr_params.fft_256_enable || nr_params.NR_decimation_enable)
     {
       NR2.ax = 0.8605;
       NR2.ap = 0.9322;
     } */
 
 
-    if(ts.nr_first_time == 1)
+    if(nr_params.first_time == 1)
     { // TODO: properly initialize all the variables
 
-		for(int bindx = 0; bindx < ts.NR_FFT_L / 2; bindx++)
+		for(int bindx = 0; bindx < nr_params.NR_FFT_L / 2; bindx++)
 			{
 				  NR.last_sample_buffer_L[bindx] = 0.0;
-				  NR.Hk[bindx] = 1.0;
+				  NR2.Hk[bindx] = 1.0;
 				//xu[bindx] = 1.0;  //has to be replaced by other variable
 				  NR.Hk_old[bindx] = 1.0; // old gain or xu in development mode
 				  NR.Nest[bindx][0] = 0.0;
@@ -1869,36 +1920,36 @@ else
 				  pslp[bindx] = 0.5;
 				  //              NR2.long_tone_gain[bindx] = 1.0;
 			}
-        ts.nr_first_time = 2; // we need to do some more a bit later down
+        nr_params.first_time = 2; // we need to do some more a bit later down
     }
 
-    for(int k = 0; k < ts.NR_FFT_LOOP_NO; k++)
+    for(int k = 0; k < nr_params.NR_FFT_LOOP_NO; k++)
     {
     // NR_FFT_buffer is 256 floats big
     // interleaved r, i, r, i . . .
     // fill first half of FFT_buffer with last events audio samples
-          for(int i = 0; i < ts.NR_FFT_L / 2; i++)
+          for(int i = 0; i < nr_params.NR_FFT_L / 2; i++)
           {
             NR.FFT_buffer[i * 2] = NR.last_sample_buffer_L[i]; // real
             NR.FFT_buffer[i * 2 + 1] = 0.0; // imaginary
           }
     // copy recent samples to last_sample_buffer for next time!
-          for(int i = 0; i < ts.NR_FFT_L  / 2; i++)
+          for(int i = 0; i < nr_params.NR_FFT_L  / 2; i++)
           {
-             NR.last_sample_buffer_L [i] = in_buffer[i + k * (ts.NR_FFT_L / 2)];
+             NR.last_sample_buffer_L [i] = in_buffer[i + k * (nr_params.NR_FFT_L / 2)];
           }
     // now fill recent audio samples into second half of FFT_buffer
-          for(int i = 0; i < ts.NR_FFT_L / 2; i++)
+          for(int i = 0; i < nr_params.NR_FFT_L / 2; i++)
           {
-              NR.FFT_buffer[ts.NR_FFT_L + i * 2] = in_buffer[i+ k * (ts.NR_FFT_L / 2)]; // real
-              NR.FFT_buffer[ts.NR_FFT_L + i * 2 + 1] = 0.0;
+              NR.FFT_buffer[nr_params.NR_FFT_L + i * 2] = in_buffer[i+ k * (nr_params.NR_FFT_L / 2)]; // real
+              NR.FFT_buffer[nr_params.NR_FFT_L + i * 2 + 1] = 0.0;
           }
     /////////////////////////////////7
     // WINDOWING
 
-//          if(ts.nr_fft_256_enable)
+//          if(nr_params.fft_256_enable)
           {
-        	  for (int idx = 0; idx < ts.NR_FFT_L; idx++)
+        	  for (int idx = 0; idx < nr_params.NR_FFT_L; idx++)
               {
         	  	  NR.FFT_buffer[idx * 2] *= SQRT_von_Hann_256[idx];
               }
@@ -1906,7 +1957,7 @@ else
           }
           /*else
           {
-              for (int idx = 0; idx < ts.NR_FFT_L; idx++)
+              for (int idx = 0; idx < nr_params.NR_FFT_L; idx++)
               {
             	  NR.FFT_buffer[idx * 2] *= SQRT_van_hann[idx];
               }
@@ -1918,15 +1969,15 @@ else
 
 
 
-	  for(int bindx = 0; bindx < ts.NR_FFT_L / 2; bindx++)
+	  for(int bindx = 0; bindx < nr_params.NR_FFT_L / 2; bindx++)
 		{
 		  //here we need squared magnitude
 			NR2.X[bindx][0] = (NR.FFT_buffer[bindx * 2] * NR.FFT_buffer[bindx * 2] + NR.FFT_buffer[bindx * 2 + 1] * NR.FFT_buffer[bindx * 2 + 1]);
 		}
 
-      if(ts.nr_first_time == 2)
+      if(nr_params.first_time == 2)
       {
- 		  for(int bindx = 0; bindx < ts.NR_FFT_L / 2; bindx++)
+ 		  for(int bindx = 0; bindx < nr_params.NR_FFT_L / 2; bindx++)
 		  {
 			  NR.Nest[bindx][0] = NR.Nest[bindx][0] + 0.05* NR2.X[bindx][0];// we do it 20 times to average over 20 frames for app. 100ms only on NR_on/bandswitch/modeswitch,...
 			  xt[bindx] = psini * NR.Nest[bindx][0];
@@ -1935,15 +1986,15 @@ else
 		  if (NR_init_counter > 19)//average over 20 frames for app. 100ms
 		  {
 			  NR_init_counter = 0;
-			  ts.nr_first_time = 3;  // now we did all the necessary initialization to actually start the noise reduction
+			  nr_params.first_time = 3;  // now we did all the necessary initialization to actually start the noise reduction
 		  }
       }
-     if (ts.nr_first_time == 3)
+     if (nr_params.first_time == 3)
      {
 
  //new noise estimate MMSE based!!!
 
-		for(int bindx = 0; bindx < ts.NR_FFT_L / 2; bindx++)// 1. Step of NR - calculate the SNR's
+		for(int bindx = 0; bindx < nr_params.NR_FFT_L / 2; bindx++)// 1. Step of NR - calculate the SNR's
     	{
 		      ph1y[bindx] = 1.0 / (1.0 + NR2.pfac * expf(NR2.xih1r * NR2.X[bindx][0]/xt[bindx]));
 		      pslp[bindx] = NR2.ap * pslp[bindx] + (1.0 - NR2.ap) * ph1y[bindx];
@@ -1962,11 +2013,11 @@ else
         }
 
 
-	  	  for(int bindx = 0; bindx < ts.NR_FFT_L / 2; bindx++)// 1. Step of NR - calculate the SNR's
+	  	  for(int bindx = 0; bindx < nr_params.NR_FFT_L / 2; bindx++)// 1. Step of NR - calculate the SNR's
 			 {
 			   NR.SNR_post[bindx] = fmax(fmin(NR2.X[bindx][0] / xt[bindx],1000.0), NR2.snr_prio_min); // limited to +30 /-15 dB, might be still too much of reduction, let's try it?
 
-			   NR.SNR_prio[bindx] = fmax(ts.nr_alpha * NR.Hk_old[bindx] + (1.0 - ts.nr_alpha) * fmax(NR.SNR_post[bindx] - 1.0, 0.0), 0.0);
+			   NR.SNR_prio[bindx] = fmax(nr_params.alpha * NR.Hk_old[bindx] + (1.0 - nr_params.alpha) * fmax(NR.SNR_post[bindx] - 1.0, 0.0), 0.0);
 			 }
 
 	  	  	  	  VAD_low = (int)lf_freq;
@@ -1982,18 +2033,18 @@ else
                 	  VAD_low = 1;
                   }
                   else
-				  if(VAD_low > ts.NR_FFT_L / 2 - 2)
+				  if(VAD_low > nr_params.NR_FFT_L / 2 - 2)
 				  {
-					  VAD_low = ts.NR_FFT_L / 2 - 2;
+					  VAD_low = nr_params.NR_FFT_L / 2 - 2;
 				  }
                   if(VAD_high < 1)
                   {
                 	  VAD_high = 1;
                   }
                   else
-				  if(VAD_high > ts.NR_FFT_L / 2)
+				  if(VAD_high > nr_params.NR_FFT_L / 2)
 				  {
-					  VAD_high = ts.NR_FFT_L / 2;
+					  VAD_high = nr_params.NR_FFT_L / 2;
 				  }
 
 
@@ -2004,14 +2055,14 @@ else
 		{
 			  float32_t v = NR.SNR_prio[bindx] * NR.SNR_post[bindx] / (1.0 + NR.SNR_prio[bindx]);
 
-			  NR.Hk[bindx] = fmax(1.0 / NR.SNR_post[bindx] * sqrtf((0.7212 * v + v * v)),0.001); //limit HK's to 0.001'
+			  NR2.Hk[bindx] = fmax(1.0 / NR.SNR_post[bindx] * sqrtf((0.7212 * v + v * v)),0.001); //limit HK's to 0.001'
 
-			  NR.Hk_old[bindx] = NR.SNR_post[bindx] * NR.Hk[bindx] * NR.Hk[bindx]; //
+			  NR.Hk_old[bindx] = NR.SNR_post[bindx] * NR2.Hk[bindx] * NR2.Hk[bindx]; //
 
 
 			  /*if(!(ts.dsp_active & DSP_NR_ENABLE)) // if NR is not enabled (but notch is enabled !)
 			  {
-				  NR.Hk[bindx] = 1.0;
+				  NR2.Hk[bindx] = 1.0;
 			  } */
 		}
 		// musical noise "artefact" reduction by dynamic averaging - depending on SNR ratio
@@ -2020,7 +2071,7 @@ else
 		for(int bindx = VAD_low; bindx < VAD_high; bindx++)
 		{
 		    NR2.pre_power += NR2.X[bindx][0];
-		    NR2.post_power += NR.Hk[bindx] * NR.Hk[bindx]  * NR2.X[bindx][0];
+		    NR2.post_power += NR2.Hk[bindx] * NR2.Hk[bindx]  * NR2.X[bindx][0];
 		}
 
 		NR2.power_ratio = NR2.post_power / NR2.pre_power;
@@ -2039,7 +2090,7 @@ else
 		    NR.Nest[bindx][0] = 0.0;
 		    for(int m = bindx - NR2.NN/2; m <= bindx + NR2.NN/2;m++)
 		      {
-			NR.Nest[bindx][0] += NR.Hk[m];
+			NR.Nest[bindx][0] += NR2.Hk[m];
 		      }
 		    NR.Nest[bindx][0] /= (float32_t)NR2.NN;
 		  }
@@ -2051,7 +2102,7 @@ else
 		    NR.Nest[bindx][0] = 0.0;
 		    for(int m = bindx; m < (bindx + NR2.NN);m++)
 		      {
-			NR.Nest[bindx][0] += NR.Hk[m];
+			NR.Nest[bindx][0] += NR2.Hk[m];
 		      }
 		    NR.Nest[bindx][0] /= (float32_t)NR2.NN;
 		 }
@@ -2062,7 +2113,7 @@ else
 		    NR.Nest[bindx][0] = 0.0;
 		    for(int m = bindx; m > (bindx - NR2.NN); m--)
 		      {
-			NR.Nest[bindx][0] += NR.Hk[m];
+			NR.Nest[bindx][0] += NR2.Hk[m];
 		      }
 		    NR.Nest[bindx][0] /= (float32_t)NR2.NN;
 		 }
@@ -2071,26 +2122,26 @@ else
 
 		for(int bindx = VAD_low + NR2.NN/2; bindx < VAD_high - NR2.NN/2; bindx++)
 		  {
-		    NR.Hk[bindx] = NR.Nest[bindx][0];
+		    NR2.Hk[bindx] = NR.Nest[bindx][0];
 		  }
 // end of musical noise reduction
-	}	//end of "if ts.nr_first_time == 3"
+	}	//end of "if nr_params.first_time == 3"
 
 
         // FINAL SPECTRAL WEIGHTING: Multiply current FFT results with NR_FFT_buffer for 64 bins with the 64 bin-specific gain factors
               // only do this for the bins inside the filter passband
               // if you do this for all the bins, you will get distorted audio: plopping !
-              //              for(int bindx = 0; bindx < ts.NR_FFT_L / 2; bindx++) // plopping !!!!
+              //              for(int bindx = 0; bindx < nr_params.NR_FFT_L / 2; bindx++) // plopping !!!!
                 for(int bindx = VAD_low; bindx < VAD_high; bindx++) // no plopping
               {
-                  NR.FFT_buffer[bindx * 2] = 						NR.FFT_buffer [bindx * 2] * NR.Hk[bindx]; // real part
-                  NR.FFT_buffer[bindx * 2 + 1] = 					NR.FFT_buffer [bindx * 2 + 1] * NR.Hk[bindx]; // imag part
-                  NR.FFT_buffer[ts.NR_FFT_L * 2 - bindx * 2 - 2] = 	NR.FFT_buffer[ts.NR_FFT_L * 2 - bindx * 2 - 2] * NR.Hk[bindx]; // real part conjugate symmetric
-                  NR.FFT_buffer[ts.NR_FFT_L * 2 - bindx * 2 - 1] = 	NR.FFT_buffer[ts.NR_FFT_L * 2 - bindx * 2 - 1] * NR.Hk[bindx]; // imag part conjugate symmetric
-//                  NR.FFT_buffer[bindx * 2] = NR.FFT_buffer [bindx * 2] * NR.Hk[bindx] * NR2.long_tone_gain[bindx]; // real part
-//                  NR.FFT_buffer[bindx * 2 + 1] = NR.FFT_buffer [bindx * 2 + 1] * NR.Hk[bindx] * NR2.long_tone_gain[bindx]; // imag part
-//                  NR.FFT_buffer[ts.NR_FFT_L * 2 - bindx * 2 - 2] = NR.FFT_buffer[ts.NR_FFT_L * 2 - bindx * 2 - 2] * NR.Hk[bindx] * NR2.long_tone_gain[bindx]; // real part conjugate symmetric
-//                  NR.FFT_buffer[ts.NR_FFT_L * 2 - bindx * 2 - 1] = NR.FFT_buffer[ts.NR_FFT_L * 2 - bindx * 2 - 1] * NR.Hk[bindx] * NR2.long_tone_gain[bindx]; // imag part conjugate symmetric
+                  NR.FFT_buffer[bindx * 2] = 						NR.FFT_buffer [bindx * 2] * NR2.Hk[bindx]; // real part
+                  NR.FFT_buffer[bindx * 2 + 1] = 					NR.FFT_buffer [bindx * 2 + 1] * NR2.Hk[bindx]; // imag part
+                  NR.FFT_buffer[nr_params.NR_FFT_L * 2 - bindx * 2 - 2] = 	NR.FFT_buffer[nr_params.NR_FFT_L * 2 - bindx * 2 - 2] * NR2.Hk[bindx]; // real part conjugate symmetric
+                  NR.FFT_buffer[nr_params.NR_FFT_L * 2 - bindx * 2 - 1] = 	NR.FFT_buffer[nr_params.NR_FFT_L * 2 - bindx * 2 - 1] * NR2.Hk[bindx]; // imag part conjugate symmetric
+//                  NR.FFT_buffer[bindx * 2] = NR.FFT_buffer [bindx * 2] * NR2.Hk[bindx] * NR2.long_tone_gain[bindx]; // real part
+//                  NR.FFT_buffer[bindx * 2 + 1] = NR.FFT_buffer [bindx * 2 + 1] * NR2.Hk[bindx] * NR2.long_tone_gain[bindx]; // imag part
+//                  NR.FFT_buffer[nr_params.NR_FFT_L * 2 - bindx * 2 - 2] = NR.FFT_buffer[nr_params.NR_FFT_L * 2 - bindx * 2 - 2] * NR2.Hk[bindx] * NR2.long_tone_gain[bindx]; // real part conjugate symmetric
+//                  NR.FFT_buffer[nr_params.NR_FFT_L * 2 - bindx * 2 - 1] = NR.FFT_buffer[nr_params.NR_FFT_L * 2 - bindx * 2 - 1] * NR2.Hk[bindx] * NR2.long_tone_gain[bindx]; // imag part conjugate symmetric
               }
 
          /*****************************************************************
@@ -2098,10 +2149,10 @@ else
          *****************************************************************/
 // NR_iFFT
 // & Window on exit!
-//      if(ts.nr_fft_256_enable)
+//      if(nr_params.fft_256_enable)
       {
           arm_cfft_f32(&arm_cfft_sR_f32_len256, NR.FFT_buffer, 1, 1);
-    	  for (int idx = 0; idx < ts.NR_FFT_L; idx++)
+    	  for (int idx = 0; idx < nr_params.NR_FFT_L; idx++)
           {
     	  	  NR.FFT_buffer[idx * 2] *= SQRT_von_Hann_256[idx];
           }
@@ -2109,27 +2160,27 @@ else
       /*else
       {
           arm_cfft_f32(&arm_cfft_sR_f32_len128, NR.FFT_buffer, 1, 1);
-          for (int idx = 0; idx < ts.NR_FFT_L; idx++)
+          for (int idx = 0; idx < nr_params.NR_FFT_L; idx++)
           {
         	  NR.FFT_buffer[idx * 2] *= SQRT_van_hann[idx];
           }
       }*/
 
     // do the overlap & add
-          for(int i = 0; i < ts.NR_FFT_L / 2; i++)
+          for(int i = 0; i < nr_params.NR_FFT_L / 2; i++)
           { // take real part of first half of current iFFT result and add to 2nd half of last iFFT_result
-        	  //              NR_output_audio_buffer[i + k * (ts.NR_FFT_L / 2)] = NR_FFT_buffer[i * 2] + NR_last_iFFT_result[i];
-        	  in_buffer[i + k * (ts.NR_FFT_L / 2)] = NR.FFT_buffer[i * 2] + NR.last_iFFT_result[i];
+        	  //              NR_output_audio_buffer[i + k * (nr_params.NR_FFT_L / 2)] = NR_FFT_buffer[i * 2] + NR_last_iFFT_result[i];
+        	  in_buffer[i + k * (nr_params.NR_FFT_L / 2)] = NR.FFT_buffer[i * 2] + NR.last_iFFT_result[i];
           }
-          for(int i = 0; i < ts.NR_FFT_L / 2; i++)
+          for(int i = 0; i < nr_params.NR_FFT_L / 2; i++)
           {
-              NR.last_iFFT_result[i] = NR.FFT_buffer[ts.NR_FFT_L + i * 2];
+              NR.last_iFFT_result[i] = NR.FFT_buffer[nr_params.NR_FFT_L + i * 2];
           }
        // end of "for" loop which repeats the FFT_iFFT_chain two times !!!
     }
 
     // IIR biquad notch filter with four independent notches
-  //  arm_biquad_cascade_df1_f32 (&NR_notch_biquad, in_buffer, in_buffer, ts.NR_FFT_L);
+  //  arm_biquad_cascade_df1_f32 (&NR_notch_biquad, in_buffer, in_buffer, nr_params.NR_FFT_L);
 }
 
 //alt noise blanking is trying to localize some impulse noise within the samples and after that
@@ -2373,7 +2424,7 @@ const float32_t NR_test_sinus_samp[128] = {
     arm_power_f32(lpcs,order,&lpc_power);  // calculate the sum of the squares (the "power") of the lpc's
 
     //    impulse_threshold = (float32_t)ts.nb_setting * 0.5 * sqrtf(sigma2 * lpc_power);  //set a detection level (3 is not really a final setting)
-    impulse_threshold = (float32_t)(16 - ts.nb_setting) * 0.5 * sqrtf(sigma2 * lpc_power);  //set a detection level (3 is not really a final setting)
+    impulse_threshold = (float32_t)(16 - ts.dsp.nb_setting) * 0.5 * sqrtf(sigma2 * lpc_power);  //set a detection level (3 is not really a final setting)
 
     //if ((nr_setting > 20) && (nr_setting <51))
     //    impulse_threshold = impulse_threshold / (0.9 + (nr_setting-20.0)/10);  //scaling the threshold by 1 ... 0.26

--- a/mchf-eclipse/drivers/audio/codec/uhsdr_hw_i2s.c
+++ b/mchf-eclipse/drivers/audio/codec/uhsdr_hw_i2s.c
@@ -13,7 +13,7 @@
 ************************************************************************************/
 
 // Common
-#include "uhsdr_board.h"
+#include "uhsdr_board_config.h"
 #include "profiling.h"
 #include "uhsdr_hw_i2s.h"
 
@@ -30,14 +30,14 @@
 
 typedef struct
 {
-    IqSample_t out[2*IQ_SAMPLES_PER_BLOCK];
-    IqSample_t in[2*IQ_SAMPLES_PER_BLOCK];
+    IqSample_t out[2*IQ_BLOCK_SIZE];
+    IqSample_t in[2*IQ_BLOCK_SIZE];
 } dma_iq_buffer_t;
 
 typedef struct
 {
-    AudioSample_t out[2*AUDIO_SAMPLES_PER_BLOCK];
-    AudioSample_t in[2*AUDIO_SAMPLES_PER_BLOCK];
+    AudioSample_t out[2*AUDIO_BLOCK_SIZE];
+    AudioSample_t in[2*AUDIO_BLOCK_SIZE];
 } dma_audio_buffer_t;
 
 
@@ -83,7 +83,7 @@ static void MchfHw_Codec_HandleBlock(uint16_t which)
 
     // Transfer complete interrupt
     // Point to 2nd half of buffers
-    const size_t sz = IQ_SAMPLES_PER_BLOCK;
+    const size_t sz = IQ_BLOCK_SIZE;
     const uint16_t offset = which == 0?sz:0;
 
     AudioSample_t *audio;

--- a/mchf-eclipse/drivers/audio/codec/uhsdr_hw_i2s.h
+++ b/mchf-eclipse/drivers/audio/codec/uhsdr_hw_i2s.h
@@ -15,14 +15,7 @@
 #ifndef __MCHF_HW_I2S_H
 #define __MCHF_HW_I2S_H
 
-#define IQ_SAMPLES_PER_BLOCK 32
-#define AUDIO_SAMPLES_PER_BLOCK 32
-
-/*
- * BUFF_LEN is derived from 2* 32 LR Samples per Audio-Interrupt (== 64 * int16_t )
- * since we get half of the buffer in each DMA Interrupt for processing
- */
-// #define BUFF_LEN (4*IQ_SAMPLES_PER_BLOCK)
+#include "uhsdr_board_config.h"
 
 void UhsdrHwI2s_Codec_StartDMA();
 void UhsdrHwI2s_Codec_StopDMA();

--- a/mchf-eclipse/drivers/audio/tx_processor.c
+++ b/mchf-eclipse/drivers/audio/tx_processor.c
@@ -105,11 +105,11 @@ void TxProcessor_Init()
 
     // coefficient calculation for TX bass & treble adjustment
     // the TX treble filter is in IIR_TX_biquad and works at 48000ksps
-    AudioDriver_CalcHighShelf(coeffs, 1700, 0.9, ts.tx_treble_gain, AUDIO_SAMPLE_RATE);
+    AudioDriver_CalcHighShelf(coeffs, 1700, 0.9, ts.dsp.tx_treble_gain, AUDIO_SAMPLE_RATE);
     AudioDriver_SetBiquadCoeffs(&IIR_TX_biquad.pCoeffs[0],coeffs);
 
     // the TX bass filter is in IIR_TX_biquad and works at 48000 sample rate
-    AudioDriver_CalcLowShelf(coeffs, 300, 0.7, ts.tx_bass_gain, AUDIO_SAMPLE_RATE);
+    AudioDriver_CalcLowShelf(coeffs, 300, 0.7, ts.dsp.tx_bass_gain, AUDIO_SAMPLE_RATE);
     AudioDriver_SetBiquadCoeffs(&IIR_TX_biquad.pCoeffs[5],coeffs);
 
     ads.tx_filter_adjusting = 0;        // enable TX filtering after adjustment

--- a/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
@@ -1392,33 +1392,33 @@ static void UiSpectrum_RedrawSpectrum()
 
         // just for debugging purposes
         // display the spectral noise reduction bin gain values in the second 64 pixels of the spectrum display
-        if((ts.dsp_active & DSP_NR_ENABLE) && NR.gain_display != 0)
+        if((is_dsp_nr()) && ts.nr_gain_display != 0)
         {
-        	if(NR.gain_display == 1)
+        	if(ts.nr_gain_display == 1)
         	{
-        	for(int bindx = 0; bindx < ts.NR_FFT_L / 2; bindx++)
+        	for(int bindx = 0; bindx < nr_params.NR_FFT_L / 2; bindx++)
         	{
-        		sd.FFT_MagData[(ts.NR_FFT_L / 2 - 1) - bindx] = NR.Hk[bindx] * 150.0;
+        		sd.FFT_MagData[(nr_params.NR_FFT_L / 2 - 1) - bindx] = NR2.Hk[bindx] * 150.0;
         	}
         	}
         	/*        	else
-        	if(NR.gain_display == 2)
+        	if(ts.nr_gain_display == 2)
         	{
-            	for(int bindx = 0; bindx < ts.NR_FFT_L / 2; bindx++)
+            	for(int bindx = 0; bindx < nr_params.NR_FFT_L / 2; bindx++)
             	{
-            		sd.FFT_MagData[(ts.NR_FFT_L / 2 - 1) - bindx] = NR2.long_tone_gain[bindx] * 150.0;
+            		sd.FFT_MagData[(nr_params.NR_FFT_L / 2 - 1) - bindx] = NR2.long_tone_gain[bindx] * 150.0;
             	}
         	}
         	else
-        	if(NR.gain_display == 3)
+        	if(ts.nr_gain_display == 3)
         	{
-            	for(int bindx = 0; bindx < ts.NR_FFT_L / 2; bindx++)
+            	for(int bindx = 0; bindx < nr_params.NR_FFT_L / 2; bindx++)
             	{
-            		sd.FFT_MagData[(ts.NR_FFT_L / 2 - 1) - bindx] = NR.Hk[bindx] * NR2.long_tone_gain[bindx] * 150.0;
+            		sd.FFT_MagData[(nr_params.NR_FFT_L / 2 - 1) - bindx] = NR.Hk[bindx] * NR2.long_tone_gain[bindx] * 150.0;
             	}
         	} */
         	// set all other pixels to a low value
-        	for(int bindx = ts.NR_FFT_L / 2; bindx < sd.spec_len; bindx++)
+        	for(int bindx = nr_params.NR_FFT_L / 2; bindx < sd.spec_len; bindx++)
         	{
         		sd.FFT_MagData[bindx] = 10.0;
         	}

--- a/mchf-eclipse/drivers/ui/menu/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu.c
@@ -39,6 +39,7 @@
 #include "osc_si570.h"
 
 #include "audio_nr.h"
+#include "audio_agc.h"
 
 #define CLR_OR_SET_BITMASK(cond,value,mask) ((value) = (((cond))? ((value) | (mask)): ((value) & ~(mask))))
 
@@ -787,11 +788,11 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
     {
     case MENU_DSP_NR_STRENGTH:  // DSP Noise reduction strength
     	nr_step = DSP_NR_STRENGTH_STEP;
-    	if(ts.dsp_nr_strength >= 190)
+    	if(ts.dsp.nr_strength >= 190)
     	{
     		nr_step = 1;
     	}
-        var_change = UiDriverMenuItemChangeUInt8(var, mode, &ts.dsp_nr_strength,
+        var_change = UiDriverMenuItemChangeUInt8(var, mode, &ts.dsp.nr_strength,
                                               DSP_NR_STRENGTH_MIN,
                                               DSP_NR_STRENGTH_MAX,
                                               DSP_NR_STRENGTH_DEFAULT,
@@ -799,36 +800,36 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
                                              );
         if(var_change)
         {
-        	if(ts.dsp_nr_strength == 189)
+        	if(ts.dsp.nr_strength == 189)
         	{
-        		ts.dsp_nr_strength = 185;
+        		ts.dsp.nr_strength = 185;
         	}
         	// did it change?
-            if(ts.dsp_active & DSP_NR_ENABLE)   // only change if DSP active
+            if(ts.dsp.active & DSP_NR_ENABLE)   // only change if DSP active
             {
 				// this causes considerable noise
 				//AudioDriver_SetRxAudioProcessing(ts.dmod_mode, false);
 				// we do this instead
-			    ts.nr_alpha = 0.799 + ((float32_t)ts.dsp_nr_strength / 1000.0);
+			    nr_params.alpha = 0.799 + ((float32_t)ts.dsp.nr_strength / 1000.0);
             }
         }
 #ifdef OBSOLETE_NR
-        if(!(ts.dsp_active & DSP_NR_ENABLE))    // make red if DSP not active
+        if(!(ts.dsp.active & DSP_NR_ENABLE))    // make red if DSP not active
         {
             clr = Orange;
         }
         else
         {
-            if(ts.dsp_nr_strength >= DSP_STRENGTH_RED)
+            if(ts.dsp.nr_strength >= DSP_STRENGTH_RED)
                 clr = Red;
-            else if(ts.dsp_nr_strength >= DSP_STRENGTH_ORANGE)
+            else if(ts.dsp.nr_strength >= DSP_STRENGTH_ORANGE)
                 clr = Orange;
-            else if(ts.dsp_nr_strength >= DSP_STRENGTH_YELLOW)
+            else if(ts.dsp.nr_strength >= DSP_STRENGTH_YELLOW)
                 clr = Yellow;
         }
 #endif
         //
-        snprintf(options,32, "  %u", ts.dsp_nr_strength);
+        snprintf(options,32, "  %u", ts.dsp.nr_strength);
         break;
     case MENU_AM_DISABLE: // AM mode enable/disable
         UiMenu_HandleDemodModeDisable(var, mode, options, &clr, DEMOD_AM_DISABLE);
@@ -1083,13 +1084,13 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
         break;
 #endif
     case MENU_AGC_WDSP_MODE: // AGC mode
-        var_change = UiDriverMenuItemChangeUInt8(var, mode, &ts.agc_wdsp_conf.mode,
+        var_change = UiDriverMenuItemChangeUInt8(var, mode, &agc_wdsp_conf.mode,
                                               0, //
                                               5,
                                               2,
                                               1
                                              );
-        switch(ts.agc_wdsp_conf.mode) {
+        switch(agc_wdsp_conf.mode) {
         case 0:
             txt_ptr = "very LONG";
             break;
@@ -1114,7 +1115,7 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
         if(var_change)
         {
             // now set the AGC parameters
-            ts.agc_wdsp_conf.switch_mode = 1; // set flag to 1 for parameter change
+            agc_wdsp_conf.switch_mode = 1; // set flag to 1 for parameter change
             AudioDriver_SetupAgcWdsp();
             UiMenu_RenderMenu(MENU_RENDER_ONLY);
         }
@@ -1125,7 +1126,7 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
         break;
 
     case MENU_AGC_WDSP_SLOPE:      //
-        var_change = UiDriverMenuItemChangeUInt8(var, mode, &ts.agc_wdsp_conf.slope,
+        var_change = UiDriverMenuItemChangeUInt8(var, mode, &agc_wdsp_conf.slope,
                                             0,
                                             200,
                                             40,
@@ -1135,11 +1136,11 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
         {
             AudioDriver_SetupAgcWdsp();
         }
-        snprintf(options, 32, "  %ddB", ts.agc_wdsp_conf.slope / 10);
+        snprintf(options, 32, "  %ddB", agc_wdsp_conf.slope / 10);
         break;
 
     case MENU_AGC_WDSP_THRESH:      //
-        var_change = UiDriverMenuItemChangeInt(var, mode, &ts.agc_wdsp_conf.thresh,
+        var_change = UiDriverMenuItemChangeInt(var, mode, &agc_wdsp_conf.thresh,
                                             -20,
                                             120,
                                             40,
@@ -1149,11 +1150,11 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
         {
             AudioDriver_SetupAgcWdsp();
         }
-        snprintf(options, 32, "  %ddB", ts.agc_wdsp_conf.thresh);
+        snprintf(options, 32, "  %ddB", agc_wdsp_conf.thresh);
         break;
 
     case MENU_AGC_WDSP_HANG_THRESH:      //
-        var_change = UiDriverMenuItemChangeInt(var, mode, &ts.agc_wdsp_conf.hang_thresh,
+        var_change = UiDriverMenuItemChangeInt(var, mode, &agc_wdsp_conf.hang_thresh,
                                             -20,
                                             120,
                                             40,
@@ -1163,11 +1164,11 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
         {
             AudioDriver_SetupAgcWdsp();
         }
-        snprintf(options, 32, "  %ddB", ts.agc_wdsp_conf.hang_thresh);
+        snprintf(options, 32, "  %ddB", agc_wdsp_conf.hang_thresh);
         break;
 
     case MENU_AGC_WDSP_TAU_DECAY:      //
-       var_change = UiDriverMenuItemChangeInt(var, mode, &ts.agc_wdsp_conf.tau_decay[ts.agc_wdsp_conf.mode],
+       var_change = UiDriverMenuItemChangeInt(var, mode, &agc_wdsp_conf.tau_decay[agc_wdsp_conf.mode],
                                            100,
                                            5000,
                                            1000,
@@ -1177,11 +1178,11 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
        {
            AudioDriver_SetupAgcWdsp();
        }
-       snprintf(options, 32, "  %ums", ts.agc_wdsp_conf.tau_decay[ts.agc_wdsp_conf.mode]);
+       snprintf(options, 32, "  %ums", agc_wdsp_conf.tau_decay[agc_wdsp_conf.mode]);
        break;
 
     case MENU_AGC_WDSP_TAU_HANG_DECAY:      //
-       var_change = UiDriverMenuItemChangeInt(var, mode, &ts.agc_wdsp_conf.tau_hang_decay,
+       var_change = UiDriverMenuItemChangeInt(var, mode, &agc_wdsp_conf.tau_hang_decay,
                                            100,
                                            5000,
                                            1000,
@@ -1191,7 +1192,7 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
        {
            AudioDriver_SetupAgcWdsp();
        }
-       snprintf(options, 32, "  %ums", ts.agc_wdsp_conf.tau_hang_decay);
+       snprintf(options, 32, "  %ums", agc_wdsp_conf.tau_hang_decay);
        break;
 
      case MENU_DBM_CALIBRATE:      //
@@ -1213,7 +1214,7 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
          break;
 
     case MENU_AGC_WDSP_HANG_TIME:      //
-        var_change = UiDriverMenuItemChangeInt(var, mode, &ts.agc_wdsp_conf.hang_time,
+        var_change = UiDriverMenuItemChangeInt(var, mode, &agc_wdsp_conf.hang_time,
                                             10,
                                             5000,
                                             250,
@@ -1223,17 +1224,17 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
         {
             AudioDriver_SetupAgcWdsp();
         }
-        snprintf(options, 32, "  %dms", ts.agc_wdsp_conf.hang_time);
+        snprintf(options, 32, "  %dms", agc_wdsp_conf.hang_time);
         break;
 #if 0
         case MENU_AGC_WDSP_SWITCH:     // Enable/Disable wdsp AGC
-            var_change = UiDriverMenuItemChangeUInt8(var, mode, &ts.agc_wdsp_conf,
+            var_change = UiDriverMenuItemChangeUInt8(var, mode, &agc_wdsp_conf,
                                                   0,
                                                   1,
                                                   0,
                                                   1
                                                  );
-            switch(ts.agc_wdsp_conf)
+            switch(agc_wdsp_conf)
             {
             case 1:       //
                 txt_ptr = "    WDSP AGC";        //
@@ -1244,13 +1245,13 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
             break;
 #endif
             case MENU_AGC_WDSP_HANG_ENABLE:     //
-            var_change = UiDriverMenuItemChangeUInt8(var, mode, &ts.agc_wdsp_conf.hang_enable,
+            var_change = UiDriverMenuItemChangeUInt8(var, mode, &agc_wdsp_conf.hang_enable,
                                                   0,
                                                   1,
                                                   0,
                                                   1
                                                  );
-            switch(ts.agc_wdsp_conf.hang_enable)
+            switch(agc_wdsp_conf.hang_enable)
             {
             case 1:       //
                 txt_ptr = "  ON";        //
@@ -1437,26 +1438,14 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
         }
         break;
     case MENU_NOISE_BLANKER_SETTING:
-        var_change = UiDriverMenuItemChangeUInt8(var, mode, &ts.nb_setting,
+        var_change = UiDriverMenuItemChangeUInt8(var, mode, &ts.dsp.nb_setting,
                                               0,
                                               MAX_NB_SETTING,
                                               10,
                                               1
                                              );
-
-        if(ts.nb_setting >= NB_WARNING3_SETTING)
-        {
-            clr = Red;      // above this value, make it red
-        }
-        else if(ts.nb_setting >= NB_WARNING2_SETTING)
-        {
-            clr = Orange;       // above this value, make it orange
-        }
-        else if(ts.nb_setting >= NB_WARNING1_SETTING)
-        {
-            clr = Yellow;       // above this value, make it yellow
-        }
-        snprintf(options,32,"   %u", ts.nb_setting);
+        clr = UiDriver_GetNBColor();
+        snprintf(options,32,"   %u", ts.dsp.nb_setting);
 
         break;
     case MENU_RX_FREQ_CONV:     // Enable/Disable receive frequency conversion
@@ -3111,69 +3100,69 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
         break;
 #ifdef OBSOLETE_NR
     case CONFIG_DSP_NR_DECORRELATOR_BUFFER_LENGTH:      // Adjustment of DSP noise reduction de-correlation delay buffer length
-        ts.dsp_nr_delaybuf_len &= 0xfff0;   // mask bottom nybble to enforce 16-count boundary
-        var_change = UiDriverMenuItemChangeUInt32(var, mode, &ts.dsp_nr_delaybuf_len,
+        ts.dsp.nr_delaybuf_len &= 0xfff0;   // mask bottom nybble to enforce 16-count boundary
+        var_change = UiDriverMenuItemChangeUInt32(var, mode, &ts.dsp.nr_delaybuf_len,
                                                DSP_NR_BUFLEN_MIN,
                                                DSP_NR_BUFLEN_MAX,
                                                DSP_NR_BUFLEN_DEFAULT,
                                                16);
 
-        if(ts.dsp_nr_delaybuf_len <= ts.dsp_nr_numtaps) // is buffer smaller/equal to number of taps?
-            ts.dsp_nr_delaybuf_len = ts.dsp_nr_numtaps + 16;    // yes - it must always be larger than number of taps!
+        if(ts.dsp.nr_delaybuf_len <= ts.dsp.nr_numtaps) // is buffer smaller/equal to number of taps?
+            ts.dsp.nr_delaybuf_len = ts.dsp.nr_numtaps + 16;    // yes - it must always be larger than number of taps!
 
         if(var_change)      // did something change?
         {
-            if(ts.dsp_active & DSP_NR_ENABLE)   // only update if DSP NR active
+            if(ts.dsp.active & DSP_NR_ENABLE)   // only update if DSP NR active
                 AudioDriver_SetRxAudioProcessing(ts.dmod_mode, false);
         }
-        if(!(ts.dsp_active & DSP_NR_ENABLE))    // mark orange if DSP NR not active
+        if(!(ts.dsp.active & DSP_NR_ENABLE))    // mark orange if DSP NR not active
             clr = Orange;
-        if(ts.dsp_nr_numtaps >= ts.dsp_nr_delaybuf_len) // Warn if number of taps greater than/equal buffer length!
+        if(ts.dsp.nr_numtaps >= ts.dsp.nr_delaybuf_len) // Warn if number of taps greater than/equal buffer length!
             clr = Red;
-        snprintf(options,32, "  %u", (uint)ts.dsp_nr_delaybuf_len);
+        snprintf(options,32, "  %u", (uint)ts.dsp.nr_delaybuf_len);
         break;
     case CONFIG_DSP_NR_FFT_NUMTAPS:     // Adjustment of DSP noise reduction de-correlation delay buffer length
-        ts.dsp_nr_numtaps &= 0xf0;  // mask bottom nybble to enforce 16-count boundary
-        var_change = UiDriverMenuItemChangeUInt8(var, mode, &ts.dsp_nr_numtaps,
+        ts.dsp.nr_numtaps &= 0xf0;  // mask bottom nybble to enforce 16-count boundary
+        var_change = UiDriverMenuItemChangeUInt8(var, mode, &ts.dsp.nr_numtaps,
                                               DSP_NR_NUMTAPS_MIN,
                                               DSP_NR_NUMTAPS_MAX,
                                               DSP_NR_NUMTAPS_DEFAULT,
                                               16);
-        if(ts.dsp_nr_numtaps >= ts.dsp_nr_delaybuf_len) // is number of taps equal or greater than buffer length?
+        if(ts.dsp.nr_numtaps >= ts.dsp.nr_delaybuf_len) // is number of taps equal or greater than buffer length?
         {
-            ts.dsp_nr_delaybuf_len = ts.dsp_nr_numtaps + 16;    // yes - make buffer larger
+            ts.dsp.nr_delaybuf_len = ts.dsp.nr_numtaps + 16;    // yes - make buffer larger
         }
 
         if(var_change)      // did something change?
         {
-            if(ts.dsp_active & DSP_NR_ENABLE)   // only update if DSP NR active
+            if(ts.dsp.active & DSP_NR_ENABLE)   // only update if DSP NR active
                 AudioDriver_SetRxAudioProcessing(ts.dmod_mode, false);
         }
 
-        if(!(ts.dsp_active & DSP_NR_ENABLE))    // mark orange if DSP NR not active
+        if(!(ts.dsp.active & DSP_NR_ENABLE))    // mark orange if DSP NR not active
         {
             clr = Orange;
         }
-        if(ts.dsp_nr_numtaps >= ts.dsp_nr_delaybuf_len) // Warn if number of taps greater than/equal buffer length!
+        if(ts.dsp.nr_numtaps >= ts.dsp.nr_delaybuf_len) // Warn if number of taps greater than/equal buffer length!
         {
             clr = Red;
         }
-        snprintf(options,32, "  %u", ts.dsp_nr_numtaps);
+        snprintf(options,32, "  %u", ts.dsp.nr_numtaps);
         break;
     case CONFIG_DSP_NR_POST_AGC_SELECT:     // selection of location of DSP noise reduction - pre audio filter/AGC or post AGC/filter
-        temp_var_u8 = ts.dsp_active & DSP_NR_POSTAGC_ENABLE;
+        temp_var_u8 = ts.dsp.active & DSP_NR_POSTAGC_ENABLE;
         var_change = UiDriverMenuItemChangeEnableOnOff(var, mode, &temp_var_u8,0,options,&clr);
         if(var_change)      // did something change?
         {
-            CLR_OR_SET_BITMASK(temp_var_u8, ts.dsp_active, DSP_NR_POSTAGC_ENABLE);
+            CLR_OR_SET_BITMASK(temp_var_u8, ts.dsp.active, DSP_NR_POSTAGC_ENABLE);
 
-            if(ts.dsp_active & DSP_NR_ENABLE)   // only update if DSP NR active
+            if(ts.dsp.active & DSP_NR_ENABLE)   // only update if DSP NR active
             {
                 AudioDriver_SetRxAudioProcessing(ts.dmod_mode, false);
             }
         }
 
-        if(!(ts.dsp_active & DSP_NR_ENABLE))    // mark orange if DSP NR not active
+        if(!(ts.dsp.active & DSP_NR_ENABLE))    // mark orange if DSP NR not active
         {
             clr = Orange;
         }
@@ -3181,7 +3170,7 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
         break;
 
     case CONFIG_DSP_NOTCH_CONVERGE_RATE:        // Adjustment of DSP noise reduction de-correlation delay buffer length
-        var_change = UiDriverMenuItemChangeUInt8(var, mode, &ts.dsp_notch_mu,
+        var_change = UiDriverMenuItemChangeUInt8(var, mode, &ts.dsp.notch_mu,
                                               0,
                                               DSP_NOTCH_MU_MAX,
                                               DSP_NOTCH_MU_DEFAULT,
@@ -3189,71 +3178,71 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
 
         if(var_change)      // did something change?
         {
-            if(ts.dsp_active & DSP_NOTCH_ENABLE)    // only update if Notch DSP is active
+            if(ts.dsp.active & DSP_NOTCH_ENABLE)    // only update if Notch DSP is active
             {
                 AudioDriver_SetRxAudioProcessing(ts.dmod_mode, false);
             }
         }
-        if(!(ts.dsp_active & DSP_NOTCH_ENABLE)) // mark orange if Notch DSP not active
+        if(!(ts.dsp.active & DSP_NOTCH_ENABLE)) // mark orange if Notch DSP not active
         {
             clr = Orange;
         }
-        snprintf(options,32, "  %u", ts.dsp_notch_mu);
+        snprintf(options,32, "  %u", ts.dsp.notch_mu);
         break;
     case CONFIG_DSP_NOTCH_DECORRELATOR_BUFFER_LENGTH:       // Adjustment of DSP noise reduction de-correlation delay buffer length
-        var_change = UiDriverMenuItemChangeUInt8(var, mode, &ts.dsp_notch_delaybuf_len,
+        var_change = UiDriverMenuItemChangeUInt8(var, mode, &ts.dsp.notch_delaybuf_len,
                                               DSP_NOTCH_BUFLEN_MIN,
                                               DSP_NOTCH_BUFLEN_MAX,
                                               DSP_NOTCH_DELAYBUF_DEFAULT,
                                               8);
 
 
-        if(ts.dsp_notch_delaybuf_len <= ts.dsp_notch_numtaps)       // did we try to decrease it smaller than FFT size?
+        if(ts.dsp.notch_delaybuf_len <= ts.dsp.notch_numtaps)       // did we try to decrease it smaller than FFT size?
         {
-            ts.dsp_notch_delaybuf_len = ts.dsp_notch_numtaps + 8;                       // yes - limit it to previous size
+            ts.dsp.notch_delaybuf_len = ts.dsp.notch_numtaps + 8;                       // yes - limit it to previous size
         }
         if(var_change)      // did something change?
         {
-            if(ts.dsp_active & DSP_NOTCH_ENABLE)    // only update if DSP Notch active
+            if(ts.dsp.active & DSP_NOTCH_ENABLE)    // only update if DSP Notch active
             {
                 AudioDriver_SetRxAudioProcessing(ts.dmod_mode, false);
             }
         }
-        if(!(ts.dsp_active & DSP_NOTCH_ENABLE)) // mark orange if DSP Notch not active
+        if(!(ts.dsp.active & DSP_NOTCH_ENABLE)) // mark orange if DSP Notch not active
         {
             clr = Orange;
         }
-        if(ts.dsp_notch_numtaps >= ts.dsp_notch_delaybuf_len)
+        if(ts.dsp.notch_numtaps >= ts.dsp.notch_delaybuf_len)
         {
             clr = Red;
         }
-        snprintf(options,32, "  %u", (uint)ts.dsp_notch_delaybuf_len);
+        snprintf(options,32, "  %u", (uint)ts.dsp.notch_delaybuf_len);
         break;
     case CONFIG_DSP_NOTCH_FFT_NUMTAPS:      // Adjustment of DSP noise reduction de-correlation delay buffer length
-        ts.dsp_notch_numtaps &= 0xf0;   // mask bottom nybble to enforce 16-count boundary
-        var_change = UiDriverMenuItemChangeUInt8(var, mode, &ts.dsp_notch_numtaps,
+        ts.dsp.notch_numtaps &= 0xf0;   // mask bottom nybble to enforce 16-count boundary
+        var_change = UiDriverMenuItemChangeUInt8(var, mode, &ts.dsp.notch_numtaps,
                                               0,
                                               DSP_NOTCH_NUMTAPS_MAX,
                                               DSP_NOTCH_NUMTAPS_DEFAULT,
                                               16);
-        if(ts.dsp_notch_numtaps >= ts.dsp_notch_delaybuf_len)   // force buffer size to always be larger than number of taps
-            ts.dsp_notch_delaybuf_len = ts.dsp_notch_numtaps + 8;
+        if(ts.dsp.notch_numtaps >= ts.dsp.notch_delaybuf_len)   // force buffer size to always be larger than number of taps
+            ts.dsp.notch_delaybuf_len = ts.dsp.notch_numtaps + 8;
         if(var_change)      // did something change?
         {
-            if(ts.dsp_active & DSP_NOTCH_ENABLE)    // only update if DSP NR active
+            if(ts.dsp.active & DSP_NOTCH_ENABLE)    // only update if DSP NR active
             {
                 AudioDriver_SetRxAudioProcessing(ts.dmod_mode, false);
             }
         }
-        if(!(ts.dsp_active & DSP_NOTCH_ENABLE)) // mark orange if DSP NR not active
+        if(!(ts.dsp.active & DSP_NOTCH_ENABLE)) // mark orange if DSP NR not active
         {
             clr = Orange;
         }
-        if(ts.dsp_notch_numtaps >= ts.dsp_notch_delaybuf_len)   // Warn if number of taps greater than/equal buffer length!
+        if(ts.dsp.notch_numtaps >= ts.dsp.notch_delaybuf_len)   // Warn if number of taps greater than/equal buffer length!
         {
             clr = Red;
         }
-        snprintf(options,32, "  %u", ts.dsp_notch_numtaps);
+        snprintf(options,32, "  %u", ts.dsp.notch_numtaps);
         break;
 /*
     case CONFIG_AGC_TIME_CONSTANT:      // Adjustment of Noise Blanker AGC Time Constant
@@ -3274,7 +3263,7 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
 
 #ifdef USE_LMS_AUTONOTCH
     case CONFIG_DSP_NOTCH_CONVERGE_RATE:        // Adjustment of DSP autonotch convergence rate
-        var_change = UiDriverMenuItemChangeUInt8(var, mode, &ts.dsp_notch_mu,
+        var_change = UiDriverMenuItemChangeUInt8(var, mode, &ts.dsp.notch_mu,
                                               0,
                                               DSP_NOTCH_MU_MAX,
                                               DSP_NOTCH_MU_DEFAULT,
@@ -3282,71 +3271,71 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
 
         if(var_change)      // did something change?
         {
-            if(ts.dsp_active & DSP_NOTCH_ENABLE)    // only update if Notch DSP is active
+            if(ts.dsp.active & DSP_NOTCH_ENABLE)    // only update if Notch DSP is active
             {
                 AudioDriver_SetRxAudioProcessing(ts.dmod_mode, false);
             }
         }
-        if(!(ts.dsp_active & DSP_NOTCH_ENABLE)) // mark orange if Notch DSP not active
+        if(!(ts.dsp.active & DSP_NOTCH_ENABLE)) // mark orange if Notch DSP not active
         {
             clr = Orange;
         }
-        snprintf(options,32, "  %u", ts.dsp_notch_mu);
+        snprintf(options,32, "  %u", ts.dsp.notch_mu);
         break;
     case CONFIG_DSP_NOTCH_DECORRELATOR_BUFFER_LENGTH:       // Adjustment of DSP noise reduction de-correlation delay buffer length
-        var_change = UiDriverMenuItemChangeUInt8(var, mode, &ts.dsp_notch_delaybuf_len,
+        var_change = UiDriverMenuItemChangeUInt8(var, mode, &ts.dsp.notch_delaybuf_len,
                                               DSP_NOTCH_BUFLEN_MIN,
                                               DSP_NOTCH_BUFLEN_MAX,
                                               DSP_NOTCH_DELAYBUF_DEFAULT,
                                               8);
 
 
-        if(ts.dsp_notch_delaybuf_len <= ts.dsp_notch_numtaps)       // did we try to decrease it smaller than FFT size?
+        if(ts.dsp.notch_delaybuf_len <= ts.dsp.notch_numtaps)       // did we try to decrease it smaller than FFT size?
         {
-            ts.dsp_notch_delaybuf_len = ts.dsp_notch_numtaps + 8;                       // yes - limit it to previous size
+            ts.dsp.notch_delaybuf_len = ts.dsp.notch_numtaps + 8;                       // yes - limit it to previous size
         }
         if(var_change)      // did something change?
         {
-            if(ts.dsp_active & DSP_NOTCH_ENABLE)    // only update if DSP Notch active
+            if(ts.dsp.active & DSP_NOTCH_ENABLE)    // only update if DSP Notch active
             {
                 AudioDriver_SetRxAudioProcessing(ts.dmod_mode, false);
             }
         }
-        if(!(ts.dsp_active & DSP_NOTCH_ENABLE)) // mark orange if DSP Notch not active
+        if(!(ts.dsp.active & DSP_NOTCH_ENABLE)) // mark orange if DSP Notch not active
         {
             clr = Orange;
         }
-        if(ts.dsp_notch_numtaps >= ts.dsp_notch_delaybuf_len)
+        if(ts.dsp.notch_numtaps >= ts.dsp.notch_delaybuf_len)
         {
             clr = Red;
         }
-        snprintf(options,32, "  %u", (uint)ts.dsp_notch_delaybuf_len);
+        snprintf(options,32, "  %u", (uint)ts.dsp.notch_delaybuf_len);
         break;
     case CONFIG_DSP_NOTCH_FFT_NUMTAPS:      // Adjustment of DSP noise reduction de-correlation delay buffer length
-        ts.dsp_notch_numtaps &= 0xf0;   // mask bottom nybble to enforce 16-count boundary
-        var_change = UiDriverMenuItemChangeUInt8(var, mode, &ts.dsp_notch_numtaps,
+        ts.dsp.notch_numtaps &= 0xf0;   // mask bottom nybble to enforce 16-count boundary
+        var_change = UiDriverMenuItemChangeUInt8(var, mode, &ts.dsp.notch_numtaps,
                                               16,
                                               DSP_NOTCH_NUMTAPS_MAX,
                                               DSP_NOTCH_NUMTAPS_DEFAULT,
                                               16);
-//        if(ts.dsp_notch_numtaps >= ts.dsp_notch_delaybuf_len)   // force buffer size to always be larger than number of taps
-//            ts.dsp_notch_delaybuf_len = ts.dsp_notch_numtaps + 8;
+//        if(ts.dsp.notch_numtaps >= ts.dsp.notch_delaybuf_len)   // force buffer size to always be larger than number of taps
+//            ts.dsp.notch_delaybuf_len = ts.dsp.notch_numtaps + 8;
         if(var_change)      // did something change?
         {
-            if(ts.dsp_active & DSP_NOTCH_ENABLE)    // only update if DSP NR active
+            if(ts.dsp.active & DSP_NOTCH_ENABLE)    // only update if DSP NR active
             {
                 AudioDriver_SetRxAudioProcessing(ts.dmod_mode, false);
             }
         }
-        if(!(ts.dsp_active & DSP_NOTCH_ENABLE)) // mark orange if DSP NR not active
+        if(!(ts.dsp.active & DSP_NOTCH_ENABLE)) // mark orange if DSP NR not active
         {
             clr = Orange;
         }
-        if(ts.dsp_notch_numtaps >= ts.dsp_notch_delaybuf_len)   // Warn if number of taps greater than/equal buffer length!
+        if(ts.dsp.notch_numtaps >= ts.dsp.notch_delaybuf_len)   // Warn if number of taps greater than/equal buffer length!
         {
             clr = Red;
         }
-        snprintf(options,32, "  %u", ts.dsp_notch_numtaps);
+        snprintf(options,32, "  %u", ts.dsp.notch_numtaps);
         break;
 #endif
 
@@ -3858,9 +3847,9 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
         break;
 #endif
 
-// this is now adjusted by ts.dsp_nr_strength
+// this is now adjusted by ts.dsp.nr_strength
 /*        case MENU_DEBUG_NR_ALPHA:      //
-            var_change = UiDriverMenuItemChangeInt16(var, mode, &ts.nr_alpha_int,
+            var_change = UiDriverMenuItemChangeInt16(var, mode, &nr_params.alpha_int,
                     700,
                     999,
                     920,
@@ -3868,20 +3857,20 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
             );
             if(var_change)
             {
-            	ts.nr_alpha = (float32_t)ts.nr_alpha_int / 1000.0;
+            	nr_params.alpha = (float32_t)nr_params.alpha_int / 1000.0;
             }
-            snprintf(options, 32, " %3u",(unsigned int)ts.nr_alpha_int);
+            snprintf(options, 32, " %3u",(unsigned int)nr_params.alpha_int);
 
         break;
 */
         case MENU_DEBUG_NR_GAIN_SHOW:      //
-            var_change = UiDriverMenuItemChangeInt16(var, mode, &NR.gain_display,
+            var_change = UiDriverMenuItemChangeInt16(var, mode, &ts.nr_gain_display,
                     0,
                     1,
                     0,
                     1
             );
-            switch(NR.gain_display)
+            switch(ts.nr_gain_display)
             {
             case 0:
                 txt_ptr = "        OFF";
@@ -3900,7 +3889,7 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
         break;
 
         /*case MENU_DEBUG_NR_GAIN_SMOOTH_ALPHA:      //
-            var_change = UiDriverMenuItemChangeInt16(var, mode, &ts.nr_gain_smooth_alpha_int,
+            var_change = UiDriverMenuItemChangeInt16(var, mode, &nr_params.gain_smooth_alpha_int,
                     100,
                     990,
                     250,
@@ -3908,14 +3897,14 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
             );
             if(var_change)
             {
-            	ts.nr_gain_smooth_alpha = (float32_t)ts.nr_gain_smooth_alpha_int / 1000.0;
+            	nr_params.gain_smooth_alpha = (float32_t)nr_params.gain_smooth_alpha_int / 1000.0;
             }
-            snprintf(options, 32, " %3u",(unsigned int)ts.nr_gain_smooth_alpha_int);
+            snprintf(options, 32, " %3u",(unsigned int)nr_params.gain_smooth_alpha_int);
 
         break;
 
         case MENU_DEBUG_NR_LONG_TONE_ALPHA:      //
-            var_change = UiDriverMenuItemChangeUInt32(var, mode, &ts.nr_long_tone_alpha_int,
+            var_change = UiDriverMenuItemChangeUInt32(var, mode, &nr_params.long_tone_alpha_int,
                     90000,
                     99999,
                     99900,
@@ -3923,13 +3912,13 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
             );
             if(var_change)
             {
-            	ts.nr_long_tone_alpha = (float32_t)ts.nr_long_tone_alpha_int / 100000.0;
+            	nr_params.long_tone_alpha = (float32_t)nr_params.long_tone_alpha_int / 100000.0;
             }
-            snprintf(options, 32, " %5u",(unsigned int)ts.nr_long_tone_alpha_int);
+            snprintf(options, 32, " %5u",(unsigned int)nr_params.long_tone_alpha_int);
 
         break;
         case MENU_DEBUG_NR_LONG_TONE_THRESH:      //
-            var_change = UiDriverMenuItemChangeInt16(var, mode, &ts.nr_long_tone_thresh,
+            var_change = UiDriverMenuItemChangeInt16(var, mode, &nr_params.long_tone_thresh,
                     10,
                     16000,
                     600,
@@ -3937,14 +3926,14 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
             );
             if(var_change)
             {
-            //	ts.nr_vad_thresh = (float32_t)ts.nr_vad_thresh_int / 1000.0;
+            //	nr_params.vad_thresh = (float32_t)nr_params.vad_thresh_int / 1000.0;
             }
-            snprintf(options, 32, " %5u",(unsigned int)ts.nr_long_tone_thresh);
+            snprintf(options, 32, " %5u",(unsigned int)nr_params.long_tone_thresh);
 
         break;
 
         case MENU_DEBUG_NR_THRESH:      //
-            var_change = UiDriverMenuItemChangeUInt32(var, mode, &ts.nr_vad_thresh_int,
+            var_change = UiDriverMenuItemChangeUInt32(var, mode, &nr_params.vad_thresh_int,
                     100,
                     20000,
                     1000,
@@ -3952,14 +3941,17 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
             );
             if(var_change)
             {
-            	ts.nr_vad_thresh = (float32_t)ts.nr_vad_thresh_int / 1000.0;
+            	nr_params.vad_thresh = (float32_t)nr_params.vad_thresh_int / 1000.0;
             }
-            snprintf(options, 32, " %5u",(unsigned int)ts.nr_vad_thresh_int);
+            snprintf(options, 32, " %5u",(unsigned int)nr_params.vad_thresh_int);
 
         break;*/
 
         case MENU_DEBUG_NR_BETA:      //
-            var_change = UiDriverMenuItemChangeInt16(var, mode, &ts.nr_beta_int,
+        {
+
+            int16_t beta_int = nr_params.beta * 1000;
+            var_change = UiDriverMenuItemChangeInt16(var, mode, &beta_int,
                     700,
                     999,
                     960,
@@ -3967,20 +3959,20 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
             );
             if(var_change)
             {
-            	ts.nr_beta = (float32_t)ts.nr_beta_int / 1000.0;
+            	nr_params.beta = (float32_t)beta_int / 1000.0;
             }
-            snprintf(options, 32, " %3u",(unsigned int)ts.nr_beta_int);
-
+            snprintf(options, 32, " %3u",(unsigned int)beta_int);
+        }
         break;
 
         /*case MENU_DEBUG_NR_Mode:      //
-            var_change = UiDriverMenuItemChangeInt16(var, mode, &ts.nr_mode,
+            var_change = UiDriverMenuItemChangeInt16(var, mode, &nr_params.mode,
                     0,
                     2,
                     0,
                     1
             );
-            switch(ts.nr_mode)
+            switch(nr_params.mode)
             {
 				case 0:
 					txt_ptr = "    Release";
@@ -3996,21 +3988,21 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
 
             if(var_change)
 			{
-				switch(ts.nr_mode)
+				switch(nr_params.mode)
 				{
 				case 0:
-					ts.nr_beta = 0.850;
-					ts.nr_beta_int=850;
-					ts.nr_first_time = 1; //Restart the noisereduction
+					nr_params.beta = 0.850;
+					nr_params.beta_int=850;
+					nr_params.first_time = 1; //Restart the noisereduction
 					break;
 				case 1:
-					ts.nr_beta = 0.960;
-					ts.nr_beta_int=960;
-					ts.nr_first_time = 1; //Restart the noisereduction
+					nr_params.beta = 0.960;
+					nr_params.beta_int=960;
+					nr_params.first_time = 1; //Restart the noisereduction
 				case 2:
-					ts.nr_beta = 0.960;
-					ts.nr_beta_int=960;
-					ts.nr_first_time = 1; //Restart the noisereduction
+					nr_params.beta = 0.960;
+					nr_params.beta_int=960;
+					nr_params.first_time = 1; //Restart the noisereduction
 					break;
 				}
 			}
@@ -4024,7 +4016,7 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
                                                    1);
              if(var_change)      // did something change?
              {
-             	//ts.nr_first_time = 1;
+             	//nr_params.first_time = 1;
              }
              snprintf(options,32, "  %3u", (unsigned int)NR2.asnr);
              break;
@@ -4038,7 +4030,7 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
                                               1);
         if(var_change)      // did something change?
         {
-        	//ts.nr_first_time = 1;
+        	//nr_params.first_time = 1;
         }
         snprintf(options,32, "  %3u", (unsigned int)NR2.width);
         break;
@@ -4051,14 +4043,14 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
                                                       5);
                 if(var_change)      // did something change?
                 {
-                	//ts.nr_first_time = 1;
+                	//nr_params.first_time = 1;
                 }
                 snprintf(options,32, "  %3u", (unsigned int)NR2.power_threshold_int);
                 break;
 
 /*
         case MENU_DEBUG_NR_VAD_DELAY:      //
-            var_change = UiDriverMenuItemChangeInt16(var, mode, &ts.nr_vad_delay,
+            var_change = UiDriverMenuItemChangeInt16(var, mode, &nr_params.vad_delay,
                     0,
                     20,
                     2,
@@ -4068,7 +4060,7 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
             {
 
             }
-            snprintf(options, 32, " %2u",(unsigned int)ts.nr_vad_delay);
+            snprintf(options, 32, " %2u",(unsigned int)nr_params.vad_delay);
 
         break;
 */
@@ -4099,10 +4091,10 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
         //         break;//
 //#if defined(STM32F7) || defined(STM32H7)
 /*     case MENU_DEBUG_NR_FFT_SIZE:
-                 var_change = UiDriverMenuItemChangeEnableOnOffBool(var, mode, &ts.nr_fft_256_enable,0,options,&clr);
+                 var_change = UiDriverMenuItemChangeEnableOnOffBool(var, mode, &nr_params.fft_256_enable,0,options,&clr);
                  ts.NR_FFT_L = 128;
                  ts.NR_FFT_LOOP_NO = 2;
-                 if(ts.nr_fft_256_enable)
+                 if(nr_params.fft_256_enable)
                  {
                 	 ts.NR_FFT_LOOP_NO = 1;
                 	 ts.NR_FFT_L = 256;
@@ -4113,13 +4105,13 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
         break;
 //#endif
 //     case MENU_DEBUG_NR_ENABLE:
-//             var_change = UiDriverMenuItemChangeEnableOnOffBool(var, mode, &ts.nr_enable,0,options,&clr);
+//             var_change = UiDriverMenuItemChangeEnableOnOffBool(var, mode, &nr_params.enable,0,options,&clr);
 //         break;
      case MENU_DEBUG_NR_LONG_TONE_ENABLE:
-             var_change = UiDriverMenuItemChangeEnableOnOffBool(var, mode, &ts.nr_long_tone_enable,0,options,&clr);
+             var_change = UiDriverMenuItemChangeEnableOnOffBool(var, mode, &nr_params.long_tone_enable,0,options,&clr);
              if(var_change)
              {
-            	 ts.nr_long_tone_reset = true;
+            	 nr_params.long_tone_reset = true;
              }
          break;*/
 
@@ -4144,7 +4136,7 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
          break;
 
      case MENU_DEBUG_NR_GAIN_SMOOTH_ENABLE:
-             var_change = UiDriverMenuItemChangeEnableOnOffBool(var, mode, &ts.nr_gain_smooth_enable,0,options,&clr);
+             var_change = UiDriverMenuItemChangeEnableOnOffBool(var, mode, &nr_params.gain_smooth_enable,0,options,&clr);
          break;*/
 
 //     case MENU_DEBUG_RTTY_ATC:

--- a/mchf-eclipse/drivers/ui/radio_management.c
+++ b/mchf-eclipse/drivers/ui/radio_management.c
@@ -51,6 +51,8 @@
 #include "rtty.h"
 #include "uhsdr_digi_buffer.h"
 
+#include "audio_nr.h"
+
 #define SWR_SAMPLES_SKP             1   //5000
 #define SWR_SAMPLES_CNT             5//10
 #define SWR_ADC_FULL_SCALE          4095    // full scale of A/D converter (4095 = 10 bits)
@@ -996,7 +998,7 @@ void RadioManagement_ChangeBandFilter(uchar band)
     default:
         break;
     }
-  ts.nr_first_time = 1; // in case of any Bandfilter change restart the NR routine
+  nr_params.first_time = 1; // in case of any Bandfilter change restart the NR routine
 }
 typedef struct BandFilterDescriptor
 {
@@ -1067,7 +1069,7 @@ bool RadioManagement_IsPowerFactorReduce(uint32_t freq)
  */
 void RadioManagement_SetDemodMode(uint8_t new_mode)
 {
-    ts.dsp_inhibit++;
+    ts.dsp.inhibit++;
     ads.af_disabled++;
 
     if (new_mode == DEMOD_DIGI)
@@ -1134,8 +1136,8 @@ void RadioManagement_SetDemodMode(uint8_t new_mode)
     ts.dmod_mode = new_mode;
 
     if  (ads.af_disabled) { ads.af_disabled--; }
-    if (ts.dsp_inhibit) { ts.dsp_inhibit--; }
-    ts.nr_first_time = 1; // re-initialize spectral noise reduction, when dmod_mode was changed
+    if (ts.dsp.inhibit) { ts.dsp.inhibit--; }
+    nr_params.first_time = 1; // re-initialize spectral noise reduction, when dmod_mode was changed
 
 }
 
@@ -1733,7 +1735,7 @@ void RadioManagement_ToggleVfoAB()
     {
         RadioManagement_SetDemodMode(vfo[vfo_new].band[ts.band].decod_mode);
     }
-    ts.nr_first_time = 1; // restart in case of VFO-Toggle
+    nr_params.first_time = 1; // restart in case of VFO-Toggle
 }
 
 /**

--- a/mchf-eclipse/drivers/ui/ui_configuration.c
+++ b/mchf-eclipse/drivers/ui/ui_configuration.c
@@ -18,6 +18,7 @@
 #include "ui_driver.h"
 
 #include "audio_driver.h"
+#include "audio_agc.h"
 #include "cw_decoder.h"
 
 #include "ui_spectrum.h"
@@ -69,23 +70,23 @@ const ConfigEntryDescriptor ConfigEntryInfo[] =
     { ConfigEntry_UInt8, EEPROM_AUDIO_GAIN,&ts.rx_gain[RX_AUDIO_SPKR].value,AUDIO_GAIN_DEFAULT,0,AUDIO_GAIN_MAX},
     { ConfigEntry_UInt8, EEPROM_RX_CODEC_GAIN,&ts.rf_codec_gain,DEFAULT_RF_CODEC_GAIN_VAL,0,MAX_RF_CODEC_GAIN_VAL},
 //    { ConfigEntry_Int32_16, EEPROM_RX_GAIN,&ts.rf_gain,DEFAULT_RF_GAIN,0,MAX_RF_GAIN},
-    { ConfigEntry_UInt8, EEPROM_NB_SETTING,&ts.nb_setting,0,0,MAX_NB_SETTING},
+    { ConfigEntry_UInt8, EEPROM_NB_SETTING,&ts.dsp.nb_setting,0,0,MAX_NB_SETTING},
     { ConfigEntry_UInt8, EEPROM_TX_POWER_LEVEL,&ts.power_level,PA_LEVEL_DEFAULT,0,PA_LEVEL_TUNE_KEEP_CURRENT},
     { ConfigEntry_UInt8, EEPROM_CW_KEYER_SPEED,&ts.cw_keyer_speed,CW_KEYER_SPEED_DEFAULT,CW_KEYER_SPEED_MIN, CW_KEYER_SPEED_MAX},
     { ConfigEntry_UInt8, EEPROM_CW_KEYER_MODE,&ts.cw_keyer_mode,CW_KEYER_MODE_IAM_B, 0, CW_KEYER_MAX_MODE},
     { ConfigEntry_UInt8, EEPROM_CW_KEYER_WEIGHT,&ts.cw_keyer_weight,CW_KEYER_WEIGHT_DEFAULT, CW_KEYER_WEIGHT_MIN, CW_KEYER_WEIGHT_MAX},
     { ConfigEntry_UInt8, EEPROM_CW_SIDETONE_GAIN,&ts.cw_sidetone_gain,DEFAULT_SIDETONE_GAIN,0, SIDETONE_MAX_GAIN},
     { ConfigEntry_Int32_16 | Calib_Val, EEPROM_FREQ_CAL,&ts.freq_cal,0,MIN_FREQ_CAL,MAX_FREQ_CAL}, // MINOR INT DEFAULT PROBLEM
-    { ConfigEntry_UInt8, EEPROM_AGC_WDSP_MODE,&ts.agc_wdsp_conf.mode, 2,0,5},
-    { ConfigEntry_UInt8, EEPROM_AGC_WDSP_HANG,&ts.agc_wdsp_conf.hang_enable, 0,0,1},
-    { ConfigEntry_Int32_16, EEPROM_AGC_WDSP_THRESH,&ts.agc_wdsp_conf.thresh, 20,-20,120}, // INT DEFAULT PROBLEM,see above
-    { ConfigEntry_UInt8, EEPROM_AGC_WDSP_SLOPE,&ts.agc_wdsp_conf.slope, 70,0,200},
-    { ConfigEntry_Int32_16, EEPROM_AGC_WDSP_TAU_DECAY_0,&ts.agc_wdsp_conf.tau_decay[0], 4000,100,5000}, // NO INT DEFAULT PROBLEM
-    { ConfigEntry_Int32_16, EEPROM_AGC_WDSP_TAU_DECAY_1,&ts.agc_wdsp_conf.tau_decay[1], 2000,100,5000}, // NO INT DEFAULT PROBLEM
-    { ConfigEntry_Int32_16, EEPROM_AGC_WDSP_TAU_DECAY_2,&ts.agc_wdsp_conf.tau_decay[2], 500,100,5000},  // NO INT DEFAULT PROBLEM
-    { ConfigEntry_Int32_16, EEPROM_AGC_WDSP_TAU_DECAY_3,&ts.agc_wdsp_conf.tau_decay[3], 250,100,5000},  // NO INT DEFAULT PROBLEM
-    { ConfigEntry_Int32_16, EEPROM_AGC_WDSP_TAU_DECAY_4,&ts.agc_wdsp_conf.tau_decay[4], 50,100,5000}, // NO INT DEFAULT PROBLEM
-    { ConfigEntry_Int32_16, EEPROM_AGC_WDSP_TAU_HANG_DECAY,&ts.agc_wdsp_conf.tau_hang_decay, 500,100,5000}, // NO INT DEFAULT PROBLEM
+    { ConfigEntry_UInt8, EEPROM_AGC_WDSP_MODE,&agc_wdsp_conf.mode, 2,0,5},
+    { ConfigEntry_UInt8, EEPROM_AGC_WDSP_HANG,&agc_wdsp_conf.hang_enable, 0,0,1},
+    { ConfigEntry_Int32_16, EEPROM_AGC_WDSP_THRESH,&agc_wdsp_conf.thresh, 20,-20,120}, // INT DEFAULT PROBLEM,see above
+    { ConfigEntry_UInt8, EEPROM_AGC_WDSP_SLOPE,&agc_wdsp_conf.slope, 70,0,200},
+    { ConfigEntry_Int32_16, EEPROM_AGC_WDSP_TAU_DECAY_0,&agc_wdsp_conf.tau_decay[0], 4000,100,5000}, // NO INT DEFAULT PROBLEM
+    { ConfigEntry_Int32_16, EEPROM_AGC_WDSP_TAU_DECAY_1,&agc_wdsp_conf.tau_decay[1], 2000,100,5000}, // NO INT DEFAULT PROBLEM
+    { ConfigEntry_Int32_16, EEPROM_AGC_WDSP_TAU_DECAY_2,&agc_wdsp_conf.tau_decay[2], 500,100,5000},  // NO INT DEFAULT PROBLEM
+    { ConfigEntry_Int32_16, EEPROM_AGC_WDSP_TAU_DECAY_3,&agc_wdsp_conf.tau_decay[3], 250,100,5000},  // NO INT DEFAULT PROBLEM
+    { ConfigEntry_Int32_16, EEPROM_AGC_WDSP_TAU_DECAY_4,&agc_wdsp_conf.tau_decay[4], 50,100,5000}, // NO INT DEFAULT PROBLEM
+    { ConfigEntry_Int32_16, EEPROM_AGC_WDSP_TAU_HANG_DECAY,&agc_wdsp_conf.tau_hang_decay, 500,100,5000}, // NO INT DEFAULT PROBLEM
     { ConfigEntry_UInt8, EEPROM_MIC_GAIN,&ts.tx_gain[TX_AUDIO_MIC],MIC_GAIN_DEFAULT,MIC_GAIN_MIN,MIC_GAIN_MAX},
     { ConfigEntry_UInt8, EEPROM_LINE_GAIN,&ts.tx_gain[TX_AUDIO_LINEIN_L],LINE_GAIN_DEFAULT,LINE_GAIN_MIN,LINE_GAIN_MAX},
     { ConfigEntry_UInt32_16, EEPROM_SIDETONE_FREQ,&ts.cw_sidetone_freq,CW_SIDETONE_FREQ_DEFAULT,CW_SIDETONE_FREQ_MIN,CW_SIDETONE_FREQ_MAX},
@@ -138,22 +139,22 @@ const ConfigEntryDescriptor ConfigEntryInfo[] =
     { ConfigEntry_UInt32_16, EEPROM_ALC_DECAY_TIME,&ts.alc_decay,ALC_DECAY_DEFAULT,0,ALC_DECAY_MAX },
     { ConfigEntry_UInt32_16, EEPROM_ALC_POSTFILT_TX_GAIN,&ts.alc_tx_postfilt_gain,ALC_POSTFILT_GAIN_DEFAULT, ALC_POSTFILT_GAIN_MIN, ALC_POSTFILT_GAIN_MAX},
     { ConfigEntry_UInt16, EEPROM_STEP_SIZE_CONFIG,&ts.freq_step_config,0,0,255},
-    { ConfigEntry_UInt8, EEPROM_DSP_MODE,&ts.dsp_active,0,0,255},
-	{ ConfigEntry_UInt8, EEPROM_DSP_NR_STRENGTH,&ts.dsp_nr_strength,DSP_NR_STRENGTH_DEFAULT,0, DSP_NR_STRENGTH_MAX},
+    { ConfigEntry_UInt8, EEPROM_DSP_MODE,&ts.dsp.active,0,0,255},
+	{ ConfigEntry_UInt8, EEPROM_DSP_NR_STRENGTH,&ts.dsp.nr_strength,DSP_NR_STRENGTH_DEFAULT,0, DSP_NR_STRENGTH_MAX},
 
 #ifdef OBSOLETE_NR
-	{ ConfigEntry_UInt32_16, EEPROM_DSP_NR_DECOR_BUFLEN,&ts.dsp_nr_delaybuf_len,DSP_NR_BUFLEN_DEFAULT, DSP_NR_BUFLEN_MIN, DSP_NR_BUFLEN_MAX},
-    { ConfigEntry_UInt8, EEPROM_DSP_NR_FFT_NUMTAPS,&ts.dsp_nr_numtaps,DSP_NR_NUMTAPS_DEFAULT, DSP_NR_NUMTAPS_MIN, DSP_NOTCH_NUMTAPS_MAX},
+	{ ConfigEntry_UInt32_16, EEPROM_DSP_NR_DECOR_BUFLEN,&ts.dsp.nr_delaybuf_len,DSP_NR_BUFLEN_DEFAULT, DSP_NR_BUFLEN_MIN, DSP_NR_BUFLEN_MAX},
+    { ConfigEntry_UInt8, EEPROM_DSP_NR_FFT_NUMTAPS,&ts.dsp.nr_numtaps,DSP_NR_NUMTAPS_DEFAULT, DSP_NR_NUMTAPS_MIN, DSP_NOTCH_NUMTAPS_MAX},
 
-	{ ConfigEntry_UInt8, EEPROM_DSP_NOTCH_DECOR_BUFLEN,&ts.dsp_notch_delaybuf_len,DSP_NOTCH_DELAYBUF_DEFAULT,DSP_NOTCH_BUFLEN_MIN,DSP_NOTCH_BUFLEN_MAX},
-    { ConfigEntry_UInt8, EEPROM_DSP_NOTCH_FFT_NUMTAPS,&ts.dsp_notch_numtaps,DSP_NOTCH_NUMTAPS_DEFAULT, DSP_NOTCH_NUMTAPS_MIN,DSP_NOTCH_NUMTAPS_MAX},
-    { ConfigEntry_UInt8, EEPROM_DSP_NOTCH_CONV_RATE,&ts.dsp_notch_mu,DSP_NOTCH_MU_DEFAULT,0,DSP_NOTCH_MU_MAX},
+	{ ConfigEntry_UInt8, EEPROM_DSP_NOTCH_DECOR_BUFLEN,&ts.dsp.notch_delaybuf_len,DSP_NOTCH_DELAYBUF_DEFAULT,DSP_NOTCH_BUFLEN_MIN,DSP_NOTCH_BUFLEN_MAX},
+    { ConfigEntry_UInt8, EEPROM_DSP_NOTCH_FFT_NUMTAPS,&ts.dsp.notch_numtaps,DSP_NOTCH_NUMTAPS_DEFAULT, DSP_NOTCH_NUMTAPS_MIN,DSP_NOTCH_NUMTAPS_MAX},
+    { ConfigEntry_UInt8, EEPROM_DSP_NOTCH_CONV_RATE,&ts.dsp.notch_mu,DSP_NOTCH_MU_DEFAULT,0,DSP_NOTCH_MU_MAX},
 #endif
 
 #ifdef USE_LMS_AUTONOTCH
-	{ ConfigEntry_UInt8, EEPROM_DSP_NOTCH_DECOR_BUFLEN,&ts.dsp_notch_delaybuf_len,DSP_NOTCH_DELAYBUF_DEFAULT,DSP_NOTCH_BUFLEN_MIN,DSP_NOTCH_BUFLEN_MAX},
-    { ConfigEntry_UInt8, EEPROM_DSP_NOTCH_FFT_NUMTAPS,&ts.dsp_notch_numtaps,DSP_NOTCH_NUMTAPS_DEFAULT, DSP_NOTCH_NUMTAPS_MIN,DSP_NOTCH_NUMTAPS_MAX},
-    { ConfigEntry_UInt8, EEPROM_DSP_NOTCH_CONV_RATE,&ts.dsp_notch_mu,DSP_NOTCH_MU_DEFAULT,0,DSP_NOTCH_MU_MAX},
+	{ ConfigEntry_UInt8, EEPROM_DSP_NOTCH_DECOR_BUFLEN,&ts.dsp.notch_delaybuf_len,DSP_NOTCH_DELAYBUF_DEFAULT,DSP_NOTCH_BUFLEN_MIN,DSP_NOTCH_BUFLEN_MAX},
+    { ConfigEntry_UInt8, EEPROM_DSP_NOTCH_FFT_NUMTAPS,&ts.dsp.notch_numtaps,DSP_NOTCH_NUMTAPS_DEFAULT, DSP_NOTCH_NUMTAPS_MIN,DSP_NOTCH_NUMTAPS_MAX},
+    { ConfigEntry_UInt8, EEPROM_DSP_NOTCH_CONV_RATE,&ts.dsp.notch_mu,DSP_NOTCH_MU_DEFAULT,0,DSP_NOTCH_MU_MAX},
 #endif
 	//   { ConfigEntry_UInt8, EEPROM_MAX_RX_GAIN,&ts.max_rf_gain,MAX_RF_GAIN_DEFAULT,0,MAX_RF_GAIN_MAX},
     { ConfigEntry_Int16, EEPROM_TX_AUDIO_COMPRESS,&ts.tx_comp_level,TX_AUDIO_COMPRESSION_DEFAULT,TX_AUDIO_COMPRESSION_MIN,TX_AUDIO_COMPRESSION_MAX}, // NO INT DEFAULT PROBLEM
@@ -198,17 +199,17 @@ const ConfigEntryDescriptor ConfigEntryInfo[] =
     { ConfigEntry_UInt8, EEPROM_BEEP_LOUDNESS,&ts.beep_loudness,DEFAULT_BEEP_LOUDNESS,0,MAX_BEEP_LOUDNESS},
     { ConfigEntry_UInt8, EEPROM_TUNE_POWER_LEVEL,&ts.tune_power_level,PA_LEVEL_TUNE_KEEP_CURRENT,PA_LEVEL_FULL,PA_LEVEL_TUNE_KEEP_CURRENT},
     { ConfigEntry_UInt8, EEPROM_CAT_XLAT,&ts.xlat,1,0,1},
-    { ConfigEntry_UInt32_16, EEPROM_MANUAL_NOTCH,&ts.notch_frequency,800,200,5000},
-    { ConfigEntry_UInt32_16, EEPROM_MANUAL_PEAK,&ts.peak_frequency,750,200,5000},
+    { ConfigEntry_UInt32_16, EEPROM_MANUAL_NOTCH,&ts.dsp.notch_frequency,800,200,5000},
+    { ConfigEntry_UInt32_16, EEPROM_MANUAL_PEAK,&ts.dsp.peak_frequency,750,200,5000},
     { ConfigEntry_UInt8, EEPROM_DISPLAY_DBM,&ts.display_dbm,0,0,2},
     { ConfigEntry_Int32_16 | Calib_Val, EEPROM_DBM_CALIBRATE,&ts.dbm_constant,0,-100,100}, // MINOR INT DEFAULT PROBLEM,see above
 //    { ConfigEntry_UInt8, EEPROM_S_METER,&ts.s_meter,0,0,2},
     { ConfigEntry_UInt8, EEPROM_DIGI_MODE_CONF,&ts.digital_mode,DigitalMode_None,0,DigitalMode_Num_Modes-1},
-	{ ConfigEntry_Int32_16, EEPROM_BASS_GAIN,&ts.bass_gain,2,-20,20}, // INT DEFAULT PROBLEM,see above
-    { ConfigEntry_Int32_16, EEPROM_TREBLE_GAIN,&ts.treble_gain,0,-20,20},  // MINOR INT DEFAULT PROBLEM,see above
+	{ ConfigEntry_Int32_16, EEPROM_BASS_GAIN,&ts.dsp.bass_gain,2,-20,20}, // INT DEFAULT PROBLEM,see above
+    { ConfigEntry_Int32_16, EEPROM_TREBLE_GAIN,&ts.dsp.treble_gain,0,-20,20},  // MINOR INT DEFAULT PROBLEM,see above
     { ConfigEntry_UInt8, EEPROM_TX_FILTER,&ts.tx_filter,0,0,TX_FILTER_BASS},
-	{ ConfigEntry_Int32_16, EEPROM_TX_BASS_GAIN,&ts.tx_bass_gain,4,-20,6}, // INT DEFAULT PROBLEM,see above
-    { ConfigEntry_Int32_16, EEPROM_TX_TREBLE_GAIN,&ts.tx_treble_gain,4,-20,6}, // INT DEFAULT PROBLEM,see above
+	{ ConfigEntry_Int32_16, EEPROM_TX_BASS_GAIN,&ts.dsp.tx_bass_gain,4,-20,6}, // INT DEFAULT PROBLEM,see above
+    { ConfigEntry_Int32_16, EEPROM_TX_TREBLE_GAIN,&ts.dsp.tx_treble_gain,4,-20,6}, // INT DEFAULT PROBLEM,see above
     { ConfigEntry_Int32_16, EEPROM_SAM_PLL_LOCKING_RANGE,&ads.pll_fmax_int,2500,50,8000}, // NO INT DEFAULT PROBLEM
     { ConfigEntry_Int32_16, EEPROM_SAM_PLL_STEP_RESPONSE,&ads.zeta_int,65,1,100},  // NO INT DEFAULT PROBLEM
     { ConfigEntry_Int32_16, EEPROM_SAM_PLL_BANDWIDTH,&ads.omegaN_int, 250,15,1000}, // NO INT DEFAULT PROBLEM
@@ -265,7 +266,7 @@ const ConfigEntryDescriptor ConfigEntryInfo[] =
 	{ ConfigEntry_Int32 | Calib_Val, EEPROM_TScal4_High,&mchf_touchscreen.cal[4], 74886,INT32_MIN,INT32_MAX}, // INT DEFAULT PROBLEM,see above
 	{ ConfigEntry_Int32 | Calib_Val, EEPROM_TScal5_High,&mchf_touchscreen.cal[5], -1630326,INT32_MIN,INT32_MAX}, // INT DEFAULT PROBLEM,see above
 	{ ConfigEntry_UInt16, EEPROM_NUMBER_OF_ENTRIES,&number_of_entries_cur_fw,EEPROM_FIRST_UNUSED,EEPROM_FIRST_UNUSED,EEPROM_FIRST_UNUSED},
-	{ ConfigEntry_UInt16, EEPROM_DSP_MODE_MASK,&ts.dsp_mode_mask,DSP_SWITCH_MODEMASK_ENABLE_DEFAULT,DSP_SWITCH_MODEMASK_ENABLE_DSPOFF,DSP_SWITCH_MODEMASK_ENABLE_MASK},
+	{ ConfigEntry_UInt16, EEPROM_DSP_MODE_MASK,&ts.dsp.mode_mask,DSP_SWITCH_MODEMASK_ENABLE_DEFAULT,DSP_SWITCH_MODEMASK_ENABLE_DSPOFF,DSP_SWITCH_MODEMASK_ENABLE_MASK},
     { ConfigEntry_UInt8, EEPROM_ENABLE_PTT_RTS,&ts.enable_ptt_rts,0,0,1},
 	{ ConfigEntry_Int32_16, EEPROM_CW_DECODER_THRESH,&cw_decoder_config.thresh,CW_DECODER_THRESH_DEFAULT,CW_DECODER_THRESH_MIN,CW_DECODER_THRESH_MAX}, // NO INT DEFAULT PROBLEM
 	{ ConfigEntry_Int32_16, EEPROM_CW_DECODER_BLOCKSIZE,&cw_decoder_config.blocksize,CW_DECODER_BLOCKSIZE_DEFAULT,CW_DECODER_BLOCKSIZE_MIN,CW_DECODER_BLOCKSIZE_MAX}, // NO INT DEFAULT PROBLEM
@@ -875,8 +876,8 @@ void UiConfiguration_FixDefaultsNotLoadedIssue()
  */
 void UiConfiguration_LoadEepromValues(bool load_freq_mode_defaults, bool load_eeprom_defaults)
 {
-    bool dspmode = ts.dsp_inhibit;
-    ts.dsp_inhibit = 1;     // disable dsp while loading EEPROM data
+    bool dspmode = ts.dsp.inhibit;
+    ts.dsp.inhibit = 1;     // disable dsp while loading EEPROM data
 
     uint32_t value32;
 
@@ -935,7 +936,7 @@ void UiConfiguration_LoadEepromValues(bool load_freq_mode_defaults, bool load_ee
 
     AudioManagement_CalcTxCompLevel();
 
-    ts.dsp_inhibit = dspmode;       // restore setting
+    ts.dsp.inhibit = dspmode;       // restore setting
 }
 
 // ********************************************************************************************************************
@@ -959,7 +960,7 @@ uint16_t UiConfiguration_SaveEepromValues(void)
     else
     {
         // disable DSP during write because it decreases speed tremendous
-        //  ts.dsp_active &= 0xfa;  // turn off DSP
+        //  ts.dsp.active &= 0xfa;  // turn off DSP
 
         const uint8_t dmod_mode = ts.dmod_mode;
 

--- a/mchf-eclipse/drivers/ui/ui_driver.h
+++ b/mchf-eclipse/drivers/ui/ui_driver.h
@@ -242,6 +242,8 @@ uint32_t UiDriver_GetActiveDSPFunctions();
 void UiDriver_UpdateDSPmode(uint8_t new_dsp_mode);
 bool UiDriver_CheckTouchRegion(const UiArea_t* tr_p);
 
+uint32_t UiDriver_GetNBColor();
+
 void UiDriver_InitBandSet();
 void UiDriver_UpdateBand(uint16_t vfo_sel, uint8_t curr_band_index, uint8_t new_band_index);
 //

--- a/mchf-eclipse/drivers/ui/ui_vkeybrd.c
+++ b/mchf-eclipse/drivers/ui/ui_vkeybrd.c
@@ -243,13 +243,13 @@ void UiVk_Redraw()
 
 //DSP box VKeypad=================================================================
 uint32_t prev_dsp_functions_active;	//used for virtual DSP keys redraw detections
-//this array is needed because different bit definitions are used for ts.dsp_mode and ts.dsp_active, so we cannot simply pass the CallBackShort parameter
+//this array is needed because different bit definitions are used for ts.dsp.mode and ts.dsp.active, so we cannot simply pass the CallBackShort parameter
 const uint32_t dsp_functions[]={0, DSP_NR_ENABLE, DSP_NOTCH_ENABLE, DSP_NOTCH_ENABLE|DSP_NR_ENABLE, DSP_MNOTCH_ENABLE, DSP_MPEAK_ENABLE};
 
 static void UiVk_DSPVKeyCallBackShort(uint8_t KeyNum, uint32_t param)
 {
-    uint8_t new_dsp_mode = ts.dsp_mode;
-	if(((ts.dsp_mode_mask&(1<<KeyNum))!=0) || (KeyNum==0))
+    uint8_t new_dsp_mode = ts.dsp.mode;
+	if(((ts.dsp.mode_mask&(1<<KeyNum))!=0) || (KeyNum==0))
 	{
 		new_dsp_mode=param;
 	}
@@ -260,13 +260,13 @@ static void UiVk_DSPVKeyCallBackShort(uint8_t KeyNum, uint32_t param)
 
 static void UiVk_DSPVKeyCallBackLong(uint8_t KeyNum, uint32_t param)
 {
-	ts.dsp_mode_mask^=1<<KeyNum;
+	ts.dsp.mode_mask^=1<<KeyNum;
 	// mask out this dsp function, to make it no longer available
 	prev_dsp_functions_active=-1;
 	// now find a new valid mode starting from the current one
 	// this switches mode only if the current active mode is the
 	// one we just disabled
-	UiDriver_UpdateDSPmode(ts.dsp_mode);
+	UiDriver_UpdateDSPmode(ts.dsp.mode);
 }
 
 static uint8_t UiVk_DSPVKeyCallBackWarning(uint8_t KeyNum, uint32_t param)
@@ -283,7 +283,7 @@ static uint8_t UiVk_DSPVKeyInitTypeDraw(uint8_t KeyNum, uint32_t param)
 {
 	uint8_t Keystate=Vbtn_State_Normal;
 	uint32_t dsp_functions_active =UiDriver_GetActiveDSPFunctions();
-	if(((ts.dsp_mode_mask&(1<<KeyNum))==0) && (KeyNum>0))
+	if(((ts.dsp.mode_mask&(1<<KeyNum))==0) && (KeyNum>0))
 	{
 		Keystate=Vbtn_State_Disabled;
 	}

--- a/mchf-eclipse/hardware/uhsdr_board_config.h
+++ b/mchf-eclipse/hardware/uhsdr_board_config.h
@@ -193,6 +193,32 @@
 #define USE_32_IQ_BITS
 #define USE_32_AUDIO_BITS
 
+
+// for now: These are fixed.
+#define IQ_SAMPLE_RATE (48000)
+#define AUDIO_SAMPLE_RATE (48000)
+
+// a lot of code pieces assume that this frequency
+// is 1500 Hz, so don't change
+#define IQ_INTERRUPT_FREQ (1500)
+
+// we process one dma block of samples at once
+// block sizes should be a power of two
+// a lot of code process information in these blocks
+#define IQ_BLOCK_SIZE (IQ_SAMPLE_RATE/IQ_INTERRUPT_FREQ)
+#define AUDIO_BLOCK_SIZE (AUDIO_SAMPLE_RATE/IQ_INTERRUPT_FREQ)
+
+#if (IQ_SAMPLE_RATE) != 48000
+    #error Only 48k sample frequency supported (yet).
+#endif
+#if (IQ_BLOCK_SIZE * 1500) != IQ_SAMPLE_RATE
+    #error Audio Interrupt Frequency must be 1500.
+#endif
+#if (IQ_SAMPLE_RATE/IQ_BLOCK_SIZE) != (AUDIO_SAMPLE_RATE/AUDIO_BLOCK_SIZE)
+    #error IQ Interrupt frequency must be idential to Audio Interrupt Frequency
+#endif
+
+
 //******************************CONFIGURATION_LOGIC_CHECKS************************************//
 
 #if !defined(USE_OSC_SI570) && !defined(USE_OSC_SI5351A)


### PR DESCRIPTION
No functional change (yet) but:
- definition of IQ/AUDIO Sample Rate and related block sizes now
  in ushdr_board_config.h which allows to remove some other dependencies
  in a number of cases
- moved all AGC WDSP related settings into audio_agc.c/audio_agc.h,
  it no longer depends on uhsdr_board.h / TransceiverState access
- same applies to all directly NR related settings into audio_nr.h/.c
- extracted all dsp related settings in a structure but still kept it
  in TransceiverState.
This all part of the rework to enable us finally to run with different
sample rates for IQ and AUDIO