### PR TITLE
Fix for #1736 (DSP mode and parameters not saved)

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -582,23 +582,25 @@ void AudioDriver_LeakyLmsNr (float32_t *in_buff, float32_t *out_buff, int buff_s
 
 static void AudioDriver_Dsp_Init(volatile dsp_params_t* dsp_p)
 {
-    dsp_p->active       = 0;                    // TRUE if DSP noise reduction is to be enabled
-    ts.digital_mode     = DigitalMode_None;                 // digital modes OFF by default
-    dsp_p->active_toggle    = 0xff;                 // used to hold the button G2 "toggle" setting.
-    dsp_p->nr_strength  = 50;                   // "Strength" of DSP noise reduction (50 = medium)
-#ifdef USE_LMS_AUTONOTCH
-    dsp_p->notch_numtaps = DSP_NOTCH_NUMTAPS_DEFAULT;       // default for number of FFT taps for notch filter
-    dsp_p->notch_delaybuf_len = DSP_NOTCH_DELAYBUF_DEFAULT;
-    dsp_p->notch_mu = DSP_NOTCH_MU_DEFAULT;
-#endif
-    dsp_p->notch_frequency = 800;               // notch start frequency for manual notch filter
-    dsp_p->peak_frequency = 750;                // peak start frequency
-    dsp_p->nb_setting       = 0;                    // Noise Blanker setting
 
-    dsp_p->bass_gain = 2;                       // gain of the low shelf EQ filter
-    dsp_p->treble_gain = 0;                     // gain of the high shelf EQ filter
-    dsp_p->tx_bass_gain = 4;                    // gain of the TX low shelf EQ filter
-    dsp_p->tx_treble_gain = 4;                  // gain of the TX high shelf EQ filter
+    dsp_p->active_toggle    = 0xff;                 // used to hold the button G2 "toggle" setting.
+
+    // Commented settings below are read from configuration store, no need to initialize them
+    // dsp_p->active       = 0;                    // TRUE if DSP noise reduction is to be enabled
+    // dsp_p->nr_strength  = 50;                   // "Strength" of DSP noise reduction (50 = medium)
+#ifdef USE_LMS_AUTONOTCH
+    // dsp_p->notch_numtaps = DSP_NOTCH_NUMTAPS_DEFAULT;       // default for number of FFT taps for notch filter
+    // dsp_p->notch_delaybuf_len = DSP_NOTCH_DELAYBUF_DEFAULT;
+    // dsp_p->notch_mu = DSP_NOTCH_MU_DEFAULT;
+#endif
+    // dsp_p->notch_frequency = 800;               // notch start frequency for manual notch filter
+    // dsp_p->peak_frequency = 750;                // peak start frequency
+    // dsp_p->nb_setting       = 0;                    // Noise Blanker setting
+
+    // dsp_p->bass_gain = 2;                       // gain of the low shelf EQ filter
+    // dsp_p->treble_gain = 0;                     // gain of the high shelf EQ filter
+    // dsp_p->tx_bass_gain = 4;                    // gain of the TX low shelf EQ filter
+    // dsp_p->tx_treble_gain = 4;                  // gain of the TX high shelf EQ filter
 }
 /**
  * One-time init of FreeDV codec's audio driver part, mostly filters

--- a/mchf-eclipse/drivers/audio/audio_nr.c
+++ b/mchf-eclipse/drivers/audio/audio_nr.c
@@ -76,24 +76,27 @@ void NR_Init()
 {
     nr_params.alpha = 0.94; // spectral noise reduction
     nr_params.beta = 0.96;
-//  nr_params.vad_thresh = 4.0;
     nr_params.enable = false;
     nr_params.NR_FFT_L = 256;
     nr_params.NR_FFT_LOOP_NO = 1;
-//  nr_params.gain_smooth_enable = false;
-//  nr_params.gain_smooth_alpha = 0.25;
-//  nr_params.long_tone_enable = false;
-//  nr_params.long_tone_alpha = 0.999;
-//  nr_params.long_tone_thresh = 10000;
-//  nr_params.long_tone_reset = true;
+
     nr_params.first_time = 1;
-//  nr_params.vad_delay = 7;
     nr_params.NR_decimation_enable = true;
     nr_params.fft_256_enable = true;
     ts.special_functions_enabled = 0;
     NR2.width = 4;
     NR2.power_threshold = 0.40;
     NR2.asnr = 30;
+
+    // TODO: Decide to through out these unused parameters
+    //  nr_params.gain_smooth_enable = false;
+    //  nr_params.gain_smooth_alpha = 0.25;
+    //  nr_params.long_tone_enable = false;
+    //  nr_params.long_tone_alpha = 0.999;
+    //  nr_params.long_tone_thresh = 10000;
+    //  nr_params.long_tone_reset = true;
+    //  nr_params.vad_thresh = 4.0;
+    //  nr_params.vad_delay = 7;
 }
 
 #if 0


### PR DESCRIPTION
- again the moved init code overwrote previously config loaded from EEPROM

Now tried to identify all other potential overwriting of config parameters
but could not find more (yet).