### PR TITLE
Fix for NR mutes everything on STM32H7

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -2430,6 +2430,10 @@ static void AudioDriver_RxProcessorNoiseReduction(uint16_t blockSizeDecim, float
             NR_out_buffer_peek(&out_buffer);
         }
     }
+    else
+    {
+        memset(NR_dec_buffer,0,sizeof(NR_dec_buffer));
+    }
 
 
     // interpolation of a_buffer from 6ksps to 12ksps!


### PR DESCRIPTION
This was an interesting issue accidentially only affecting the H7.
We have to fill the buffer with silence if we are not getting a buffer