### PR TITLE
Fix for #1749 (FreeDV crashes on mcHF / STM32F4)

### DIFF
--- a/mchf-eclipse/Makefile
+++ b/mchf-eclipse/Makefile
@@ -100,7 +100,7 @@ ifeq ($(OS),Darwin)
   SED = gsed
 endif
 
-COMPILEFLAGS := -D_GNU_SOURCE -DTRX_ID=\"$(TRX_ID)\" -DTRX_NAME=\"$(TRX_NAME)\" $(CONFIGFLAGS) -DUSE_HAL_DRIVER \
+COMPILEFLAGS := -D_GNU_SOURCE -DTRX_ID=\"$(TRX_ID)\" -DTRX_NAME=\"$(TRX_NAME)\" $(CONFIGFLAGS) -DUSE_HAL_DRIVER -DFDV_ARM_MATH \
 	-ffunction-sections -fdata-sections -flto -Wall -Wuninitialized -Wextra -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -g3
 
 # identifying of "official builds by DF8OE"


### PR DESCRIPTION
A newly introduced build flag for FreeDV optimization (FDV_ARM_MATH) was
not set in the Makefile only in Eclipse. Shame on me (I added this flag to
Eclipse only)...