### PR TITLE
Fix for #1750 After Tune Power Display is not restored

### DIFF
--- a/mchf-eclipse/drivers/ui/radio_management.c
+++ b/mchf-eclipse/drivers/ui/radio_management.c
@@ -377,12 +377,12 @@ bool RadioManagement_Tune(bool tune)
         }
         else
         {
+            RadioManagement_SwitchTxRx(TRX_MODE_RX,true);                // tune OFF
             if(ts.tune_power_level != PA_LEVEL_TUNE_KEEP_CURRENT)
             {
-                ts.power_level = ts.power_temp; // restore tx level
+                RadioManagement_SetPowerLevel(RadioManagement_GetBand(df.tune_new), ts.power_temp);
             }
 
-            RadioManagement_SwitchTxRx(TRX_MODE_RX,true);                // tune OFF
             retval = (ts.txrx_mode == TRX_MODE_TX); // no longer tuning
         }
     }


### PR DESCRIPTION
If the tune power was not set identical to TX power, the display of the TX
did not return to the set TX power.