### PR TITLE
Audio driver breakup and fix for #1728

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_agc.c
+++ b/mchf-eclipse/drivers/audio/audio_agc.c
@@ -13,7 +13,8 @@
 #include <assert.h>
 #include "uhsdr_board_config.h"
 #include "audio_agc.h"
-#include "audio_driver.h" // log10f_fast and ADC_CLIP_WARN_THRESHOLD
+#include "audio_driver.h" // ADC_CLIP_WARN_THRESHOLD
+#include "uhsdr_math.h"
 
 #define AGC_WDSP_RB_SIZE ((AUDIO_SAMPLE_RATE/1000)*4) // max buffer size based on max sample rate to be supported
 // this translates to 192 at 48k SPS. We have FM using the AGC at full sampling speed
@@ -90,7 +91,7 @@ agc_variables_t agc_wdsp;
  * Sets the basic initial values for the WDSP AGC
  * Call only once at startup!
  */
-void AudioAgc_InitAgcWdsp()
+void AudioAgc_AgcWdsp_Init()
 {
     agc_wdsp_conf.mode = 2;
     agc_wdsp_conf.slope = 70;
@@ -553,7 +554,7 @@ void AudioAgc_RunAgcWdsp(int16_t blockSize, float32_t (*agcbuffer)[AUDIO_BLOCK_S
             agc_wdsp_conf.action = 1;
         }
 
-        float32_t vo =  log10f_fast(agc_wdsp.inv_max_input * agc_wdsp.volts);
+        float32_t vo =  Math_log10f_fast(agc_wdsp.inv_max_input * agc_wdsp.volts);
         if(vo > 0.0)
         {
             vo = 0.0;

--- a/mchf-eclipse/drivers/audio/audio_agc.h
+++ b/mchf-eclipse/drivers/audio/audio_agc.h
@@ -40,7 +40,7 @@ extern agc_wdsp_params_t agc_wdsp_conf;
 
 void AudioAgc_RunAgcWdsp(int16_t blockSize, float32_t (*agcbuffer)[AUDIO_BLOCK_SIZE], const bool use_stereo );
 void AudioAgc_SetupAgcWdsp(float32_t sample_rate, bool remove_dc);
-void AudioAgc_InitAgcWdsp();
+void AudioAgc_AgcWdsp_Init();
 
 
 #endif

--- a/mchf-eclipse/drivers/audio/audio_driver.h
+++ b/mchf-eclipse/drivers/audio/audio_driver.h
@@ -384,55 +384,31 @@ typedef struct SMeter
 //
 #define	MAX_RF_GAIN_MAX		30		// Maximum setting for "Max RF gain"
 #define	MAX_RF_GAIN_DEFAULT	10
-//
+
 // Noise blanker constants
-//
-//#define	NBLANK_AGC_ATTACK	0.33	// Attack time multiplier for AGC
-//
-//#define NBLANK_AGC_DECAY	0.002	// Decay rate multiplier for "Fast" AGC
-//
 #define	MAX_NB_SETTING		15
 #define	NB_WARNING1_SETTING	7		// setting at or above which NB warning1 (yellow) is given
 #define	NB_WARNING2_SETTING	12		// setting at or above which NB warning2 (orange) is given
 #define	NB_WARNING3_SETTING	15		// setting at or above which NB warning3 (red) is given
-//#define	NB_DURATION			4
-//
-//#define	NB_AGC_FILT			0.999	// Component of IIR filter for recyling previous AGC value
-//#define	NB_SIG_FILT			0.001	// Component of IIR filter for present signal value's contribution to AGC
-//
-//#define	NB_AVG_WEIGHT		0.80	// Weighting applied to average based on past signal for NB2
-//#define	NB_SIG_WEIGHT		0.20	// Weighting applied to present signal for NB2
-//
-//
-//#define	NB_MAX_AGC_SETTING	35		// maximum setting for noise blanker setting
-//#define	NB_AGC_DEFAULT		20		// Default setting for noise blanker AGC time constant adjust
-//
+
 // Values used for "custom" AGC settings
-//
-//#define	MIN_CUST_AGC_VAL	10	// Minimum and maximum RF gain settings
-//#define	MAX_CUST_AGC_VAL	30
-//#define	CUST_AGC_OFFSET_VAL	30	// RF Gain offset value used in calculations
-//#define	CUST_AGC_VAL_DEFAULT	17.8	// Value for "medium" AGC value
-//
 #define	LINE_OUT_SCALING_FACTOR	10 // multiplication of audio for fixed LINE out level (nominally 1vpp)
 //
 #define	LINE_IN_GAIN_RESCALE	20		// multiplier for line input gain
 #define	MIC_GAIN_RESCALE	2	// divisor for microphone gain setting
-//
+
+
 // ALC (Auto Level Control) for transmitter, constants
-//
 #define	ALC_VAL_MAX			1		// Maximum ALC Value is 1 (e.g. it can NEVER amplify)
 #define	ALC_VAL_MIN			0.001	// Minimum ALC Value - it can provide up to 60dB of attenuation
 #define	ALC_ATTACK			0.1//0.033	// Attack time for the ALC's gain control
 #define	ALC_KNEE			30000	// The audio value threshold for the ALC operation
-//
+
 // Decay (release time) for ALC/Audio compressor
-//
 #define	ALC_DECAY_MAX		20		// Maximum (slowest) setting for ALC decay
 #define	ALC_DECAY_DEFAULT	10		// Default custom ALC setting (approx. equal to AGC "medium")
-//
+
 // Audio post-filter (pre-alc) gain adjust.  This effectively sets the min/max compression level.
-//
 #define	ALC_POSTFILT_GAIN_MIN	1
 #define	ALC_POSTFILT_GAIN_MAX	25
 #define	ALC_POSTFILT_GAIN_DEFAULT	1
@@ -453,90 +429,26 @@ typedef struct SMeter
 //
 // DO NOT change the above unless you know *EXACTLY* what you are doing!  If you screw with these numbers, you WILL wreck the
 // AM modulation!!!  (No, I'm not kidding!)
-//
-// FM Demodulator parameters
-//
-#define	FM_DEMOD_COEFF1		PI/4			// Factors used in arctan approximation used in FM demodulator
-#define	FM_DEMOD_COEFF2		PI*0.75
-//
-#define	FM_RX_SCALING_2K5	10000	// 33800			// Amplitude scaling factor of demodulated FM audio (normalized for +/- 2.5 kHz deviation at 1 kHZ)
-#define FM_RX_SCALING_5K	(FM_RX_SCALING_2K5/2)	// Amplitude scaling factor of demodulated FM audio (normalized for +/- 5 kHz deviation at 1 kHz)
-//
-#define FM_AGC_SCALING		2				// Scaling factor for AGC result when in FM (AGC used only for S-meter)
-//
-#define FM_RX_LPF_ALPHA		0.05			// For FM demodulator:  "Alpha" (low-pass) factor to result in -6dB "knee" at approx. 270 Hz
-//
-#define FM_RX_HPF_ALPHA		0.96			// For FM demodulator:  "Alpha" (high-pass) factor to result in -6dB "knee" at approx. 180 Hz
-//
-#define FM_RX_SQL_SMOOTHING	0.005			// Smoothing factor for IIR squelch noise averaging
-#define	FM_SQUELCH_HYSTERESIS	3			// Hysteresis for FM squelch
-#define FM_SQUELCH_PROC_DECIMATION	((uint32_t)(1/FM_RX_SQL_SMOOTHING))		// Number of times we go through the FM demod algorithm before we do a squelch calculation
-#define	FM_SQUELCH_MAX		20				// maximum setting for FM squelch
-#define	FM_SQUELCH_DEFAULT	12				// default setting for FM squelch
-//
-// FM Modulator parameters
-//
-#define FM_TX_HPF_ALPHA		0.05			// For FM modulator:  "Alpha" (high-pass) factor to pre-emphasis
-//
-// NOTE:  FM_MOD_SCALING_2K5 is rescaled (doubled) for 5 kHz deviation, as are modulation factors for subaudible tones and tone burst
-//
-#define	FM_MOD_SCALING_2K5		16				// For FM modulator:  Scaling factor for NCO, after all processing, to achieve 2.5 kHz with a 1 kHz tone
-//
-#define FM_MOD_SCALING	FM_MOD_SCALING_2K5		// For FM modulator - system deviation
-#define	FM_MOD_AMPLITUDE_SCALING	0.875		// For FM modulator:  Scaling factor for output of modulator to set proper output power
 
-// this value represents 2*PI, here 16 bit. It must be a power of two!
-// Otherwise a simpel shift does not work as conversion
-#define FM_MOD_ACC_BITS 16
-#define FM_MOD_ACC_MAX_VALUE (1 << FM_MOD_ACC_BITS)
+// FM TX/RX
+#define NUM_SUBAUDIBLE_TONES 56
+#define FM_SUBAUDIBLE_TONE_OFF  0
 
-// this is the generic formula for the conversion from the accumulator to the
-// table index
-// #define FM_MOD_ACC_DIV (FM_MOD_ACC_MAX_VALUE/DDS_TBL_SIZE)
-// but we simply state how many bits to shift to the right
-#define FM_MOD_DDS_ACC_SHIFT   (FM_MOD_ACC_BITS-DDS_TBL_BITS)
+// FM TX
 
-//
-#define	FM_ALC_GAIN_CORRECTION	0.95
-//
-// For subaudible and burst:  FM Tone word calculation:  freq / (sample rate/2^24) => freq / (IQ_SAMPLE_RATE/16777216) => freq * 349.52533333
-//
-#define FM_SUBAUDIBLE_TONE_AMPLITUDE_SCALING	0.00045	// Scaling factor for subaudible tone modulation - not pre-emphasized -to produce approx +/- 300 Hz deviation in 2.5kHz mode
+#define FM_TONE_BURST_MAX   2
+extern uint32_t fm_tone_burst_freq[FM_TONE_BURST_MAX+1];
 
-#define	NUM_SUBAUDIBLE_TONES 56
-#define FM_SUBAUDIBLE_TONE_OFF	0
+#define FM_TONE_BURST_OFF   0
 
-#define	FM_TONE_BURST_OFF	0
-#define	FM_TONE_BURST_1750_MODE	1
-#define	FM_TONE_BURST_2135_MODE	2
-#define	FM_TONE_BURST_MAX	2
+#define FM_TONE_BURST_DURATION  100         // duration, in 100ths of a second, of the tone burst
 
-#define FM_TONE_BURST_AMPLITUDE_SCALING (FM_MOD_SCALING/4266.0) // scale tone modulation (which is NOT pre-emphasized) for approx. 2/3rds of system modulation
-#define FM_TONE_BURST_DURATION	100			// duration, in 100ths of a second, of the tone burst
-//
-// FM RX bandwidth settings
-//
-/*
-enum	{
-	FM_RX_BANDWIDTH_7K2 = 0,
-	FM_RX_BANDWIDTH_10K,
-	FM_RX_BANDWIDTH_12K,
-//	FM_RX_BANDWIDTH_15K,		// 15K bandwidth has too much distortion with a "translation" frequency of + or - 6 kHz, likely due to the "Zero Hz Hole"
-	FM_RX_BANDWIDTH_MAX
-}; */
-//
-//#define	FM_BANDWIDTH_DEFAULT	FM_RX_BANDWIDTH_10K		// We will use the second-to-narrowest bandwidth as the "Default" FM RX bandwidth to be safe!
-//
-#define	FM_SUBAUDIBLE_GOERTZEL_WINDOW	400				// this sets the overall number of samples involved in the Goertzel decode windows (this value * "size/2")
-#define	FM_TONE_DETECT_ALPHA	0.9						// setting for IIR filtering of ratiometric result from frequency-differential tone detection
-//
-#define FM_SUBAUDIBLE_TONE_DET_THRESHOLD	1.75		// threshold of "smoothed" output of Goertzel, above which a tone is considered to be "provisionally" detected pending debounce
-#define FM_SUBAUDIBLE_DEBOUNCE_MAX			5			// maximum "detect" count in debounce
-#define FM_SUBAUDIBLE_TONE_DEBOUNCE_THRESHOLD	2		// number of debounce counts at/above which a tone detection is considered valid
-//
-#define	FM_GOERTZEL_HIGH	1.04		// ratio of "high" detect frequency with respect to center
-#define	FM_GOERTZEL_LOW		0.95		// ratio of "low" detect frequency with respect to center
-//
+// FM RX
+#define FM_SQUELCH_MAX      20              // maximum setting for FM squelch
+#define FM_SQUELCH_DEFAULT  12              // default setting for FM squelch
+#define FM_SUBAUDIBLE_GOERTZEL_WINDOW   400             // this sets the overall number of samples involved in the Goertzel decode windows (this value * "size/2")
+
+
 #define	BEEP_SCALING	20				// audio scaling of keyboard beep
 #define	BEEP_TONE_WORD_FACTOR			(65536/IQ_SAMPLE_RATE)	// scaling factor for beep frequency calculation
 //
@@ -614,20 +526,9 @@ enum	{
 #define	FREQ_IQ_CONV_MODE_DEFAULT	FREQ_IQ_CONV_M12KHZ		//FREQ_IQ_CONV_MODE_OFF
 #define	FREQ_IQ_CONV_MODE_MAX		4
 
-// Exports
-void AudioDriver_Init(void);
-void AudioDriver_SetRxAudioProcessing(uint8_t dmod_mode, bool reset_dsp_nr);
-void AudioDriver_TxFilterInit(uint8_t dmod_mode);
-int32_t AudioDriver_GetTranslateFreq();
-void AudioDriver_SetSamPllParameters ();
-float log10f_fast(float X);
-
-
-void AudioDriver_I2SCallback(AudioSample_t *audio, IqSample_t *iq, AudioSample_t *audioDst, int16_t size);
-
 // Public Audio
 extern AudioDriverState	ads;
-extern __IO SMeter       sm;
+extern SMeter       sm;
 
 extern AudioDriverBuffer adb;
 
@@ -716,20 +617,21 @@ extern lLMS leakyLMS;
 #endif
 #define AUDIO_BIT_SCALE_UP (1<<AUDIO_BIT_SHIFT)
 
+// Exports
+void AudioDriver_Init(void);
+void AudioDriver_SetProcessingChain(uint8_t dmod_mode, bool reset_dsp_nr);
+int32_t AudioDriver_GetTranslateFreq();
+void AudioDriver_SetSamPllParameters ();
+
+void AudioDriver_I2SCallback(AudioSample_t *audio, IqSample_t *iq, AudioSample_t *audioDst, int16_t size);
+
+
 void AudioDriver_CalcLowShelf(float32_t coeffs[5], float32_t f0, float32_t S, float32_t gain, float32_t FS);
 void AudioDriver_CalcHighShelf(float32_t coeffs[5], float32_t f0, float32_t S, float32_t gain, float32_t FS);
 void AudioDriver_CalcBandpass(float32_t coeffs[5], float32_t f0, float32_t FS);
 void AudioDriver_SetBiquadCoeffs(float32_t* coeffsTo,const float32_t* coeffsFrom);
-float32_t AudioDriver_absmax(float32_t* buffer, int size);
 
-void AudioDriver_TxProcessor(AudioSample_t * const srcCodec, IqSample_t * const dst, AudioSample_t * const audioDst, uint16_t blockSize);
 void AudioDriver_IQPhaseAdjust(uint16_t txrx_mode, float32_t* i_buffer, float32_t* q_buffer, const uint16_t blockSize);
-void AudioDriver_Dsp_Init(volatile dsp_params_t* dsp_p);
-
-void TxProcessor_Init();
-
-extern float32_t   audio_delay_buffer    [AUDIO_DELAY_BUFSIZE];
-
-void AudioDriver_SetupAgcWdsp();
+void AudioDriver_AgcWdsp_Set();
 
 #endif

--- a/mchf-eclipse/drivers/audio/audio_filter.c
+++ b/mchf-eclipse/drivers/audio/audio_filter.c
@@ -1132,7 +1132,7 @@ static IQFilterCoeffs_t   __MCHF_SPECIALMEM     fc;
 /*
  * @brief Initialize RX Hilbert and Decimation filters
  */
-void 	AudioFilter_InitRxHilbertAndDecimationFIR(uint8_t dmod_mode)
+void 	AudioFilter_SetRxHilbertAndDecimationFIR(uint8_t dmod_mode)
 {
     // always make a fresh copy of the original Q and I coefficients into fast RAM
     // this speeds up processing on the STM32F4
@@ -1225,12 +1225,13 @@ void 	AudioFilter_InitRxHilbertAndDecimationFIR(uint8_t dmod_mode)
 
 
 /*
- * @brief Initialize TX Hilbert filters
+ * Sets the TX Hilbert filters according to selected voice profile, has to be called before
+ * going on TX.
  */
-void AudioFilter_InitTxHilbertFIR(void)
+void AudioFilter_SetTxHilbertFIR(void)
 {
 
-    ads.tx_filter_adjusting = 1;        // disable TX I/Q filter during adjustment
+    ads.tx_filter_adjusting++;        // disable TX I/Q filter during adjustment
     // always make a fresh copy of the original Q and I coefficients
     // NOTE:  We are assuming that the I and Q filters are of the same length!
     //
@@ -1257,7 +1258,7 @@ void AudioFilter_InitTxHilbertFIR(void)
     arm_fir_init_f32(&Fir_TxFreeDV_Interpolate_I, Fir_TxFreeDV_Interpolate.numTaps, Fir_TxFreeDV_Interpolate.pCoeffs, Fir_TxFreeDV_Interpolate_State_I, IQ_TX_BLOCK_SIZE);
     arm_fir_init_f32(&Fir_TxFreeDV_Interpolate_Q, Fir_TxFreeDV_Interpolate.numTaps, Fir_TxFreeDV_Interpolate.pCoeffs, Fir_TxFreeDV_Interpolate_State_Q, IQ_TX_BLOCK_SIZE);
 
-    ads.tx_filter_adjusting = 0;        // re-enable TX I/Q filter now that we are done
+    ads.tx_filter_adjusting--;        // re-enable TX I/Q filter now that we are done
 }
 
 void AudioFilter_GetNamesOfFilterPath(uint16_t filter_path,const char** filter_names)

--- a/mchf-eclipse/drivers/audio/audio_filter.h
+++ b/mchf-eclipse/drivers/audio/audio_filter.h
@@ -35,8 +35,8 @@ extern arm_fir_decimate_instance_f32 DECIMATE_RX_I;
 extern arm_fir_decimate_instance_f32 DECIMATE_RX_Q;
 
 
-void 	AudioFilter_InitRxHilbertAndDecimationFIR(uint8_t dmod_mode);
-void 	AudioFilter_InitTxHilbertFIR(void);
+void 	AudioFilter_SetRxHilbertAndDecimationFIR(uint8_t dmod_mode);
+void 	AudioFilter_SetTxHilbertFIR(void);
 
 enum
 {

--- a/mchf-eclipse/drivers/audio/audio_management.h
+++ b/mchf-eclipse/drivers/audio/audio_management.h
@@ -28,8 +28,8 @@ void    AudioManagement_CalcAGCDecay();
 void    AudioManagement_SetSidetoneForDemodMode(uint8_t dmod_mode, bool tune_mode);
 
 void    AudioManagement_LoadToneBurstMode();
-void    AudioManagement_CalcSubaudibleGenFreq();        // load/set current FM subaudible tone settings for generation
-void    AudioManagement_CalcSubaudibleDetFreq();
+void    AudioManagement_CalcSubaudibleGenFreq(float32_t freq);        // load/set current FM subaudible tone settings for generation
+void    AudioManagement_CalcSubaudibleDetFreq(float32_t freq);
 
 void    AudioManagement_KeyBeep();
 void    AudioManagement_KeyBeepPrepare();

--- a/mchf-eclipse/drivers/audio/cw/cw_decoder.c
+++ b/mchf-eclipse/drivers/audio/cw/cw_decoder.c
@@ -66,7 +66,7 @@ cw_config_t cw_decoder_config =
 
 static void CW_Decode(void);
 
-void CwDecode_FilterInit()
+void CwDecode_Filter_Set()
 {
 	// set Goertzel parameters for CW decoding
 	AudioFilter_CalcGoertzel(&cw_goertzel, ts.cw_sidetone_freq , // cw_decoder_config.target_freq,

--- a/mchf-eclipse/drivers/audio/cw/cw_decoder.h
+++ b/mchf-eclipse/drivers/audio/cw/cw_decoder.h
@@ -41,7 +41,7 @@ extern cw_config_t cw_decoder_config;
 
 
 void CwDecode_RxProcessor(float32_t * const src, int16_t blockSize);
-void CwDecode_FilterInit();
+void CwDecode_Filter_Set();
 //void CW_Decoder_WPM_display_erase();
 void CwDecoder_WpmDisplayUpdate(bool force_update);
 void CwDecoder_WpmDisplayClearOrPrepare(bool prepare);

--- a/mchf-eclipse/drivers/audio/fm_subaudible_tone_table.h
+++ b/mchf-eclipse/drivers/audio/fm_subaudible_tone_table.h
@@ -16,7 +16,7 @@
 #define __SUBAUDIBLE_TONE_TABLE
 
 
-const float fm_subaudible_tone_table[] =
+static const float fm_subaudible_tone_table[] =
 {
     0,
     67.0,

--- a/mchf-eclipse/drivers/audio/tx_processor.h
+++ b/mchf-eclipse/drivers/audio/tx_processor.h
@@ -1,0 +1,26 @@
+/*  -*-  mode: c; tab-width: 4; indent-tabs-mode: t; c-basic-offset: 4; coding: utf-8  -*-  */
+/************************************************************************************
+ **                                                                                 **
+ **                                        UHSDR                                    **
+ **               a powerful firmware for STM32 based SDR transceivers              **
+ **                                                                                 **
+ **---------------------------------------------------------------------------------**
+ **                                                                                 **
+ **  File name:                                                                     **
+ **  Description:                                                                   **
+ **  Last Modified:                                                                 **
+ **  Licence:		GNU GPLv3                                                      **
+ ************************************************************************************/
+
+#ifndef __TX_PROCESSOR_H
+#define __TX_PROCESSOR_H
+
+#include "uhsdr_board_config.h"
+#include "uhsdr_types.h"
+#include "audio_driver.h" // for types
+
+void TxProcessor_Init();
+void TxProcessor_Set(uint8_t dmod_mode);
+void TxProcessor_PrepareRun();
+void TxProcessor_Run(AudioSample_t * const srcCodec, IqSample_t * const dst, AudioSample_t * const audioDst, uint16_t blockSize, bool external_mute);
+#endif

--- a/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
+++ b/mchf-eclipse/drivers/ui/lcd/ui_spectrum.c
@@ -26,7 +26,7 @@
 #include "cw_decoder.h"
 #include "audio_nr.h"
 #include "psk.h"
-
+#include "uhsdr_math.h"
 /*
 #if defined(USE_DISP_480_320) || defined(USE_EXPERIMENTAL_MULTIRES)
 #define USE_DISP_480_320_SPEC
@@ -1257,7 +1257,7 @@ static void UiSpectrum_DrawWaterfall()
 
 static float32_t  UiSpectrum_ScaleFFTValue(const float32_t value, float32_t* min_p)
 {
-    float32_t sig = sd.display_offset + log10f_fast(value) * sd.db_scale;     // take FFT data, do a log10 and multiply it to scale 10dB (fixed)
+    float32_t sig = sd.display_offset + Math_log10f_fast(value) * sd.db_scale;     // take FFT data, do a log10 and multiply it to scale 10dB (fixed)
     // apply "AGC", vertical "sliding" offset (or brightness for waterfall)
 
     if (sig < *min_p)
@@ -2120,8 +2120,8 @@ static void UiSpectrum_CalculateDBm()
 
         if (sum_db > 0)
         {
-            sm.dbm_cur = slope * log10f_fast (sum_db) + cons;
-            sm.dbmhz_cur = sm.dbm_cur -  10 * log10f_fast ((float32_t)(((int)Ubin-(int)Lbin) * bin_BW)) ;
+            sm.dbm_cur = slope * Math_log10f_fast (sum_db) + cons;
+            sm.dbmhz_cur = sm.dbm_cur -  10 * Math_log10f_fast ((float32_t)(((int)Ubin-(int)Lbin) * bin_BW)) ;
         }
         else
         {

--- a/mchf-eclipse/drivers/ui/radio_management.c
+++ b/mchf-eclipse/drivers/ui/radio_management.c
@@ -1121,8 +1121,7 @@ void RadioManagement_SetDemodMode(uint8_t new_mode)
              df.tune_new -= sidetone_mult * ts.cw_sidetone_freq;
          }
     }
-    AudioDriver_SetRxAudioProcessing(new_mode, false);
-    AudioDriver_TxFilterInit(new_mode);
+    AudioDriver_SetProcessingChain(new_mode, false);
     AudioManagement_SetSidetoneForDemodMode(new_mode,false);
 
     if (new_mode == DEMOD_SAM)

--- a/mchf-eclipse/drivers/ui/radio_management.c
+++ b/mchf-eclipse/drivers/ui/radio_management.c
@@ -1375,12 +1375,16 @@ uint32_t RadioManagement_NextAlternativeDemodMode(uint32_t loc_mode)
         break;
     case DEMOD_SAM:
         ads.sam_sideband ++;
+
         // stereo SAM is only switchable if you have stereo modes enabled
-        uint8_t minus = 0;
 #ifdef USE_TWO_CHANNEL_AUDIO
-        minus = !ts.stereo_enable;
+        if (ts.stereo_enable == false && ads.sam_sideband == SAM_SIDEBAND_STEREO)
+        {
+            // skip if we have stereo disabled
+            ads.sam_sideband ++;
+        }
 #endif
-        if (ads.sam_sideband > (SAM_SIDEBAND_MAX - minus))
+        if (ads.sam_sideband >= SAM_SIDEBAND_MAX)
         {
             ads.sam_sideband = SAM_SIDEBAND_BOTH;
             retval = DEMOD_AM;

--- a/mchf-eclipse/drivers/ui/ui_configuration.c
+++ b/mchf-eclipse/drivers/ui/ui_configuration.c
@@ -876,8 +876,7 @@ void UiConfiguration_FixDefaultsNotLoadedIssue()
  */
 void UiConfiguration_LoadEepromValues(bool load_freq_mode_defaults, bool load_eeprom_defaults)
 {
-    bool dspmode = ts.dsp.inhibit;
-    ts.dsp.inhibit = 1;     // disable dsp while loading EEPROM data
+    ts.dsp.inhibit++;     // disable dsp while loading EEPROM data
 
     uint32_t value32;
 
@@ -936,7 +935,7 @@ void UiConfiguration_LoadEepromValues(bool load_freq_mode_defaults, bool load_ee
 
     AudioManagement_CalcTxCompLevel();
 
-    ts.dsp.inhibit = dspmode;       // restore setting
+    if (ts.dsp.inhibit) { ts.dsp.inhibit--; } // restore setting
 }
 
 // ********************************************************************************************************************

--- a/mchf-eclipse/drivers/usb/app/usbd_audio_if.c
+++ b/mchf-eclipse/drivers/usb/app/usbd_audio_if.c
@@ -220,8 +220,8 @@ void audio_out_fill_tx_buffer(AudioSample_t *buffer, uint32_t len)
     {
         for (uint32_t idx = len; idx; idx--)
         {
-            buffer->l = *pkt++;
-            buffer->r = *pkt++;
+            buffer->l = (*pkt++) << AUDIO_BIT_SHIFT;
+            buffer->r = (*pkt++) << AUDIO_BIT_SHIFT;
             buffer++;
         }
         audio_out_buffer_pop_pkt(pkt,2*len);

--- a/mchf-eclipse/files.mak
+++ b/mchf-eclipse/files.mak
@@ -6,6 +6,7 @@ misc/TestCPlusPlusBuild.cpp \
 misc/profiling.c \
 misc/serial_eeprom.c \
 misc/uhsdr_canary.c \
+misc/uhsdr_math.c \
 hardware/uhsdr_board.c \
 hardware/uhsdr_hw_i2c.c \
 hardware/uhsdr_hmc1023.c \

--- a/mchf-eclipse/hardware/uhsdr_board.h
+++ b/mchf-eclipse/hardware/uhsdr_board.h
@@ -631,12 +631,6 @@ typedef struct TransceiverState
 #define STREAM_TX_AUDIO_GENIQ   4  // generated "clean" IQ signal before final scaling and IQ phase/balance adjust
 #define STREAM_TX_AUDIO_NUM     5  // how many choices
 
-	// Freedv Test DL2FW
-	bool	FDV_TX_encode_ready;
-	int	FDV_TX_samples_ready;
-	uint16_t FDV_TX_out_start_pt;
-	uint16_t FDV_TX_in_start_pt;
-
     bool    digi_lsb;                 // flag used to indicate that mcHF is to operate in LSB when TRUE
 
     bool dial_moved; // dial was moved, used to communicate with spectrum display code
@@ -651,7 +645,6 @@ typedef struct TransceiverState
     int16_t rtc_calib; // ppm variation value, unit 1 ppm
     bool vbat_present; // we detected a working vbat mod
     bool codec_present; // we detected a working codec
-	bool new_nb; // new noise blanker
 	bool rtty_atc_enable; // is ATC enabled for RTTY decoding? (for testing!)
 
 	uint8_t enable_rtty_decode; // new rtty encoder (experimental)

--- a/mchf-eclipse/misc/uhsdr_math.c
+++ b/mchf-eclipse/misc/uhsdr_math.c
@@ -1,0 +1,66 @@
+/*  -*-  mode: c; tab-width: 4; indent-tabs-mode: t; c-basic-offset: 4; coding: utf-8  -*-  */
+/************************************************************************************
+ **                                                                                 **
+ **                                        UHSDR                                    **
+ **               a powerful firmware for STM32 based SDR transceivers              **
+ **                                                                                 **
+ **---------------------------------------------------------------------------------**
+ **                                                                                 **
+ **  Licence:       GNU GPLv3                                                       **
+ ************************************************************************************/
+#include <malloc.h>
+#include <string.h>
+#include <assert.h>
+#include "uhsdr_math.h"
+
+/**
+ * Fast algorithm for log10
+ *
+ * This is a fast approximation to log2()
+ * Y = C[0]*F*F*F + C[1]*F*F + C[2]*F + C[3] + E;
+ * log10f is exactly log2(x)/log2(10.0f)
+ * Math_log10f_fast(x) =(log2f_approx(x)*0.3010299956639812f)
+ *
+ * @param X number want log10 for
+ * @return log10(x)
+ */
+float32_t Math_log10f_fast(float32_t X) {
+    float Y, F;
+    int E;
+    F = frexpf(fabsf(X), &E);
+    Y = 1.23149591368684f;
+    Y *= F;
+    Y += -4.11852516267426f;
+    Y *= F;
+    Y += 6.02197014179219f;
+    Y *= F;
+    Y += -3.13396450166353f;
+    Y += E;
+    return(Y * 0.3010299956639812f);
+}
+
+/**
+ * Find the absolute (i.e. ignoring the sign) maximum value
+ * @param float32_t buffer to be searched
+ * @param size how many elements
+ * @return the actual maxium value of the size elements in buffer
+ */
+float32_t Math_absmax(float32_t* buffer, int size)
+{
+    float32_t min, max;
+    uint32_t  pindex;
+
+    arm_max_f32(buffer, size, &max, &pindex);      // find absolute value of audio in buffer after gain applied
+    arm_min_f32(buffer, size, &min, &pindex);
+
+    return -min>max?-min:max;
+}
+
+/**
+ * get the sign of a float number
+ * @param x the number to test
+ * @return -1 if below zero, 0 if zero, 1 if above zero
+ */
+float32_t Math_sign_new (float32_t x) {
+    return (x < 0) ? -1.0 : ( (x > 0) ? 1.0 : 0.0);
+}

--- a/mchf-eclipse/misc/uhsdr_math.h
+++ b/mchf-eclipse/misc/uhsdr_math.h
@@ -1,0 +1,19 @@
+/*  -*-  mode: c; tab-width: 4; indent-tabs-mode: t; c-basic-offset: 4; coding: utf-8  -*-  */
+/************************************************************************************
+ **                                                                                 **
+ **                                        UHSDR                                    **
+ **               a powerful firmware for STM32 based SDR transceivers              **
+ **                                                                                 **
+ **---------------------------------------------------------------------------------**
+ **                                                                                 **
+ **  Licence:       GNU GPLv3                                                       **
+ ************************************************************************************/
+#ifndef __UHSDR_MATH_H
+#define __UHSDR_MATH_H
+
+#include "uhsdr_types.h"
+float32_t Math_log10f_fast(float32_t X);
+float32_t Math_absmax(float32_t* buffer, int size);
+float32_t Math_sign_new (float32_t x);
+
+#endif // __UHSDR_MATH_H

--- a/mchf-eclipse/src/uhsdr_main.c
+++ b/mchf-eclipse/src/uhsdr_main.c
@@ -129,9 +129,6 @@ void TransceiverStateInit(void)
     ts.audio_spkr_unmute_delay_count		= VOICE_TX2RX_DELAY_DEFAULT;			// TX->RX delay turnaround
 
     ts.tune_freq		= 0;
-    //ts.tune_freq_old	= 0;
-
-    //	ts.calib_mode		= 0;					// calibrate mode
 
     ts.menu_mode		= 0;					// menu mode
     ts.menu_item		= 0;					// menu item selection
@@ -142,8 +139,8 @@ void TransceiverStateInit(void)
     ts.tx_mic_gain_mult	= MIC_GAIN_DEFAULT;			// actual operating value for microphone gain
 
     ts.tx_gain[TX_AUDIO_MIC]		= MIC_GAIN_DEFAULT;	// default line gain
-    ts.tx_gain[TX_AUDIO_LINEIN_L]		= LINE_GAIN_DEFAULT;	// default line gain
-    ts.tx_gain[TX_AUDIO_LINEIN_R]		= LINE_GAIN_DEFAULT;	// default line gain
+    ts.tx_gain[TX_AUDIO_LINEIN_L]	= LINE_GAIN_DEFAULT;	// default line gain
+    ts.tx_gain[TX_AUDIO_LINEIN_R]	= LINE_GAIN_DEFAULT;	// default line gain
     ts.tx_gain[TX_AUDIO_DIG]		= LINE_GAIN_DEFAULT;	// default line gain
     ts.tx_gain[TX_AUDIO_DIGIQ]		= LINE_GAIN_DEFAULT;	// default line gain
 
@@ -155,16 +152,9 @@ void TransceiverStateInit(void)
     ts.pa_cw_bias		= PA_BIAS_DEFAULT;			// Use lowest possible voltage as default (nonzero sets separate bias for CW mode)
     ts.freq_cal			= 0;				// Initial setting for frequency calibration
     ts.power_level		= PA_LEVEL_DEFAULT;			// See uhsdr_board.h for setting
-    //
-    //	ts.codec_vol		= 0;					// Holder for codec volume
-    //	ts.codec_mute_state	= 0;					// Holder for codec mute state
-    //	ts.codec_was_muted = 0;						// Indicator that codec *was* muted
-    //
-    ts.powering_down	= 0;						// TRUE if powering down
-    //
 
-    //
-    ts.menu_item		= 0;					// start out with a reasonable menu item
+    ts.powering_down	= 0;						// TRUE if powering down
+
     //
     ts.radio_config_menu_enable = 0;				// TRUE if radio configuration menu is to be enabled
     //
@@ -177,29 +167,29 @@ void TransceiverStateInit(void)
     ts.filter_cw_wide_disable		= 0;			// TRUE if wide filters are to be disabled in CW mode
     ts.filter_ssb_narrow_disable	= 0;				// TRUE if narrow (CW) filters are to be disabled in SSB mode
     ts.demod_mode_disable			= 0;		// TRUE if AM mode is to be disabled
-    //
+
     ts.tx_meter_mode	= METER_SWR;
-    //
+
     ts.alc_decay		= ALC_DECAY_DEFAULT;			// ALC Decay (release) default value
     ts.alc_decay_var	= ALC_DECAY_DEFAULT;			// ALC Decay (release) default value
     ts.alc_tx_postfilt_gain		= ALC_POSTFILT_GAIN_DEFAULT;	// Post-filter added gain default (used for speech processor/ALC)
     ts.alc_tx_postfilt_gain_var	= ALC_POSTFILT_GAIN_DEFAULT;	// Post-filter added gain default (used for speech processor/ALC)
     ts.tx_comp_level	= 0;					// 0=Release Time/Pre-ALC gain manually adjusted, >=1:  Value calculated by this parameter
-    //
+
     ts.freq_step_config		= 0;				// disabled both marker line under frequency and swapping of STEP buttons
-    //
 
     ts.lcd_backlight_brightness = 0;			// = 0 full brightness
     ts.lcd_backlight_blanking = 0;				// MSB = 1 for auto-off of backlight, lower nybble holds time for auto-off in seconds
     ts.low_power_config = LOW_POWER_THRESHOLD_DEFAULT; // add LOW_POWER_THRESHOLD_OFFSET for voltage value
-    //
+
     ts.tune_step		= 0;					// Used for press-and-hold step size changing mode
     ts.frequency_lock	= 0;					// TRUE if frequency knob is locked
-    //
+
     ts.tx_disable		= TX_DISABLE_OFF;	    // > 0 if transmitter is to be disabled
     ts.flags1			= 0;					// Used to hold individual status flags, stored in EEPROM location "EEPROM_FLAGS1"
     ts.flags2			= 0;					// Used to hold individual status flags, stored in EEPROM location "EEPROM_FLAGS2"
     ts.sysclock			= 0;					// This counts up from zero when the unit is powered up at precisely 100 Hz over the long term.  This
+
     // is NEVER reset and is used for timing certain events.
     ts.version_number_release	= 0;			// version release - used to detect firmware change
     ts.version_number_major = 0;				// version build - used to detect firmware change
@@ -229,20 +219,12 @@ void TransceiverStateInit(void)
     ts.scope_speed      = SPECTRUM_SCOPE_SPEED_DEFAULT;     // default rate of spectrum scope update
     ts.scope_scheduler = 0;             // timer for scheduling the next update of the spectrum update
 
-    // ts.spectrum_scope_nosig_adjust = SPECTRUM_SCOPE_NOSIG_ADJUST_DEFAULT;   // Adjustment for no signal adjustment conditions for spectrum scope
-
     ts.waterfall.speed  = WATERFALL_SPEED_DEFAULT;      // default speed of update of the waterfall
     ts.waterfall.color_scheme = WATERFALL_COLOR_DEFAULT;		// color scheme for waterfall display
     ts.waterfall.vert_step_size = WATERFALL_STEP_SIZE_DEFAULT;	// step size in waterfall display
-#if 0
-    ts.waterfall.offset = WATERFALL_OFFSET_DEFAULT;			// Offset for waterfall display (brightness)
-#endif
     ts.waterfall.contrast = WATERFALL_CONTRAST_DEFAULT;		// contrast setting for waterfall display
     ts.waterfall.scheduler=0;
 
-#if 0
-    ts.waterfall.nosig_adjust = WATERFALL_NOSIG_ADJUST_DEFAULT;	// Adjustment for no signal adjustment conditions for waterfall
-#endif
 //    ts.fft_window_type = FFT_WINDOW_DEFAULT;			// FFT Windowing type
     ts.dvmode = false;							        // disable "DV" mode RX/TX functions by default
 
@@ -258,6 +240,7 @@ void TransceiverStateInit(void)
     ts.fm_tone_burst_timing = 0;					// used to time the duration of the tone burst
     ts.fm_sql_threshold = FM_SQUELCH_DEFAULT;			// squelch threshold
     ts.fm_subaudible_tone_det_select = 0;				// lookup ("tone number") used to index the table for tone detection (0 corresponds to "tone disabled")
+
     ts.beep_active = 1;						// TRUE if beep is active
     ts.beep_frequency = DEFAULT_BEEP_FREQUENCY;			// beep frequency, in Hz
     ts.beep_loudness = DEFAULT_BEEP_LOUDNESS;			// loudness of keyboard/CW sidetone test beep
@@ -282,18 +265,7 @@ void TransceiverStateInit(void)
     ts.iq_auto_correction = 1;              // disable/enable automatic IQ correction
     ts.twinpeaks_tested = TWINPEAKS_WAIT;
 
-    AudioDriver_Dsp_Init(&ts.dsp);
-    AudioAgc_InitAgcWdsp();
-
     ts.dbm_constant = 0;
-
-    ts.FDV_TX_encode_ready = false;		// FREEDV handshaking test DL2FW
-    ts.FDV_TX_samples_ready = 0;	// FREEDV handshaking test DL2FW
-    ts.FDV_TX_out_start_pt=0;
-    ts.FDV_TX_in_start_pt=0;
-	ts.new_nb = false;	// new nb OFF at poweron
-
-	NR_Init();
 
     ts.i2c_speed[I2C_BUS_1] = I2C1_SPEED_DEFAULT; // Si570, MCP9801
     ts.i2c_speed[I2C_BUS_2] = I2C2_SPEED_DEFAULT; // Codec, EEPROM
@@ -309,6 +281,7 @@ void TransceiverStateInit(void)
     }
     ts.buffered_tx = false;
     ts.cw_text_entry = false;
+
     ts.debug_si5351a_pllreset = 2;		//start with "reset on IQ Divider"
 
     ts.debug_vswr_protection_threshold = 0; // OFF
@@ -460,12 +433,6 @@ int mchfMain(void)
 
                 "Upgrade bootloader to 5.0.1 or newer");
 
-
-    AudioManagement_CalcSubaudibleGenFreq();		// load/set current FM subaudible tone settings for generation
-    AudioManagement_CalcSubaudibleDetFreq();		// load/set current FM subaudible tone settings	for detection
-    AudioManagement_LoadToneBurstMode();	// load/set tone burst frequency
-    AudioManagement_KeyBeepPrepare();		// load/set beep frequency
-
     AudioFilter_SetDefaultMemories();
 
 
@@ -481,6 +448,7 @@ int mchfMain(void)
     UiDriver_StartUpScreenFinish(2000);
 
     // We initialize the requested demodulation mode
+    // and update the screen accordingly
     UiDriver_SetDemodMode(ts.dmod_mode);
 
     // Finally, start DMA transfers to get everything going


### PR DESCRIPTION
Fixes the SAM issue in #1728 

Second commit is Restructuring and Cleanup Audio Driver Part X

- factored out some math functions
- tried to properly organize the init's
- renamed the TxProcessor functions and defined the external function
- partially renamed the functions so that they consistently use ...Init (for one time init)
  and ...Set (to be called after parameter changes). The Position of Init and Set in the names
  is not consistent yet.
- fixed few issues introduced in earlier breakup commits (affected only OVI40 UI)
- factored out some math functions

Many changes are just renames, but a significant number bear risk of breaking
things. You have been warned...