### PR TITLE
 Fix for #1730 (AGC values are not restored) and type "changes"

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_agc.c
+++ b/mchf-eclipse/drivers/audio/audio_agc.c
@@ -93,22 +93,28 @@ agc_variables_t agc_wdsp;
  */
 void AudioAgc_AgcWdsp_Init()
 {
-    agc_wdsp_conf.mode = 2;
-    agc_wdsp_conf.slope = 70;
-    agc_wdsp_conf.hang_enable = 0;
+    // the values below are all loaded from
+    // EEPROM, which happens BEFORE we get here
+    // so there is no point in setting these.
+    // agc_wdsp_conf.mode = 2;
+    // agc_wdsp_conf.slope = 70;
+    // agc_wdsp_conf.hang_enable = 0;
+    // agc_wdsp_conf.tau_decay[0] = 4000;
+    // agc_wdsp_conf.tau_decay[1] = 2000;
+    // agc_wdsp_conf.tau_decay[2] = 500;
+    // agc_wdsp_conf.tau_decay[3] = 250;
+    // agc_wdsp_conf.tau_decay[4] = 50;
+    // agc_wdsp_conf.thresh = 20;
+    // agc_wdsp_conf.tau_hang_decay = 500;
+
+    // these are not stored in volatile memory
+    // so let us initialize them here.
     agc_wdsp_conf.hang_time = 500;
     agc_wdsp_conf.hang_thresh = 45;
-    agc_wdsp_conf.thresh = 60;
     agc_wdsp_conf.action = 0;
     agc_wdsp_conf.switch_mode = 1;
     agc_wdsp_conf.hang_action = 0;
-    agc_wdsp_conf.tau_decay[0] = 4000;
-    agc_wdsp_conf.tau_decay[1] = 2000;
-    agc_wdsp_conf.tau_decay[2] = 500;
-    agc_wdsp_conf.tau_decay[3] = 250;
-    agc_wdsp_conf.tau_decay[4] = 50;
-    agc_wdsp_conf.tau_decay[5] = 500;
-    agc_wdsp_conf.tau_hang_decay = 200;
+    agc_wdsp_conf.tau_decay[5] = 1; // this is the OFF-Mode
 }
 
 /**

--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -3033,21 +3033,29 @@ void AudioDriver_I2SCallback(AudioSample_t *audio, IqSample_t *iq, AudioSample_t
         ks.debounce_time++;   // keyboard debounce timer
     }
 
+    // UiDriver_Callback_AudioISR();
+
     // Perform LCD backlight PWM brightness function
     UiDriver_BacklightDimHandler();
 
-    tcount+=CLOCKS_PER_DMA_CYCLE;		// add the number of clock cycles that would have passed between DMA cycles
-    if(tcount > CLOCKS_PER_CENTISECOND)	 	// has enough clock cycles for 0.01 second passed?
+    tcount+= SAMPLES_PER_DMA_CYCLE;        // add the number of samples that have passed in DMA cycle
+    if(tcount >= SAMPLES_PER_CENTISECOND)  // enough samples for 0.01 second passed?
     {
-        tcount -= CLOCKS_PER_CENTISECOND;	// yes - subtract that many clock cycles
+        tcount -= SAMPLES_PER_CENTISECOND;  // yes - subtract that many samples
         ts.sysclock++;	// this clock updates at PRECISELY 100 Hz over the long term
-        //
-        // Has the timing for the keyboard beep expired?
 
-        if(ts.sysclock > ts.beep_timing)
+        // Has the timing for the keyboard beep expired?
+        if(ts.beep_timing > 0 || ts.beep_active != false)
         {
-            ts.beep_active = 0;				// yes, turn the tone off
-            ts.beep_timing = 0;
+            // we kill any beep_active even if we have previously no timing set.
+            if (ts.beep_timing == 0)
+            {
+                ts.beep_active = false;				// yes, turn the tone off
+            }
+            else
+            {
+                ts.beep_timing--;
+            }
         }
     }
 

--- a/mchf-eclipse/drivers/audio/audio_driver.h
+++ b/mchf-eclipse/drivers/audio/audio_driver.h
@@ -514,8 +514,6 @@ extern uint32_t fm_tone_burst_freq[FM_TONE_BURST_MAX+1];
 #define	AUDIO_DELAY_BUFSIZE		(IQ_BUFSZ)*5	// Size of AGC delaying audio buffer - Must be a multiple of IQ_BUFSZ.
 // This is divided by the decimation rate so that the time delay is constant.
 
-#define CLOCKS_PER_DMA_CYCLE	10656			// Number of 16 MHz clock cycles per DMA cycle
-#define	CLOCKS_PER_CENTISECOND	160000			// Number of 16 MHz clock cycles per 0.01 second timing cycle
 
 #define	FREQ_IQ_CONV_MODE_OFF		0	// No frequency conversion
 #define FREQ_IQ_CONV_P6KHZ		1	// LO is 6KHz above receive frequency in RX mode

--- a/mchf-eclipse/drivers/audio/audio_management.c
+++ b/mchf-eclipse/drivers/audio/audio_management.c
@@ -374,7 +374,7 @@ void AudioManagement_KeyBeep()
     {
         AudioManagement_KeyBeepPrepare();       // load and calculate beep frequency
         ads.beep.acc = 0; // force reset of accumulator to start at zero to minimize "click" caused by an abrupt voltage transition at startup
-        ts.beep_timing = ts.sysclock + BEEP_DURATION;       // set duration of beep
+        ts.beep_timing = BEEP_DURATION;       // set duration of beep
         ts.beep_active = 1;                                 // activate tone
     }
 }

--- a/mchf-eclipse/drivers/audio/tx_processor.c
+++ b/mchf-eclipse/drivers/audio/tx_processor.c
@@ -1050,8 +1050,20 @@ void TxProcessor_Run(AudioSample_t * const srcCodec, IqSample_t * const dst, Aud
         {
             // 16 bit format - convert to float and increment
             // we collect our I/Q samples for USB transmission if TX_AUDIO_DIGIQ
-            audio_in_put_buffer(src[i].r);
-            audio_in_put_buffer(src[i].l);
+            if (srcUSB == src)
+            {
+                // we can use the USB data as is (no need to convert back/to
+                // the weird format the F4 delivers us 32bit I2S
+                audio_in_put_buffer(src[i].r);
+                audio_in_put_buffer(src[i].l);
+            }
+            else
+            {
+                // get audio from I2S and need to convert back/to
+                // the weird format the F4 delivers us 32bit I2S (no conversion happens on F7/H7)
+                audio_in_put_buffer(correctHalfWord(src[i].r) >> IQ_BIT_SHIFT);
+                audio_in_put_buffer(correctHalfWord(src[i].l) >> IQ_BIT_SHIFT);
+            }
         }
         break;
     case STREAM_TX_AUDIO_FILT:

--- a/mchf-eclipse/drivers/ui/menu/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu.c
@@ -1166,13 +1166,13 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
        break;
 
      case MENU_DBM_CALIBRATE:      //
-        var_change = UiDriverMenuItemChangeInt(var, mode, &ts.dbm_constant,
+        var_change = UiDriverMenuItemChangeInt32(var, mode, &ts.dbm_constant,
                                             -100,
                                             100,
                                             0,
                                             1
                                            );
-        snprintf(options, 32, "  %ddB", ts.dbm_constant);
+        snprintf(options, 32, "  %lddB", ts.dbm_constant);
         break;
 
      case MENU_UI_INVERSE_SCROLLING:      //

--- a/mchf-eclipse/hardware/uhsdr_board.c
+++ b/mchf-eclipse/hardware/uhsdr_board.c
@@ -516,7 +516,7 @@ __attribute__ ((noinline)) bool is_ram_at(volatile uint32_t* where) {
     return retval;
 }
 
-unsigned int Board_RamSizeGet() {
+uint32_t Board_RamSizeGet() {
     uint32_t retval = 0;
     // we enable the bus fault
     // we now get bus faults if we access not  available  memory

--- a/mchf-eclipse/hardware/uhsdr_board.h
+++ b/mchf-eclipse/hardware/uhsdr_board.h
@@ -30,7 +30,7 @@ struct mchf_waterfall
     uint8_t	color_scheme;			// stores waterfall color scheme
     uint8_t	vert_step_size;		// vertical step size in waterfall mode
     // int32_t	offset;			// offset for waterfall display
-    ulong	contrast;			// contrast setting for waterfall display
+    uint32_t	contrast;			// contrast setting for waterfall display
 	uint8_t	speed;	// speed of update of the waterfall
 	// uint8_t	nosig_adjust;			// Adjustment for no signal adjustment conditions for waterfall
 	uint16_t scheduler;
@@ -198,7 +198,7 @@ typedef struct Gain_s
     uint8_t value;
     uint8_t max;
     uint8_t value_old;
-    float   active_value;
+    float32_t   active_value;
 } Gain;
 
 typedef struct {
@@ -236,16 +236,16 @@ typedef struct vfo_reg_s
 typedef struct TransceiverState
 {
     // Sampling rate public flag
-    ulong 	samp_rate;
+    uint32_t 	samp_rate;
 
     // Virtual pots public values
-    short  	rit_value;
+    int16_t  	rit_value;
 
 #define RX_AUDIO_SPKR 0
 #define RX_AUDIO_DIG  1
     Gain    rx_gain[2]; //ts.rx_gain[RX_AUDIO_SPKR].value
 
-    int 	rf_gain;			// RF gain control
+    int32_t 	rf_gain;			// RF gain control
     uint8_t lineout_gain;            // lineout gain to control lineout level
 
 
@@ -271,11 +271,11 @@ typedef struct TransceiverState
     int	freq_cal;				// frequency calibration
 
     // Frequency synthesizer
-    ulong	tune_freq;			// main synthesizer frequency
-    ulong	tune_freq_req;		// used to detect change of main synthesizer frequency
+    uint32_t	tune_freq;			// main synthesizer frequency
+    uint32_t	tune_freq_req;		// used to detect change of main synthesizer frequency
 
     // Transceiver calibration mode flag
-    //uchar	calib_mode;
+    //uint8_t	calib_mode;
 
     // Transceiver menu mode variables
     uint8_t	menu_mode;		// TRUE if in menu mode
@@ -311,7 +311,7 @@ typedef struct TransceiverState
     uint8_t	tx_meter_mode;				// meter mode
 
     // Audio filter ID
-    // uchar	filter_id;
+    // uint8_t	filter_id;
     //
     uint8_t   filter_select[AUDIO_FILTER_NUM];
 
@@ -367,14 +367,14 @@ typedef struct TransceiverState
 #define CW_SIDETONE_FREQ_MIN        400
 #define CW_SIDETONE_FREQ_MAX        1000
 
-    ulong	audio_spkr_unmute_delay_count;
+    uint32_t	audio_spkr_unmute_delay_count;
 
     uint8_t	power_level; // an abstract power level id
     int32_t power; // the actual request power in mW
     bool    power_modified; // the actual power is lower than the requested power_level, e.g. because of out side band.
 
     uint8_t 	tx_audio_source;
-    ulong	tx_mic_gain_mult;
+    uint32_t	tx_mic_gain_mult;
     uint8_t	tx_gain[TX_AUDIO_NUM];
     int16_t	tx_comp_level;			// Used to hold compression level which is used to calculate other values for compression.  0 = manual.
 
@@ -409,7 +409,7 @@ typedef struct TransceiverState
     bool	radio_config_menu_enable;	// TRUE if radio configuration menu is to be visible
     //
     uint8_t	xverter_mode;		// TRUE if transverter mode active
-    ulong	xverter_offset;		// frequency offset for transverter (added to frequency display)
+    uint32_t	xverter_offset;		// frequency offset for transverter (added to frequency display)
 
     bool	refresh_freq_disp;		// TRUE if frequency display display is to be refreshed
     //
@@ -419,10 +419,10 @@ typedef struct TransceiverState
 #define ADJ_FULL_POWER 1
     uint8_t	pwr_adj[2][MAX_BAND_NUM];
     //
-    ulong	alc_decay;					// adjustable ALC release time - EEPROM read/write version
-    ulong	alc_decay_var;				// adjustable ALC release time - working variable version
-    ulong	alc_tx_postfilt_gain;		// amount of gain after the TX audio filtering - EEPROM read/write version
-    ulong	alc_tx_postfilt_gain_var;	// amount of gain after the TX audio filtering - working variable version
+    uint32_t	alc_decay;					// adjustable ALC release time - EEPROM read/write version
+    uint32_t	alc_decay_var;				// adjustable ALC release time - working variable version
+    uint32_t	alc_tx_postfilt_gain;		// amount of gain after the TX audio filtering - EEPROM read/write version
+    uint32_t	alc_tx_postfilt_gain_var;	// amount of gain after the TX audio filtering - working variable version
 
 // we can use AT least the upper 8 bits of freq_step_config for other purpose since these have not been used and are all initialized with 0)
 #define FREQ_STEP_SWAP_BTN	    0x10
@@ -455,10 +455,10 @@ typedef struct TransceiverState
 
 
     uint8_t   low_power_config;        // for voltage colours and auto shutdown
-    ulong   low_power_shutdown_time;    // earliest time when auto shutdown can be executed
+    uint32_t   low_power_shutdown_time;    // earliest time when auto shutdown can be executed
     //
     uint8_t	tune_step;					// Used for press-and-hold tune step adjustment
-    ulong	tune_step_idx_holder;		// used to hold the original step size index during the press-and-hold
+    uint32_t	tune_step_idx_holder;		// used to hold the original step size index during the press-and-hold
     //
     bool	frequency_lock;				// TRUE if frequency knob is locked
     //
@@ -522,8 +522,8 @@ typedef struct TransceiverState
     int32_t	iq_freq_mode;				// used to set/configure the I/Q frequency/conversion mode
     uint8_t	lsb_usb_auto_select;			// holds setting of LSB/USB auto-select above/below 10 MHz
     bool	conv_sine_flag;				// FALSE until the sine tables for the frequency conversion have been built (normally zero, force 0 to rebuild)
-    ulong	last_tuning;				// this is a timer used to prevent too fast tuning per second
-    ulong	lcd_blanking_time;			// this holds the system time after which the LCD is blanked - if blanking is enabled
+    uint32_t	last_tuning;				// this is a timer used to prevent too fast tuning per second
+    uint32_t	lcd_blanking_time;			// this holds the system time after which the LCD is blanked - if blanking is enabled
     bool	lcd_blanking_flag;			// if TRUE, the LCD is blanked completely (e.g. backlight is off)
     bool	xvtr_adjust_flag;			// set TRUE if transverter offset adjustment is in process
     bool	SpectrumResize_flag;		// set TRUE if waterfall/spectrum resize request from touchscreen action
@@ -532,10 +532,10 @@ typedef struct TransceiverState
     uint32_t SpectrumResize_timer;		//
 #define VFO_MEM_MODE_SPLIT 0x80
 #define VFO_MEM_MODE_VFO_B 0x40
-    ulong	vfo_mem_mode;				// this is used to record the VFO/memory mode (0 = VFO "A" = backwards compatibility)
+    uint32_t	vfo_mem_mode;				// this is used to record the VFO/memory mode (0 = VFO "A" = backwards compatibility)
     // LSB+6 (0x40):  0 = VFO A, 1 = VFO B
     // LSB+7 (0x80): 0 = normal mode, 1 = Split mode (e.g. LSB=0:  RX=A, TX=B;  LSB=1:  RX=B, TX=A)
-    ulong	voltmeter_calibrate;			// used to calibrate the voltmeter
+    uint32_t	voltmeter_calibrate;			// used to calibrate the voltmeter
 
 
     bool	dvmode;					// TRUE if alternate (stripped-down) RX and TX functions (USB-only) are to be used
@@ -546,15 +546,15 @@ typedef struct TransceiverState
     bool	audio_dac_muting_flag;			// when TRUE, audio is to be muted after PTT/keyup
     bool	vfo_mem_flag;				// when TRUE, memory mode is enabled
     bool	mem_disp;				// when TRUE, memory display is enabled
-    ulong	fm_subaudible_tone_gen_select;		// lookup ("tone number") used to index the table tone generation (0 corresponds to "tone disabled")
+    uint32_t	fm_subaudible_tone_gen_select;		// lookup ("tone number") used to index the table tone generation (0 corresponds to "tone disabled")
     uint8_t	fm_tone_burst_mode;			// this is the setting for the tone burst generator
-    ulong	fm_tone_burst_timing;			// this is used to time/schedule the duration of a tone burst
+    uint32_t	fm_tone_burst_timing;			// this is used to time/schedule the duration of a tone burst
     uint8_t	fm_sql_threshold;			// squelch threshold "dial" setting
-//	uchar	fm_rx_bandwidth;			// bandwidth setting for FM reception
-    ulong	fm_subaudible_tone_det_select;		// lookup ("tone number") used to index the table for tone detection (0 corresponds to "disabled")
+//	uint8_t	fm_rx_bandwidth;			// bandwidth setting for FM reception
+    uint32_t	fm_subaudible_tone_det_select;		// lookup ("tone number") used to index the table for tone detection (0 corresponds to "disabled")
     bool	beep_active;				// TRUE if beep is active
-    ulong	beep_frequency;				// beep frequency, in Hz
-    ulong	beep_timing;				// used to time/schedule the duration of a keyboard beep
+    uint32_t	beep_frequency;				// beep frequency, in Hz
+    uint32_t	beep_timing;				// used to time/schedule the duration of a keyboard beep
     uint8_t	beep_loudness;				// loudness of the keyboard/CW sidetone test beep
 
 #define EEPROM_SER_NONE 0
@@ -578,7 +578,7 @@ typedef struct TransceiverState
     uint8_t	xlat;					// CAT <> IQ-Audio
 
 //    bool	dBm_Hz_Test;			// for testing only
-//    ulong	dBm_count;				// timer for calculating RX dBm
+//    uint32_t	dBm_count;				// timer for calculating RX dBm
     uint8_t 	display_dbm;			// display dbm or dbm/Hz or OFF
     uint8_t	s_meter;				// defines S-Meter style/configuration
 	uint8_t	meter_colour_up;
@@ -598,7 +598,7 @@ typedef struct TransceiverState
 	uint8_t twinpeaks_tested;
 
 
-    int dbm_constant;
+    int32_t dbm_constant;
 
 //#define DISPLAY_S_METER_STD   0
 #define DISPLAY_S_METER_DBM   1
@@ -615,7 +615,7 @@ typedef struct TransceiverState
 
     uint32_t audio_int_counter;		// used for encoder timing - test DL2FW
     bool encoder3state;
-    int bc_band;
+    int32_t bc_band;
 
     Oscillator_ResultCodes_t last_lo_result;			// used in dynamic tuning to hold frequency color
 
@@ -696,7 +696,7 @@ extern __IO TransceiverState ts;
 
 #define non_os_delay()						\
 do {							\
-  register unsigned int i;				\
+  register uint32_t i;				\
   for (i = 0; i < 1000000; ++i)				\
     __asm__ __volatile__ ("nop\n\t":::"memory");	\
 } while (0)
@@ -735,12 +735,12 @@ void Board_BlueLed(ledstate_t state);
 bool Board_PttDahLinePressed();
 bool Board_DitLinePressed();
 
-unsigned int Board_RamSizeGet();
+uint32_t Board_RamSizeGet();
 void Board_RamSizeDetection();
 void Board_TouchscreenInit();
 const char* Board_BootloaderVersion();
 // in main.c
-void CriticalError(ulong error);
+void CriticalError(uint32_t error);
 
 bool is_vfo_b();
 

--- a/mchf-eclipse/hardware/uhsdr_board_config.h
+++ b/mchf-eclipse/hardware/uhsdr_board_config.h
@@ -208,6 +208,11 @@
 #define IQ_BLOCK_SIZE (IQ_SAMPLE_RATE/IQ_INTERRUPT_FREQ)
 #define AUDIO_BLOCK_SIZE (AUDIO_SAMPLE_RATE/IQ_INTERRUPT_FREQ)
 
+// use for clocking based on DMA IRQ
+#define SAMPLES_PER_DMA_CYCLE   (IQ_BLOCK_SIZE)
+#define SAMPLES_PER_CENTISECOND (IQ_SAMPLE_RATE/100)
+
+
 #if (IQ_SAMPLE_RATE) != 48000
     #error Only 48k sample frequency supported (yet).
 #endif

--- a/mchf-eclipse/src/uhsdr_main.c
+++ b/mchf-eclipse/src/uhsdr_main.c
@@ -241,9 +241,7 @@ void TransceiverStateInit(void)
     ts.fm_sql_threshold = FM_SQUELCH_DEFAULT;			// squelch threshold
     ts.fm_subaudible_tone_det_select = 0;				// lookup ("tone number") used to index the table for tone detection (0 corresponds to "tone disabled")
 
-    ts.beep_active = 1;						// TRUE if beep is active
-    ts.beep_frequency = DEFAULT_BEEP_FREQUENCY;			// beep frequency, in Hz
-    ts.beep_loudness = DEFAULT_BEEP_LOUDNESS;			// loudness of keyboard/CW sidetone test beep
+    ts.beep_active = false;	// TRUE if beep is active, we don't beep at start so it must be 0
 
     ts.ser_eeprom_type = 0;						// serial eeprom not present
     ts.configstore_in_use = CONFIGSTORE_IN_USE_FLASH;					// serial eeprom not in use


### PR DESCRIPTION
This fix is necessary, because I changed the order of initiallization
  (first load config values AND AFTER THAT run the initialization using the
   load parameters ) but some code overwrote already loaded config values
   which previously was not visible since this code was executed BEFORE we
   loaded config values...