### PR TITLE
Added proper dependency generation to Makefile and FreeDV mode selection

### DIFF
--- a/mchf-eclipse/Makefile
+++ b/mchf-eclipse/Makefile
@@ -59,7 +59,6 @@ ifeq ($(BUILDFOR),H7)
 endif
 
 ROOTLOC=.
-vpath %.h $(ROOTLOC)
 vpath %.c $(ROOTLOC)
 vpath %.cpp $(ROOTLOC)
 vpath %.S $(ROOTLOC)
@@ -100,7 +99,8 @@ ifeq ($(OS),Darwin)
   SED = gsed
 endif
 
-COMPILEFLAGS := -D_GNU_SOURCE -DTRX_ID=\"$(TRX_ID)\" -DTRX_NAME=\"$(TRX_NAME)\" $(CONFIGFLAGS) -DUSE_HAL_DRIVER -DFDV_ARM_MATH \
+COMPILEFLAGS := -D_GNU_SOURCE -DTRX_ID=\"$(TRX_ID)\" -DTRX_NAME=\"$(TRX_NAME)\" $(CONFIGFLAGS) -DUSE_HAL_DRIVER\
+	-DFDV_ARM_MATH -DFREEDV_MODE_EN_DEFAULT=0 -DFREEDV_MODE_1600_EN=1 -DCODEC2_MODE_EN_DEFAULT=0 -DCODEC2_MODE_1300_EN=1\
 	-ffunction-sections -fdata-sections -flto -Wall -Wuninitialized -Wextra -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare -g3
 
 # identifying of "official builds by DF8OE"
@@ -114,8 +114,8 @@ MACHFLAGS_F7 := -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-d16    -mthumb -DARM
 MACHFLAGS_H7 := -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-d16    -mthumb -DARM_MATH_CM7 -DCORTEX_M7 -DSTM32H743xx -D__FPU_PRESENT=1
 
 BASECFLAGS_F4  = $(MACHFLAGS_F4)  $(COMPILEFLAGS) $(EXTRACFLAGS)
-BASECFLAGS_F7  = $(MACHFLAGS_F7)  $(COMPILEFLAGS) $(EXTRACFLAGS)
-BASECFLAGS_H7  = $(MACHFLAGS_H7)  $(COMPILEFLAGS) $(EXTRACFLAGS)
+BASECFLAGS_F7  = $(MACHFLAGS_F7)  $(COMPILEFLAGS) $(EXTRACFLAGS) -DFREEDV_MODE_700D_EN=1 -DCODEC2_MODE_700C_EN=1
+BASECFLAGS_H7  = $(MACHFLAGS_H7)  $(COMPILEFLAGS) $(EXTRACFLAGS) -DFREEDV_MODE_700D_EN=1 -DCODEC2_MODE_700C_EN=1
 
 LINKERLOC=$(ROOTLOC)/linker
 
@@ -217,6 +217,9 @@ OC      = $(VPRE)$(PREFIX)arm-none-eabi-objcopy
 SZ      = $(VPRE)$(PREFIX)arm-none-eabi-size
 HEX2DFU = $(VPRE)python $(ROOTLOC)/support/hex2dfu/hex2dfu.py
 
+POSTCOMPILE = @mv -f $*.Td $*.d && touch $@
+DEPFLAGS = -MT $@ -MMD -MP -MF $*.Td
+
 
 ECHO = @echo
 
@@ -229,11 +232,16 @@ else
 endif
 
 # how to compile individual object files
+ALL_SRC:=$(SRC) $(DSPLIB_SRC) $(HAL_SRC) $(BL_SRC) $(BL_HAL_SRC)
+
 OBJS := $(patsubst %.S,%.o,$(patsubst %.c,%.o,$(SRC:.cpp=.o)))
 DSPLIB_OBJS := $(patsubst %.S,%.o,$(patsubst %.c,%.o,$(DSPLIB_SRC:.cpp=.o)))
 HAL_OBJS := $(patsubst %.S,%.o,$(patsubst %.c,%.o,$(HAL_SRC:.cpp=.o)))
 BL_OBJS := $(patsubst %.S,%.o,$(patsubst %.cpp,%.o,$(BL_SRC:.c=.o)))
 BL_HAL_OBJS := $(patsubst %.S,%.o,$(patsubst %.cpp,%.o,$(BL_HAL_SRC:.c=.o)))
+
+ALL_OBJS := $(patsubst %.S,%.o,$(patsubst %.c,%.o,$(ALL_SRC:.cpp=.o)))
+
 
 $(DSPLIB_OBJS): EXTRA_CFLAGS:= -Wno-strict-aliasing
 basesw/%/usbh_mtp.o: CFLAGS += -Wno-implicit-fallthrough
@@ -244,24 +252,29 @@ basesw/%stm32f4xx_ll_usb.o: CFLAGS += -Wno-attributes
 basesw/%stm32f7xx_ll_usb.o: CFLAGS += -Wno-attributes
 basesw/%stm32h7xx_ll_usb.o: CFLAGS += -Wno-attributes
 
-.S.o:
+.S.o: %.d
 	$(ECHO) "  [CC] $@"
 	@mkdir -p $(subst $(ROOTLOC)/,,$(shell dirname $<))
-	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) -std=gnu11 -c ${INC_DIRS} $< -o $@
-.c.o:
+	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) $(DEPFLAGS) -std=gnu11 -c ${INC_DIRS} $< -o $@
+	$(POSTCOMPILE)
+
+.c.o: %.d
 	$(ECHO) "  [CC] $@"
 	@mkdir -p $(subst $(ROOTLOC)/,,$(shell dirname $<))
-	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) -std=gnu11 -c ${INC_DIRS} $< -o $@
+	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) $(DEPFLAGS) -std=gnu11 -c ${INC_DIRS} $< -o $@
+	$(POSTCOMPILE)
 
-.cxx.o:
+.cxx.o: %.d
 	$(ECHO) "  [CXX] $@"
 	@mkdir -p $(subst $(ROOTLOC)/,,$(shell dirname $<))
-	$(CXX) $(CFLAGS) $(CXXFLAGS) -std=gnu++11 -c ${INC_DIRS} $< -o $@
+	$(CXX) $(CFLAGS) $(CXXFLAGS) $(DEPFLAGS) -std=gnu++11 -c ${INC_DIRS} $< -o $@
+	$(POSTCOMPILE)
 
-.cpp.o:
+.cpp.o: %.d
 	$(ECHO) "  [CXX] $@"
 	@mkdir -p $(subst $(ROOTLOC)/,,$(shell dirname $<))
-	$(CXX) $(CFLAGS) $(CXXFLAGS) -std=gnu++11 -c ${INC_DIRS} $< -o $@
+	$(CXX) $(CFLAGS) $(CXXFLAGS) $(DEPFLAGS) -std=gnu++11 -c ${INC_DIRS} $< -o $@
+	$(POSTCOMPILE)
 
 %.bin: %.elf
 	$(ECHO) "  [OBJC] $@"
@@ -277,6 +290,12 @@ basesw/%stm32h7xx_ll_usb.o: CFLAGS += -Wno-attributes
 	$(ECHO) "  [H2D] $@"
 	$(SZ) $<
 	$(HEX2DFU) $< $@
+
+%.d: ;
+
+.PRECIOUS: %.d
+
+include $(wildcard $(patsubst %,%.d,$(basename $(ALL_SRC))))
 
 # ---------------------------------------------------------
 #  BUILT-IN HELP
@@ -396,11 +415,7 @@ handbook-ui-menu-clean:
 
 handy:  
 	# rm all .o (but not executables, .map and .dmp)
-	$(RM) $(call FixPath,$(OBJS))
-	$(RM) $(call FixPath,$(DSPLIB_OBJS))
-	$(RM) $(call FixPath,$(HAL_OBJS))
-	$(RM) $(call FixPath,$(BL_OBJS))
-	$(RM) $(call FixPath,$(BL_HAL_OBJS))
+	$(RM) $(call FixPath,$(ALL_OBJS))
 	$(RM) $(call FixPath,*~)
 
 release:  

--- a/mchf-eclipse/drivers/freedv/codec2.h
+++ b/mchf-eclipse/drivers/freedv/codec2.h
@@ -48,6 +48,57 @@
 #define CODEC2_MODE_450 	10
 #define CODEC2_MODE_450PWB 	11
 
+#ifndef CODEC2_MODE_EN_DEFAULT
+#define CODEC2_MODE_EN_DEFAULT 1
+#endif
+
+// by default we enable all modes
+// disable during compile time with -DCODEC2_MODE_1600_EN=0
+// all but CODEC2 1600 are enabled then
+
+//or the other way round
+// -DCODEC2_MODE_EN_DEFAULT=0 -DCODEC2_MODE_1600_EN=1
+// only CODEC2 Mode 1600
+
+#if !defined(CODEC2_MODE_3200_EN)
+        #define CODEC2_MODE_3200_EN CODEC2_MODE_EN_DEFAULT
+#endif
+#if !defined(CODEC2_MODE_2400_EN)
+        #define CODEC2_MODE_2400_EN CODEC2_MODE_EN_DEFAULT
+#endif
+#if !defined(CODEC2_MODE_1600_EN)
+        #define CODEC2_MODE_1600_EN CODEC2_MODE_EN_DEFAULT
+#endif
+#if !defined(CODEC2_MODE_1400_EN)
+        #define CODEC2_MODE_1400_EN CODEC2_MODE_EN_DEFAULT
+#endif
+#if !defined(CODEC2_MODE_1300_EN)
+        #define CODEC2_MODE_1300_EN CODEC2_MODE_EN_DEFAULT
+#endif
+#if !defined(CODEC2_MODE_1200_EN)
+        #define CODEC2_MODE_1200_EN CODEC2_MODE_EN_DEFAULT
+#endif
+#if !defined(CODEC2_MODE_700_EN)
+        #define CODEC2_MODE_700_EN CODEC2_MODE_EN_DEFAULT
+#endif
+#if !defined(CODEC2_MODE_700B_EN)
+        #define CODEC2_MODE_700B_EN CODEC2_MODE_EN_DEFAULT
+#endif
+#if !defined(CODEC2_MODE_700C_EN)
+        #define CODEC2_MODE_700C_EN CODEC2_MODE_EN_DEFAULT
+#endif
+#if !defined(CODEC2_MODE_WB_EN)
+        #define CODEC2_MODE_WB_EN CODEC2_MODE_EN_DEFAULT
+#endif
+#if !defined(CODEC2_MODE_450_EN)
+        #define CODEC2_MODE_450_EN CODEC2_MODE_EN_DEFAULT
+#endif
+#if !defined(CODEC2_MODE_450PWB_EN)
+        #define CODEC2_MODE_450PWB_EN CODEC2_MODE_EN_DEFAULT
+#endif
+
+#define CODEC2_MODE_ACTIVE(mode_name, var)  ((mode_name##_EN) == 0 ? 0: (var) == mode_name)
+
 struct CODEC2;
 
 struct CODEC2 *  codec2_create(int mode);

--- a/mchf-eclipse/drivers/freedv/codec2_fft.h
+++ b/mchf-eclipse/drivers/freedv/codec2_fft.h
@@ -14,11 +14,10 @@
 #include <string.h>
 #include <math.h>
 
-
 #ifdef FDV_ARM_MATH
   #include "fdv_arm_math.h"
 #else
-  #define USE_KISS_FFT
+    #define USE_KISS_FFT
 #endif
 
 #include "defines.h"
@@ -86,7 +85,7 @@ static inline void codec2_fft(codec2_fft_cfg cfg, codec2_fft_cpx* in, codec2_fft
       kiss_fft(cfg, (kiss_fft_cpx*)in, (kiss_fft_cpx*)out);
 #else
     memcpy(out,in,cfg->instance->fftLen*2*sizeof(float));
-    arm_cfft_f32(cfg->instance,(float*)out,cfg->inverse,1);
+    arm_cfft_f32(cfg->instance,(float*)out,cfg->inverse, 1);
     // TODO: this is not nice, but for now required to keep changes minimal
     // however, since main goal is to reduce the memory usage
     // we should convert to an in place interface

--- a/mchf-eclipse/drivers/freedv/codec2_internal.h
+++ b/mchf-eclipse/drivers/freedv/codec2_internal.h
@@ -88,6 +88,11 @@ struct CODEC2 {
 
     /* used to dump features for deep learning experiments */
     FILE *flspEWov;
+
+    /* encode/decode function pointers for the selected mode */
+    void (*encode)(struct CODEC2 *c2, unsigned char * bits, short speech[]);
+    void (*decode)(struct CODEC2 *c2, short speech[], const unsigned char * bits);
+    void (*decode_ber)(struct CODEC2 *c2, short speech[], const unsigned char * bits, float ber_est);
 };
 
 // test and debug

--- a/mchf-eclipse/drivers/freedv/codec2_ofdm.h
+++ b/mchf-eclipse/drivers/freedv/codec2_ofdm.h
@@ -36,7 +36,8 @@ extern "C" {
     
 #include <complex.h>
 #include <stdbool.h>
-    
+#include <stdint.h>
+  
 #include "comp.h"
 #include "modem_stats.h"
 
@@ -44,21 +45,13 @@ extern "C" {
 
 #define OFDM_AMP_SCALE (2E5*1.1491/1.06)   /* use to scale to 16 bit short */
 #define OFDM_CLIP (32767*0.35)             /* experimentally derived constant to reduce PAPR to about 8dB */
+
+#define UN_SYNC      0  /* Used with the ofdm_set_sync() */
+#define AUTO_SYNC    1
+#define MANUAL_SYNC  2
     
 struct OFDM_CONFIG;
 struct OFDM;
-
-typedef enum {
-    search,
-    trial,
-    synced
-} State;
-
-typedef enum {
-    unsync,             /* force sync state machine to lose sync, and search for new sync */
-    autosync,           /* falls out of sync automatically */
-    manualsync          /* fall out of sync only under operator control */
-} Sync;
 
 /* create and destroy modem states */
 
@@ -72,7 +65,7 @@ void ofdm_demod(struct OFDM *, int *, COMP *);
 void ofdm_demod_shorts(struct OFDM *, int *, short *, float);
 int  ofdm_sync_search(struct OFDM *, COMP *);
 int  ofdm_sync_search_shorts(struct OFDM *, short *, float);
-void ofdm_sync_state_machine(struct OFDM *, int *);
+void ofdm_sync_state_machine(struct OFDM *, uint8_t *);
 
 /* getters */
     
@@ -90,7 +83,7 @@ void ofdm_set_timing_enable(struct OFDM *, bool);
 void ofdm_set_foff_est_enable(struct OFDM *, bool);
 void ofdm_set_phase_est_enable(struct OFDM *, bool);
 void ofdm_set_off_est_hz(struct OFDM *, float);
-void ofdm_set_sync(struct OFDM *, Sync);
+void ofdm_set_sync(struct OFDM *, int);
 void ofdm_set_tx_bpf(struct OFDM *, bool);
 
 void ofdm_print_info(struct OFDM *);

--- a/mchf-eclipse/drivers/freedv/cohpsk.c
+++ b/mchf-eclipse/drivers/freedv/cohpsk.c
@@ -629,7 +629,7 @@ void frame_sync_fine_freq_est(struct COHPSK *coh, COMP ch_symb[][COHPSK_NC*ND], 
         coh->ff_rect.real = cosf(coh->f_fine_est*2.0*M_PI/COHPSK_RS);
         coh->ff_rect.imag = -sinf(coh->f_fine_est*2.0*M_PI/COHPSK_RS);
         if (coh->verbose)
-            fprintf(stderr, "  [%d]   fine freq f: %6.2f max_ratio: %f ct: %d\n", coh->frame, coh->f_fine_est, max_corr/max_mag, coh->ct);
+            fprintf(stderr, "  [%d]   fine freq f: %6.2f max_ratio: %f ct: %d\n", coh->frame, (double)coh->f_fine_est, (double)(max_corr/max_mag), coh->ct);
 
         if (max_corr/max_mag > 0.9) {
             if (coh->verbose)
@@ -1077,7 +1077,7 @@ void cohpsk_demod(struct COHPSK *coh, float rx_bits[], int *sync_good, COMP rx_f
         	}
 
             if (coh->verbose)
-                fprintf(stderr, "  [%d] acohpsk.f_est: %f +/- 20\n", coh->frame, coh->f_est);
+                fprintf(stderr, "  [%d] acohpsk.f_est: %f +/- 20\n", coh->frame, (double)coh->f_est);
 
             /* we are out of sync so reset f_est and process two frames to clean out memories */
 
@@ -1109,7 +1109,7 @@ void cohpsk_demod(struct COHPSK *coh, float rx_bits[], int *sync_good, COMP rx_f
             coh->f_est = f_est;
 
             if (coh->verbose)
-                fprintf(stderr, "  [%d] trying sync and f_est: %f\n", coh->frame, coh->f_est);
+                fprintf(stderr, "  [%d] trying sync and f_est: %f\n", coh->frame, (double)coh->f_est);
 
             rate_Fs_rx_processing(coh, ch_symb, coh->ch_fdm_frame_buf, &coh->f_est, NSW*NSYMROWPILOT, COHPSK_M, 0);
             for (i=0; i<NSW-1; i++) {
@@ -1129,7 +1129,7 @@ void cohpsk_demod(struct COHPSK *coh, float rx_bits[], int *sync_good, COMP rx_f
 
             if (fabs(coh->f_fine_est) > 2.0) {
                 if (coh->verbose)
-                    fprintf(stderr, "  [%d] Hmm %f is a bit big :(\n", coh->frame, coh->f_fine_est);
+                    fprintf(stderr, "  [%d] Hmm %f is a bit big :(\n", coh->frame, (double)coh->f_fine_est);
                 next_sync = 0;
             }
         }
@@ -1139,7 +1139,7 @@ void cohpsk_demod(struct COHPSK *coh, float rx_bits[], int *sync_good, COMP rx_f
                demodulate first frame (demod completed below) */
 
             if (coh->verbose)
-                fprintf(stderr, "  [%d] in sync! f_est: %f ratio: %f \n", coh->frame, coh->f_est, coh->ratio);
+                fprintf(stderr, "  [%d] in sync! f_est: %f ratio: %f \n", coh->frame, (double)coh->f_est, (double)coh->ratio);
             for(r=0; r<NSYMROWPILOT+2; r++)
                 for(c=0; c<COHPSK_NC*ND; c++)
                     coh->ct_symb_ff_buf[r][c] = coh->ct_symb_buf[coh->ct+r][c];
@@ -1387,6 +1387,6 @@ float *cohpsk_get_rx_bits_upper(struct COHPSK *coh) {
 void cohpsk_set_carrier_ampl(struct COHPSK *coh, int c, float ampl) {
     assert(c < COHPSK_NC*ND);
     coh->carrier_ampl[c] = ampl;
-    fprintf(stderr, "cohpsk_set_carrier_ampl: %d %f\n", c, ampl);
+    fprintf(stderr, "cohpsk_set_carrier_ampl: %d %f\n", c, (double)ampl);
 }
 

--- a/mchf-eclipse/drivers/freedv/fdmdv.c
+++ b/mchf-eclipse/drivers/freedv/fdmdv.c
@@ -1698,7 +1698,7 @@ float calc_snr(int Nc, float sig_est[], float noise_est[])
 
     S = 0.0;
     for(c=0; c<Nc+1; c++)
-	S += sig_est[c] * sig_est[c];
+	S += powf(sig_est[c], 2.0);
     SdB = 10.0*log10f(S+1E-12);
 
     /* Average noise mag across all carriers and square to get an
@@ -1710,7 +1710,7 @@ float calc_snr(int Nc, float sig_est[], float noise_est[])
     for(c=0; c<Nc+1; c++)
 	mean += noise_est[c];
     mean /= (Nc+1);
-    N50 = mean * mean;
+    N50 = powf(mean, 2.0);
     N50dB = 10.0*log10f(N50+1E-12);
 
     /* Now multiply by (3000 Hz)/(50 Hz) to find the total noise power

--- a/mchf-eclipse/drivers/freedv/fdv_arm_math.h
+++ b/mchf-eclipse/drivers/freedv/fdv_arm_math.h
@@ -31,11 +31,8 @@
 
 #ifdef FDV_ARM_MATH
     #include "arm_const_structs.h"
-    //#define SINF(a) arm_sin_f32(a)
-    //#define COSF(a) arm_cos_f32(a)
-
-    #define SINF(a) sinf(a) //arm_sin_f32(a)
-    #define COSF(a) cosf(a) //arm_cos_f32(a)
+    #define SINF(a) arm_sin_f32(a)
+    #define COSF(a) arm_cos_f32(a)
 #else
     #define SINF(a) sinf(a)
     #define COSF(a) cosf(a)

--- a/mchf-eclipse/drivers/freedv/freedv_api.c
+++ b/mchf-eclipse/drivers/freedv/freedv_api.c
@@ -115,11 +115,13 @@ struct freedv *freedv_open_advanced(int mode, struct freedv_advanced *adv) {
     struct freedv *f;
     int            Nc, codec2_mode, nbit, nbyte;
 
-    if ((mode != FREEDV_MODE_1600) && (mode != FREEDV_MODE_700) && 
-        (mode != FREEDV_MODE_700B) && (mode != FREEDV_MODE_2400A) &&
-        (mode != FREEDV_MODE_2400B) && (mode != FREEDV_MODE_800XA) &&
-        (mode != FREEDV_MODE_700C) && (mode != FREEDV_MODE_700D) )
+    if (false == (FDV_MODE_ACTIVE( FREEDV_MODE_1600,mode) || FDV_MODE_ACTIVE( FREEDV_MODE_700,mode) || 
+		FDV_MODE_ACTIVE( FREEDV_MODE_700B,mode) || FDV_MODE_ACTIVE( FREEDV_MODE_2400A,mode) || 
+		FDV_MODE_ACTIVE( FREEDV_MODE_2400B,mode) || FDV_MODE_ACTIVE( FREEDV_MODE_800XA,mode) || 
+		FDV_MODE_ACTIVE( FREEDV_MODE_700C,mode) || FDV_MODE_ACTIVE( FREEDV_MODE_700D,mode) ))
+    {
         return NULL;
+    }
 
     f = (struct freedv*)MALLOC(sizeof(struct freedv));
     if (f == NULL)
@@ -135,7 +137,7 @@ struct freedv *freedv_open_advanced(int mode, struct freedv_advanced *adv) {
     
     /* Init states for this mode, and set up samples in/out -----------------------------------------*/
     
-    if (mode == FREEDV_MODE_1600) {
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_1600, f->mode)) {
         f->snr_squelch_thresh = 2.0;
         f->squelch_en = 1;
         Nc = 16;
@@ -172,7 +174,7 @@ struct freedv *freedv_open_advanced(int mode, struct freedv_advanced *adv) {
         f->sz_error_pattern = fdmdv_error_pattern_size(f->fdmdv);
     }
 
-    if ((mode == FREEDV_MODE_700) || (mode == FREEDV_MODE_700B) || (mode == FREEDV_MODE_700C)) {
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_700, mode) || FDV_MODE_ACTIVE( FREEDV_MODE_700B, mode) || FDV_MODE_ACTIVE( FREEDV_MODE_700C, mode)) {
         f->snr_squelch_thresh = 0.0;
         f->squelch_en = 0;
         switch(mode) {
@@ -203,7 +205,7 @@ struct freedv *freedv_open_advanced(int mode, struct freedv_advanced *adv) {
         f->sz_error_pattern = cohpsk_error_pattern_size();
     }
    
-    if (mode == FREEDV_MODE_700D) {
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_700D, mode) ) {
         /*
           TODO:
             [ ] how to set up interleaver, prob init time option best, as many arrays depend on it
@@ -300,7 +302,7 @@ struct freedv *freedv_open_advanced(int mode, struct freedv_advanced *adv) {
 #endif
     }
 
-    if ((mode == FREEDV_MODE_2400A) || (mode == FREEDV_MODE_2400B)) {
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_2400A, mode) || FDV_MODE_ACTIVE( FREEDV_MODE_2400B, mode)) {
       
         /* Set up the C2 mode */
         codec2_mode = CODEC2_MODE_1300;
@@ -310,7 +312,7 @@ struct freedv *freedv_open_advanced(int mode, struct freedv_advanced *adv) {
         f->ext_vco = 0;
     }
     
-    if (mode == FREEDV_MODE_2400A) {
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_2400A, mode)) {
         /* Create the framer|deframer */
         f->deframer = fvhff_create_deframer(FREEDV_VHF_FRAME_A,0);
         if(f->deframer == NULL)
@@ -336,7 +338,7 @@ struct freedv *freedv_open_advanced(int mode, struct freedv_advanced *adv) {
         f->codec_bits = MALLOC(1);
     }
     
-    if (mode == FREEDV_MODE_2400B) {
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_2400B, mode) ) {
         /* Create the framer|deframer */
         f->deframer = fvhff_create_deframer(FREEDV_VHF_FRAME_A,1);
         if(f->deframer == NULL) {
@@ -362,7 +364,7 @@ struct freedv *freedv_open_advanced(int mode, struct freedv_advanced *adv) {
         f->codec_bits = MALLOC(1);
     }
     
-    if (mode == FREEDV_MODE_800XA) {
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_800XA, mode)) {
         /* Create the framer|deframer */
         f->deframer = fvhff_create_deframer(FREEDV_HF_FRAME_B,0);
         if(f->deframer == NULL)
@@ -416,12 +418,12 @@ struct freedv *freedv_open_advanced(int mode, struct freedv_advanced *adv) {
        need to work in packed bits at all?  It's messy, chars would probably
        be OK.... */
     
-    if ((mode == FREEDV_MODE_1600) || (mode == FREEDV_MODE_2400A) || (mode == FREEDV_MODE_2400B)) {
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_1600, mode) || FDV_MODE_ACTIVE( FREEDV_MODE_2400A, mode) || FDV_MODE_ACTIVE( FREEDV_MODE_2400B, mode)) {
         f->n_speech_samples = codec2_samples_per_frame(f->codec2);
         f->n_codec_bits = codec2_bits_per_frame(f->codec2);
         nbit = f->n_codec_bits;
         nbyte = (nbit + 7) / 8;
-    } else if (mode == FREEDV_MODE_800XA) {
+    } else if (FDV_MODE_ACTIVE( FREEDV_MODE_800XA, mode) ) {
         f->n_speech_samples = 2*codec2_samples_per_frame(f->codec2);
         f->n_codec_bits = codec2_bits_per_frame(f->codec2);
         nbit = f->n_codec_bits;
@@ -429,12 +431,12 @@ struct freedv *freedv_open_advanced(int mode, struct freedv_advanced *adv) {
         nbyte = nbyte*2;
         nbit = 8*nbyte;
         f->n_codec_bits = nbit;
-    } else if ((mode == FREEDV_MODE_700) || (mode == FREEDV_MODE_700B) || (mode == FREEDV_MODE_700C)) {
+    } else if (FDV_MODE_ACTIVE( FREEDV_MODE_700, mode) || FDV_MODE_ACTIVE( FREEDV_MODE_700B, mode) || FDV_MODE_ACTIVE( FREEDV_MODE_700C, mode)) {
         f->n_speech_samples = 2*codec2_samples_per_frame(f->codec2);
         f->n_codec_bits = 2*codec2_bits_per_frame(f->codec2);
         nbit = f->n_codec_bits;
         nbyte = 2*((codec2_bits_per_frame(f->codec2) + 7) / 8);
-    } else /* mode == FREEDV_MODE_700D */ {
+    } else if (FDV_MODE_ACTIVE(FREEDV_MODE_700D, mode)) /* mode == FREEDV_MODE_700D */ {
 
         /* should be exactly an integer number ofCodec 2 frames in a OFDM modem frame */
 
@@ -460,10 +462,10 @@ struct freedv *freedv_open_advanced(int mode, struct freedv_advanced *adv) {
     f->packed_codec_bits = (unsigned char*)MALLOC(nbyte*sizeof(char));
     if (f->packed_codec_bits == NULL) return(NULL);
 
-    if (mode == FREEDV_MODE_1600)
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_1600, mode))
         f->codec_bits = (int*)MALLOC(nbit*sizeof(int));
 
-    if ((mode == FREEDV_MODE_700) || (mode == FREEDV_MODE_700B) || (mode == FREEDV_MODE_700C))
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_700, mode) || FDV_MODE_ACTIVE( FREEDV_MODE_700B, mode) || FDV_MODE_ACTIVE( FREEDV_MODE_700C, mode))
         f->codec_bits = (int*)MALLOC(COHPSK_BITS_PER_FRAME*sizeof(int));
     
     /* Note: VHF Framer/deframer goes directly from packed codec/vc/proto bits to filled frame */
@@ -475,7 +477,7 @@ struct freedv *freedv_open_advanced(int mode, struct freedv_advanced *adv) {
 
     /* Sample rate conversion for modes using COHPSK */
     
-    if ((mode == FREEDV_MODE_700) || (mode == FREEDV_MODE_700B) || (mode == FREEDV_MODE_700C) ) { 
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_700, mode) || FDV_MODE_ACTIVE( FREEDV_MODE_700B, mode) || FDV_MODE_ACTIVE( FREEDV_MODE_700C, mode) ) { 
         f->ptFilter7500to8000 = (struct quisk_cfFilter *)MALLOC(sizeof(struct quisk_cfFilter));
         f->ptFilter8000to7500 = (struct quisk_cfFilter *)MALLOC(sizeof(struct quisk_cfFilter));
         quisk_filt_cfInit(f->ptFilter8000to7500, quiskFilt120t480, sizeof(quiskFilt120t480)/sizeof(float));
@@ -515,11 +517,11 @@ void freedv_close(struct freedv *freedv) {
     FREE(freedv->packed_codec_bits);
     FREE(freedv->codec_bits);
     FREE(freedv->tx_bits);
-    if (freedv->mode == FREEDV_MODE_1600)
+    if (FDV_MODE_ACTIVE(FREEDV_MODE_1600, freedv->mode))
         fdmdv_destroy(freedv->fdmdv);
-    if ((freedv->mode == FREEDV_MODE_700) || (freedv->mode == FREEDV_MODE_700B) || (freedv->mode == FREEDV_MODE_700C))
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_700, freedv->mode) || FDV_MODE_ACTIVE( FREEDV_MODE_700B, freedv->mode) || FDV_MODE_ACTIVE( FREEDV_MODE_700C, freedv->mode))
         cohpsk_destroy(freedv->cohpsk);
-    if (freedv->mode == FREEDV_MODE_700D) {
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_700D, freedv->mode)) {
         FREE(freedv->packed_codec_bits_tx);
         if (freedv->interleave_frames > 1)
             FREE(freedv->mod_out);
@@ -528,12 +530,12 @@ void freedv_close(struct freedv *freedv) {
         FREE(freedv->ldpc);
         ofdm_destroy(freedv->ofdm);
     }
-    if ((freedv->mode == FREEDV_MODE_2400A) || (freedv->mode == FREEDV_MODE_800XA)){
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_2400A, freedv->mode) || FDV_MODE_ACTIVE( FREEDV_MODE_800XA, freedv->mode)){
         fsk_destroy(freedv->fsk);
         fvhff_destroy_deframer(freedv->deframer);
     }
     
-    if (freedv->mode == FREEDV_MODE_2400B){
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_2400B, freedv->mode)){
         fmfsk_destroy(freedv->fmfsk);
 		fvhff_destroy_deframer(freedv->deframer);
     }
@@ -600,7 +602,7 @@ static void freedv_tx_fsk_voice(struct freedv *f, short mod_out[]) {
     uint8_t proto_bits[3]; /* Prococol bits for 2400 framing */
 
     /* Frame for 2400A/B */
-    if(f->mode == FREEDV_MODE_2400A || f->mode == FREEDV_MODE_2400B){
+    if(FDV_MODE_ACTIVE( FREEDV_MODE_2400A, f->mode) || FDV_MODE_ACTIVE( FREEDV_MODE_2400B, f->mode)){
         /* Get varicode bits for TX and possibly ask for a new char */
         /* 2 bits per 2400A/B frame, so this has to be done twice */
         for(i=0;i<2;i++){
@@ -630,7 +632,7 @@ static void freedv_tx_fsk_voice(struct freedv *f, short mod_out[]) {
             fvhff_frame_bits(FREEDV_VHF_FRAME_A,(uint8_t*)(f->tx_bits),(uint8_t*)(f->packed_codec_bits),NULL,NULL);
         }
     /* Frame for 800XA */
-    }else if(f->mode == FREEDV_MODE_800XA){
+    }else if(FDV_MODE_ACTIVE( FREEDV_MODE_800XA, f->mode)){
         fvhff_frame_bits(FREEDV_HF_FRAME_B,(uint8_t*)(f->tx_bits),(uint8_t*)(f->packed_codec_bits),NULL,NULL);
     }
 
@@ -638,7 +640,7 @@ static void freedv_tx_fsk_voice(struct freedv *f, short mod_out[]) {
     tx_float = alloca(sizeof(float)*f->n_nom_modem_samples);
 
     /* do 4fsk mod */
-    if(f->mode == FREEDV_MODE_2400A || f->mode == FREEDV_MODE_800XA){
+    if(FDV_MODE_ACTIVE( FREEDV_MODE_2400A, f->mode) || FDV_MODE_ACTIVE( FREEDV_MODE_800XA, f->mode)){
         if (f->ext_vco) {
             fsk_mod_ext_vco(f->fsk,tx_float,(uint8_t*)(f->tx_bits));
             for(i=0; i<f->n_nom_modem_samples; i++){
@@ -653,7 +655,7 @@ static void freedv_tx_fsk_voice(struct freedv *f, short mod_out[]) {
             }
         }
     /* do me-fsk mod */
-    }else if(f->mode == FREEDV_MODE_2400B){
+    }else if(FDV_MODE_ACTIVE( FREEDV_MODE_2400B, f->mode)){
         fmfsk_mod(f->fmfsk,tx_float,(uint8_t*)(f->tx_bits));
         /* Convert float samps to short */
         for(i=0; i<f->n_nom_modem_samples; i++){
@@ -670,7 +672,7 @@ static void freedv_comptx_fsk_voice(struct freedv *f, COMP mod_out[]) {
     uint8_t proto_bits[3]; /* Prococol bits for 2400 framing */
 
     /* Frame for 2400A/B */
-    if(f->mode == FREEDV_MODE_2400A || f->mode == FREEDV_MODE_2400B){
+    if(FDV_MODE_ACTIVE( FREEDV_MODE_2400A, f->mode) || FDV_MODE_ACTIVE( FREEDV_MODE_2400B, f->mode)){
         /* Get varicode bits for TX and possibly ask for a new char */
         /* 2 bits per 2400A/B frame, so this has to be done twice */
         for(i=0;i<2;i++){
@@ -700,7 +702,7 @@ static void freedv_comptx_fsk_voice(struct freedv *f, COMP mod_out[]) {
             fvhff_frame_bits(FREEDV_VHF_FRAME_A,(uint8_t*)(f->tx_bits),(uint8_t*)(f->packed_codec_bits),NULL,NULL);
         }
     /* Frame for 800XA */
-    }else if(f->mode == FREEDV_MODE_800XA){
+    }else if(FDV_MODE_ACTIVE( FREEDV_MODE_800XA, f->mode)){
         fvhff_frame_bits(FREEDV_HF_FRAME_B,(uint8_t*)(f->tx_bits),(uint8_t*)(f->packed_codec_bits),NULL,NULL);
     }
 
@@ -708,14 +710,14 @@ static void freedv_comptx_fsk_voice(struct freedv *f, COMP mod_out[]) {
     tx_float = alloca(sizeof(float)*f->n_nom_modem_samples);
 
     /* do 4fsk mod */
-    if(f->mode == FREEDV_MODE_2400A || f->mode == FREEDV_MODE_800XA){
+    if(FDV_MODE_ACTIVE( FREEDV_MODE_2400A, f->mode) || FDV_MODE_ACTIVE( FREEDV_MODE_800XA, f->mode)){
         fsk_mod_c(f->fsk,mod_out,(uint8_t*)(f->tx_bits));
         /* Convert float samps to short */
         for(i=0; i<f->n_nom_modem_samples; i++){
         	mod_out[i] = fcmult(NORM_PWR_FSK,mod_out[i]);
         }
     /* do me-fsk mod */
-    }else if(f->mode == FREEDV_MODE_2400B){
+    }else if(FDV_MODE_ACTIVE( FREEDV_MODE_2400B, f->mode)){
         fmfsk_mod(f->fmfsk,tx_float,(uint8_t*)(f->tx_bits));
         /* Convert float samps to short */
         for(i=0; i<f->n_nom_modem_samples; i++){
@@ -730,23 +732,23 @@ static void freedv_tx_fsk_data(struct freedv *f, short mod_out[]) {
     int  i;
     float *tx_float; /* To hold on to modulated samps from fsk/fmfsk */
     
-    if (f->mode != FREEDV_MODE_800XA)
-    	fvhff_frame_data_bits(f->deframer, FREEDV_VHF_FRAME_A,(uint8_t*)(f->tx_bits));
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_800XA, f->mode))
+	fvhff_frame_data_bits(f->deframer, FREEDV_HF_FRAME_B,(uint8_t*)(f->tx_bits));
     else
-        fvhff_frame_data_bits(f->deframer, FREEDV_HF_FRAME_B,(uint8_t*)(f->tx_bits));
+    	fvhff_frame_data_bits(f->deframer, FREEDV_VHF_FRAME_A,(uint8_t*)(f->tx_bits));
         
     /* Allocate floating point buffer for FSK mod */
     tx_float = alloca(sizeof(float)*f->n_nom_modem_samples);
         
     /* do 4fsk mod */
-    if(f->mode == FREEDV_MODE_2400A || f->mode == FREEDV_MODE_800XA){
+    if(FDV_MODE_ACTIVE( FREEDV_MODE_2400A, f->mode) || FDV_MODE_ACTIVE( FREEDV_MODE_800XA, f->mode)){
         fsk_mod(f->fsk,tx_float,(uint8_t*)(f->tx_bits));
         /* Convert float samps to short */
         for(i=0; i<f->n_nom_modem_samples; i++){
             mod_out[i] = (short)(tx_float[i]*FSK_SCALE);
         }
     /* do me-fsk mod */
-    }else if(f->mode == FREEDV_MODE_2400B){
+    }else if(FDV_MODE_ACTIVE( FREEDV_MODE_2400B, f->mode)){
         fmfsk_mod(f->fmfsk,tx_float,(uint8_t*)(f->tx_bits));
         /* Convert float samps to short */
         for(i=0; i<f->n_nom_modem_samples; i++){
@@ -759,19 +761,19 @@ void freedv_tx(struct freedv *f, short mod_out[], short speech_in[]) {
     assert(f != NULL);
     COMP tx_fdm[f->n_nom_modem_samples];
     int  i;
-    assert((f->mode == FREEDV_MODE_1600)  || (f->mode == FREEDV_MODE_700)   || 
-           (f->mode == FREEDV_MODE_700B)  || (f->mode == FREEDV_MODE_700C)  ||
-           (f->mode == FREEDV_MODE_700D)  || 
-           (f->mode == FREEDV_MODE_2400A) || (f->mode == FREEDV_MODE_2400B) || 
-           (f->mode == FREEDV_MODE_800XA));
+    assert((FDV_MODE_ACTIVE( FREEDV_MODE_1600, f->mode))  || (FDV_MODE_ACTIVE( FREEDV_MODE_700, f->mode))   || 
+           (FDV_MODE_ACTIVE( FREEDV_MODE_700B, f->mode))  || (FDV_MODE_ACTIVE( FREEDV_MODE_700C, f->mode))  ||
+           (FDV_MODE_ACTIVE( FREEDV_MODE_700D, f->mode))  || 
+           (FDV_MODE_ACTIVE( FREEDV_MODE_2400A, f->mode)) || (FDV_MODE_ACTIVE( FREEDV_MODE_2400B, f->mode)) || 
+           (FDV_MODE_ACTIVE( FREEDV_MODE_800XA, f->mode)));
     
     /* FSK and MEFSK/FMFSK modems work only on real samples. It's simpler to just 
      * stick them in the real sample tx/rx functions than to add a comp->real converter
      * to comptx */
      
-    if ((f->mode == FREEDV_MODE_2400A) || (f->mode == FREEDV_MODE_2400B) || (f->mode == FREEDV_MODE_800XA)){
+    if ((FDV_MODE_ACTIVE( FREEDV_MODE_2400A, f->mode)) || (FDV_MODE_ACTIVE( FREEDV_MODE_2400B, f->mode)) || (FDV_MODE_ACTIVE( FREEDV_MODE_800XA, f->mode))){
         /* 800XA has two codec frames per modem frame */
-        if(f->mode == FREEDV_MODE_800XA){
+        if(FDV_MODE_ACTIVE( FREEDV_MODE_800XA, f->mode)){
             codec2_encode(f->codec2, &f->packed_codec_bits[0], &speech_in[  0]);
             codec2_encode(f->codec2, &f->packed_codec_bits[4], &speech_in[320]);
         }else{
@@ -1040,7 +1042,7 @@ static void freedv_comptx_700d(struct freedv *f, COMP mod_out[]) {
     /* optionally replace codec payload bits with test frames known to rx */
 
     if (f->test_frames) {
-        int payload_data_bits[data_bits_per_frame];
+        uint8_t payload_data_bits[data_bits_per_frame];
         ofdm_generate_payload_data_bits(payload_data_bits, data_bits_per_frame);
 
         for (j=0; j<f->interleave_frames; j++) {
@@ -1074,12 +1076,12 @@ static void freedv_comptx_700d(struct freedv *f, COMP mod_out[]) {
 void freedv_comptx(struct freedv *f, COMP mod_out[], short speech_in[]) {
     assert(f != NULL);
 
-    assert((f->mode == FREEDV_MODE_1600) || (f->mode == FREEDV_MODE_700) || 
-           (f->mode == FREEDV_MODE_700B) || (f->mode == FREEDV_MODE_700C) || 
-           (f->mode == FREEDV_MODE_2400A) || (f->mode == FREEDV_MODE_2400B) ||
-           (f->mode == FREEDV_MODE_700D));
+    assert((FDV_MODE_ACTIVE( FREEDV_MODE_1600, f->mode)) || (FDV_MODE_ACTIVE( FREEDV_MODE_700, f->mode)) || 
+           (FDV_MODE_ACTIVE( FREEDV_MODE_700B, f->mode)) || (FDV_MODE_ACTIVE( FREEDV_MODE_700C, f->mode)) || 
+           (FDV_MODE_ACTIVE( FREEDV_MODE_2400A, f->mode)) || (FDV_MODE_ACTIVE( FREEDV_MODE_2400B, f->mode)) ||
+           (FDV_MODE_ACTIVE( FREEDV_MODE_700D, f->mode)));
 
-    if (f->mode == FREEDV_MODE_1600) {
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_1600, f->mode)) {
         codec2_encode(f->codec2, f->packed_codec_bits, speech_in);
         freedv_comptx_fdmdv_1600(f, mod_out);
     }
@@ -1091,7 +1093,7 @@ void freedv_comptx(struct freedv *f, COMP mod_out[], short speech_in[]) {
     
     /* all these modes need to pack a bunch of codec frames into one modem frame */
     
-    if ((f->mode == FREEDV_MODE_700) || (f->mode == FREEDV_MODE_700B) || (f->mode == FREEDV_MODE_700C)) {
+    if ((FDV_MODE_ACTIVE( FREEDV_MODE_700, f->mode)) || (FDV_MODE_ACTIVE( FREEDV_MODE_700B, f->mode)) || (FDV_MODE_ACTIVE( FREEDV_MODE_700C, f->mode))) {
 	int codec_frames = f->n_codec_bits / bits_per_codec_frame;
 
         for (j=0; j<codec_frames; j++) {
@@ -1103,7 +1105,7 @@ void freedv_comptx(struct freedv *f, COMP mod_out[], short speech_in[]) {
 
     /* special treatment due to interleaver */
     
-    if (f->mode == FREEDV_MODE_700D) {
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_700D, f->mode)) {
         int data_bits_per_frame = f->ldpc->data_bits_per_frame;
 	int codec_frames = data_bits_per_frame / bits_per_codec_frame;
 
@@ -1141,7 +1143,7 @@ void freedv_comptx(struct freedv *f, COMP mod_out[], short speech_in[]) {
     }
     
     /* 2400 A and B are handled by the real-mode TX */
-    if((f->mode == FREEDV_MODE_2400A) || (f->mode == FREEDV_MODE_2400B)){
+    if(FDV_MODE_ACTIVE( FREEDV_MODE_2400A, f->mode) || FDV_MODE_ACTIVE( FREEDV_MODE_2400B, f->mode)){
     	codec2_encode(f->codec2, f->packed_codec_bits, speech_in);
         freedv_comptx_fsk_voice(f,mod_out);
     }
@@ -1211,17 +1213,17 @@ void freedv_codectx(struct freedv *f, short mod_out[], unsigned char *packed_cod
 
 void freedv_datatx  (struct freedv *f, short mod_out[]){
     assert(f != NULL);
-    if (f->mode == FREEDV_MODE_2400A || f->mode == FREEDV_MODE_2400B || f->mode == FREEDV_MODE_800XA) {
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_2400A, f->mode) || FDV_MODE_ACTIVE( FREEDV_MODE_2400B, f->mode) || FDV_MODE_ACTIVE( FREEDV_MODE_800XA, f->mode)) {
             freedv_tx_fsk_data(f, mod_out);
     }
 }
 
 int  freedv_data_ntxframes (struct freedv *f){
     assert(f != NULL);
-    if (f->mode == FREEDV_MODE_2400A || f->mode == FREEDV_MODE_2400B) {
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_2400A, f->mode) || FDV_MODE_ACTIVE( FREEDV_MODE_2400B, f->mode)) {
         if (f->deframer->fdc)
             return freedv_data_get_n_tx_frames(f->deframer->fdc, 8);
-    } else if (f->mode == FREEDV_MODE_800XA) {
+    } else if (FDV_MODE_ACTIVE( FREEDV_MODE_800XA, f->mode)) {
         if (f->deframer->fdc)
             return freedv_data_get_n_tx_frames(f->deframer->fdc, 6);
     }
@@ -1229,7 +1231,7 @@ int  freedv_data_ntxframes (struct freedv *f){
 }
 
 int freedv_nin(struct freedv *f) {
-    if ((f->mode == FREEDV_MODE_700) || (f->mode == FREEDV_MODE_700B) || (f->mode == FREEDV_MODE_700C))
+    if ((FDV_MODE_ACTIVE( FREEDV_MODE_700, f->mode)) || (FDV_MODE_ACTIVE( FREEDV_MODE_700B, f->mode)) || (FDV_MODE_ACTIVE( FREEDV_MODE_700C, f->mode)))
         // For mode 700, the input rate is 8000 sps, but the modem rate is 7500 sps
         // For mode 700, we request a larger number of Rx samples that will be decimated to f->nin samples
         return (16 * f->nin + f->ptFilter8000to7500->decim_index) / 15;
@@ -1293,7 +1295,7 @@ int freedv_rx(struct freedv *f, short speech_out[], short demod_in[]) {
     assert(nin <= f->n_max_modem_samples);
        
     /* FSK RX happens in real floats, so convert to those and call their demod here */
-    if( (f->mode == FREEDV_MODE_2400A) || (f->mode == FREEDV_MODE_2400B) || (f->mode == FREEDV_MODE_800XA) ){
+    if( (FDV_MODE_ACTIVE( FREEDV_MODE_2400A, f->mode)) || (FDV_MODE_ACTIVE( FREEDV_MODE_2400B, f->mode)) || (FDV_MODE_ACTIVE( FREEDV_MODE_800XA, f->mode)) ){
         float rx_float[f->n_max_modem_samples];
         for(i=0; i<nin; i++) {
             rx_float[i] = ((float)demod_in[i]);
@@ -1301,8 +1303,8 @@ int freedv_rx(struct freedv *f, short speech_out[], short demod_in[]) {
         return freedv_floatrx(f,speech_out,rx_float);
     }
     
-    if ( (f->mode == FREEDV_MODE_1600) || (f->mode == FREEDV_MODE_700) || 
-         (f->mode == FREEDV_MODE_700B) || (f->mode == FREEDV_MODE_700C)) {
+    if ( (FDV_MODE_ACTIVE( FREEDV_MODE_1600, f->mode)) || (FDV_MODE_ACTIVE( FREEDV_MODE_700, f->mode)) || 
+         (FDV_MODE_ACTIVE( FREEDV_MODE_700B, f->mode)) || (FDV_MODE_ACTIVE( FREEDV_MODE_700C, f->mode))) {
 
         float gain = 1.0;
         
@@ -1315,7 +1317,7 @@ int freedv_rx(struct freedv *f, short speech_out[], short demod_in[]) {
         return freedv_comprx(f, speech_out, rx_fdm);
     }
 
-    if (f->mode == FREEDV_MODE_700D) {
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_700D, f->mode)) {
         float gain = 2.0; /* keep levels the same as Octave simulations and C unit tests for real signals */
         return freedv_shortrx(f, speech_out, demod_in, gain);
     }
@@ -1334,7 +1336,7 @@ int freedv_comprx_fsk(struct freedv *f, COMP demod_in[], int *valid) {
     int n_ascii;
     char ascii_out;
 
-    if(f->mode == FREEDV_MODE_2400A || f->mode == FREEDV_MODE_800XA){        
+    if(FDV_MODE_ACTIVE( FREEDV_MODE_2400A, f->mode) || FDV_MODE_ACTIVE( FREEDV_MODE_800XA, f->mode)){        
 	fsk_demod(f->fsk,(uint8_t*)f->tx_bits,demod_in);
         f->nin = fsk_nin(f->fsk);
         float EbNodB = f->fsk->stats->snr_est;           /* fsk demod actually estimates Eb/No     */
@@ -1795,7 +1797,7 @@ static int freedv_comprx_700d(struct freedv *f, short demod_in_8kHz[], float gai
     int Nerrs_coded = 0;
     int iter = 0;
     int parityCheckCount = 0;
-    int rx_uw[ofdm_nuwbits];
+    uint8_t rx_uw[ofdm_nuwbits];
 
     float new_gain = gain / OFDM_AMP_SCALE;
     
@@ -1851,7 +1853,7 @@ static int freedv_comprx_700d(struct freedv *f, short demod_in_8kHz[], float gai
         gp_deinterleave_float(codeword_amps_de   , codeword_amps   , interleave_frames*coded_syms_per_frame);
 
         float llr[coded_bits_per_frame];
-        char out_char[coded_bits_per_frame];
+        uint8_t out_char[coded_bits_per_frame];
 
         interleaver_sync_state_machine(ofdm, ldpc, ofdm_config, codeword_symbols_de, codeword_amps_de, EsNo,
                                        interleave_frames, &iter, &parityCheckCount, &Nerrs_coded);
@@ -1876,7 +1878,7 @@ static int freedv_comprx_700d(struct freedv *f, short demod_in_8kHz[], float gai
                 iter = run_ldpc_decoder(ldpc, out_char, llr, &parityCheckCount);
 
                 if (f->test_frames) {
-                    int payload_data_bits[data_bits_per_frame];
+                    uint8_t payload_data_bits[data_bits_per_frame];
                     ofdm_generate_payload_data_bits(payload_data_bits, data_bits_per_frame);
                     Nerrs_coded = count_errors(payload_data_bits, out_char, data_bits_per_frame);
                     f->total_bit_errors_coded += Nerrs_coded;
@@ -1983,14 +1985,14 @@ int freedv_comprx(struct freedv *f, short speech_out[], COMP demod_in[]) {
     bits_per_codec_frame  = codec2_bits_per_frame(f->codec2);
     bytes_per_codec_frame = (bits_per_codec_frame + 7) / 8;
 
-    if (f->mode == FREEDV_MODE_1600) {
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_1600, f->mode)) {
         nout = freedv_comprx_fdmdv_1600(f, demod_in, &valid);
     }
-    if ((f->mode == FREEDV_MODE_700) || (f->mode == FREEDV_MODE_700B) || (f->mode == FREEDV_MODE_700C)) {
+    if ((FDV_MODE_ACTIVE( FREEDV_MODE_700, f->mode)) || (FDV_MODE_ACTIVE( FREEDV_MODE_700B, f->mode)) || (FDV_MODE_ACTIVE( FREEDV_MODE_700C, f->mode))) {
         nout = freedv_comprx_700(f, demod_in, &valid);
     }
 
-    if( (f->mode == FREEDV_MODE_2400A) || (f->mode == FREEDV_MODE_2400B) || (f->mode == FREEDV_MODE_800XA)){
+    if( (FDV_MODE_ACTIVE( FREEDV_MODE_2400A, f->mode)) || (FDV_MODE_ACTIVE( FREEDV_MODE_2400B, f->mode)) || (FDV_MODE_ACTIVE( FREEDV_MODE_800XA, f->mode))){
         nout = freedv_comprx_fsk(f, demod_in, &valid);
     }
 
@@ -2035,7 +2037,7 @@ int freedv_shortrx(struct freedv *f, short speech_out[], short demod_in[], float
     bits_per_codec_frame  = codec2_bits_per_frame(f->codec2);
     bytes_per_codec_frame = (bits_per_codec_frame + 7) / 8;
 
-    if (f->mode == FREEDV_MODE_700D) {
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_700D, f->mode)) {
         nout = freedv_comprx_700d(f, demod_in, gain, &valid);
     }
     
@@ -2086,7 +2088,7 @@ int freedv_codecrx(struct freedv *f, unsigned char *packed_codec_bits, short dem
 
     assert(nin <= f->n_max_modem_samples);
 
-    if (f->mode != FREEDV_MODE_700D) {
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_700D, f->mode) == false) {
         COMP rx_fdm[f->n_max_modem_samples];
     
         for(i=0; i<nin; i++) {
@@ -2094,22 +2096,22 @@ int freedv_codecrx(struct freedv *f, unsigned char *packed_codec_bits, short dem
             rx_fdm[i].imag = 0.0;
         }
 
-        if (f->mode == FREEDV_MODE_1600) {
+        if (FDV_MODE_ACTIVE( FREEDV_MODE_1600, f->mode)) {
             freedv_comprx_fdmdv_1600(f, rx_fdm, &valid);
         }
 
-        if ((f->mode == FREEDV_MODE_700) || (f->mode == FREEDV_MODE_700B) || (f->mode == FREEDV_MODE_700C)) {
+        if ((FDV_MODE_ACTIVE( FREEDV_MODE_700, f->mode)) || (FDV_MODE_ACTIVE( FREEDV_MODE_700B, f->mode)) || (FDV_MODE_ACTIVE( FREEDV_MODE_700C, f->mode))) {
             freedv_comprx_700(f, rx_fdm, &valid);
         }
 
-        if( (f->mode == FREEDV_MODE_2400A) || (f->mode == FREEDV_MODE_2400B) || (f->mode == FREEDV_MODE_800XA)){
+        if( FDV_MODE_ACTIVE( FREEDV_MODE_2400A, f->mode) || FDV_MODE_ACTIVE( FREEDV_MODE_2400B, f->mode) || FDV_MODE_ACTIVE( FREEDV_MODE_800XA, f->mode)){
             freedv_comprx_fsk(f, rx_fdm, &valid);
         }
     }
 
     int bytes_per_codec_frame = (bits_per_codec_frame + 7) / 8;
 
-    if (f->mode == FREEDV_MODE_700D) {
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_700D, f->mode)) {
         freedv_comprx_700d(f, demod_in, 1.0, &valid);
 
         int data_bits_per_frame = f->ldpc->data_bits_per_frame;
@@ -2172,7 +2174,7 @@ int freedv_get_version(void)
 
 void freedv_set_callback_txt(struct freedv *f, freedv_callback_rx rx, freedv_callback_tx tx, void *state)
 {
-    if (f->mode != FREEDV_MODE_800XA) {
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_800XA, f->mode) == false) {
         f->freedv_put_next_rx_char = rx;
         f->freedv_get_next_tx_char = tx;
         f->callback_state = state;
@@ -2196,7 +2198,7 @@ void freedv_set_callback_txt(struct freedv *f, freedv_callback_rx rx, freedv_cal
 \*---------------------------------------------------------------------------*/
 
 void freedv_set_callback_protocol(struct freedv *f, freedv_callback_protorx rx, freedv_callback_prototx tx, void *callback_state){
-    if (f->mode != FREEDV_MODE_800XA) {
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_800XA, f->mode) == false) {
         f->freedv_put_next_proto = rx;
         f->freedv_get_next_proto = tx;
         f->proto_callback_state = callback_state;
@@ -2217,7 +2219,7 @@ void freedv_set_callback_protocol(struct freedv *f, freedv_callback_protorx rx, 
   generated, but will contain only a header update.
 \*---------------------------------------------------------------------------*/
 void freedv_set_callback_data(struct freedv *f, freedv_callback_datarx datarx, freedv_callback_datatx datatx, void *callback_state) {
-    if ((f->mode == FREEDV_MODE_2400A) || (f->mode == FREEDV_MODE_2400B) || (f->mode == FREEDV_MODE_800XA)){
+    if ((FDV_MODE_ACTIVE( FREEDV_MODE_2400A, f->mode)) || (FDV_MODE_ACTIVE( FREEDV_MODE_2400B, f->mode)) || (FDV_MODE_ACTIVE( FREEDV_MODE_800XA, f->mode))){
         if (!f->deframer->fdc)
             f->deframer->fdc = freedv_data_channel_create();
         if (!f->deframer->fdc)
@@ -2241,7 +2243,7 @@ void freedv_set_callback_data(struct freedv *f, freedv_callback_datarx datarx, f
 \*---------------------------------------------------------------------------*/
 void freedv_set_data_header(struct freedv *f, unsigned char *header)
 {
-    if ((f->mode == FREEDV_MODE_2400A) || (f->mode == FREEDV_MODE_2400B) || (f->mode == FREEDV_MODE_800XA)){
+    if ((FDV_MODE_ACTIVE( FREEDV_MODE_2400A, f->mode)) || (FDV_MODE_ACTIVE( FREEDV_MODE_2400B, f->mode)) || (FDV_MODE_ACTIVE( FREEDV_MODE_800XA, f->mode))){
         if (!f->deframer->fdc)
             f->deframer->fdc = freedv_data_channel_create();
         if (!f->deframer->fdc)
@@ -2264,14 +2266,14 @@ void freedv_set_data_header(struct freedv *f, unsigned char *header)
 
 void freedv_get_modem_stats(struct freedv *f, int *sync, float *snr_est)
 {
-    if (f->mode == FREEDV_MODE_1600)
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_1600, f->mode))
         fdmdv_get_demod_stats(f->fdmdv, &f->stats);
-    if ((f->mode == FREEDV_MODE_700) || (f->mode == FREEDV_MODE_700B)  || (f->mode == FREEDV_MODE_700C))
+    if ((FDV_MODE_ACTIVE( FREEDV_MODE_700, f->mode)) || (FDV_MODE_ACTIVE( FREEDV_MODE_700B, f->mode))  || (FDV_MODE_ACTIVE( FREEDV_MODE_700C, f->mode)))
         cohpsk_get_demod_stats(f->cohpsk, &f->stats);
-    if (f->mode == FREEDV_MODE_700D) {
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_700D, f->mode)) {
         ofdm_get_demod_stats(f->ofdm, &f->stats);
     }
-    if (f->mode == FREEDV_MODE_2400B) {
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_2400B, f->mode)) {
         fmfsk_get_demod_stats(f->fmfsk, &f->stats);
     }
     if (sync) *sync = f->stats.sync;
@@ -2305,7 +2307,7 @@ void freedv_set_ext_vco                   (struct freedv *f, int val) {f->ext_vc
 /* Band Pass Filter to cleanup OFDM tx waveform, only supported by FreeDV 700D */
 
 void freedv_set_tx_bpf(struct freedv *f, int val) {
-    if (f->mode == FREEDV_MODE_700D) {
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_700D, f->mode)) {
         ofdm_set_tx_bpf(f->ofdm, val);
     }
 }
@@ -2313,7 +2315,7 @@ void freedv_set_tx_bpf(struct freedv *f, int val) {
 
 void freedv_set_verbose(struct freedv *f, int verbosity) {
     f->verbose = verbosity;
-    if (f->mode == FREEDV_MODE_700D) {
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_700D, f->mode)) {
         ofdm_set_verbose(f->ofdm, f->verbose);
     }
 }
@@ -2327,9 +2329,9 @@ void freedv_set_callback_error_pattern    (struct freedv *f, freedv_calback_erro
     f->error_pattern_callback_state = state;
 }
 
-void freedv_set_carrier_ampl(struct freedv *freedv, int c, float ampl) {
-    assert(freedv->mode == FREEDV_MODE_700C);
-    cohpsk_set_carrier_ampl(freedv->cohpsk, c, ampl);
+void freedv_set_carrier_ampl(struct freedv *f, int c, float ampl) {
+    assert(FDV_MODE_ACTIVE( FREEDV_MODE_700C, f->mode));
+    cohpsk_set_carrier_ampl(f->cohpsk, c, ampl);
 }
 
 /*---------------------------------------------------------------------------*\
@@ -2350,7 +2352,7 @@ void freedv_set_carrier_ampl(struct freedv *freedv, int c, float ampl) {
 \*---------------------------------------------------------------------------*/
 
 int freedv_set_alt_modem_samp_rate(struct freedv *f, int samp_rate){
-	if(f->mode == FREEDV_MODE_2400A){ 
+	if (FDV_MODE_ACTIVE( FREEDV_MODE_2400A, f->mode)){ 
 		if(samp_rate == 24000 || samp_rate == 48000 || samp_rate == 96000){
 			fsk_destroy(f->fsk);
 			f->fsk = fsk_create_hbr(samp_rate,1200,10,4,1200,1200);
@@ -2367,7 +2369,7 @@ int freedv_set_alt_modem_samp_rate(struct freedv *f, int samp_rate){
 			return 0;
 		}else
 			return -1;
-	}else if(f->mode == FREEDV_MODE_2400B){
+	}else if(FDV_MODE_ACTIVE( FREEDV_MODE_2400B, f->mode)){
 		if(samp_rate == 48000 || samp_rate == 96000){
 			return -1;
 		}else
@@ -2394,13 +2396,12 @@ int freedv_set_alt_modem_samp_rate(struct freedv *f, int samp_rate){
 
 \*---------------------------------------------------------------------------*/
 
-void freedv_set_sync(struct freedv *freedv, Sync sync_cmd) {
+void freedv_set_sync(struct freedv *freedv, int sync_cmd) {
     assert (freedv != NULL);
 
-    if (freedv->mode == FREEDV_MODE_700D) {
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_700D, freedv->mode)) {
         ofdm_set_sync(freedv->ofdm, sync_cmd);        
     }
-    
 }
 
 struct FSK * freedv_get_fsk(struct freedv *f){
@@ -2434,7 +2435,7 @@ int freedv_get_total_bit_errors_coded     (struct freedv *f) {return f->total_bi
 int freedv_get_sync                       (struct freedv *f) {return f->stats.sync;}
 
 int freedv_get_sync_interleaver(struct freedv *f) {
-    if (f->mode == FREEDV_MODE_700D) {
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_700D, f->mode)) {
         return f->ofdm->sync_state_interleaver == synced;
     }
 
@@ -2443,7 +2444,7 @@ int freedv_get_sync_interleaver(struct freedv *f) {
 
 int freedv_get_sz_error_pattern(struct freedv *f) 
 {
-    if ((f->mode == FREEDV_MODE_700) || (f->mode == FREEDV_MODE_700B) || (f->mode == FREEDV_MODE_700C)) {
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_700, f->mode) || FDV_MODE_ACTIVE( FREEDV_MODE_700B, f->mode) || FDV_MODE_ACTIVE( FREEDV_MODE_700C, f->mode)) {
         /* if diversity disabled callback sends error pattern for upper and lower carriers */
         return f->sz_error_pattern * (2 - f->test_frames_diversity);
     }
@@ -2461,24 +2462,24 @@ int freedv_get_n_codec_bits             (struct freedv *f){return f->n_codec_bit
 
 void freedv_get_modem_extended_stats(struct freedv *f, struct MODEM_STATS *stats)
 {
-    if (f->mode == FREEDV_MODE_1600)
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_1600, f->mode))
         fdmdv_get_demod_stats(f->fdmdv, stats);
 
-    if ((f->mode == FREEDV_MODE_2400A) || (f->mode == FREEDV_MODE_800XA)) {
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_2400A, f->mode) || FDV_MODE_ACTIVE( FREEDV_MODE_800XA, f->mode)) {
         fsk_get_demod_stats(f->fsk, stats);
         float EbNodB = stats->snr_est;                       /* fsk demod actually estimates Eb/No     */
         stats->snr_est = EbNodB + 10.0*log10f(800.0/3000.0); /* so convert to SNR Rb=800, noise B=3000 */
     }
 
-    if (f->mode == FREEDV_MODE_2400B) {
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_2400B, f->mode)) {
         fmfsk_get_demod_stats(f->fmfsk, stats);
     }
     
-    if ((f->mode == FREEDV_MODE_700) || (f->mode == FREEDV_MODE_700B) || (f->mode == FREEDV_MODE_700C)) {
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_700, f->mode) || FDV_MODE_ACTIVE( FREEDV_MODE_700B, f->mode) || FDV_MODE_ACTIVE( FREEDV_MODE_700C, f->mode)) {
         cohpsk_get_demod_stats(f->cohpsk, stats);
     }
     
-    if (f->mode == FREEDV_MODE_700D) {
+    if (FDV_MODE_ACTIVE( FREEDV_MODE_700D, f->mode)) {
         ofdm_get_demod_stats(f->ofdm, stats);
     }
     

--- a/mchf-eclipse/drivers/freedv/freedv_api.h
+++ b/mchf-eclipse/drivers/freedv/freedv_api.h
@@ -50,6 +50,48 @@
 #define FREEDV_MODE_700C        6
 #define FREEDV_MODE_700D        7
 
+
+#ifndef FREEDV_MODE_EN_DEFAULT
+#define FREEDV_MODE_EN_DEFAULT 1
+#endif
+
+// by default we enable all modes
+// disable during compile time with -DFREEDV_MODE_1600_EN=0
+// all butFreeDV 1600
+
+//or the other way round
+// -DFREEDV_MODE_EN_DEFAULT=0 -DFREEDV_MODE_1600_EN=1
+// only FreeDV 1600
+
+#if !defined(FREEDV_MODE_1600_EN)
+        #define FREEDV_MODE_1600_EN FREEDV_MODE_EN_DEFAULT
+#endif
+#if !defined(FREEDV_MODE_700_EN)
+        #define FREEDV_MODE_700_EN FREEDV_MODE_EN_DEFAULT
+#endif
+#if !defined(FREEDV_MODE_700B_EN)
+        #define FREEDV_MODE_700B_EN FREEDV_MODE_EN_DEFAULT
+#endif
+#if !defined(FREEDV_MODE_700C_EN)
+        #define FREEDV_MODE_700C_EN FREEDV_MODE_EN_DEFAULT
+#endif
+#if !defined(FREEDV_MODE_700D_EN)
+        #define FREEDV_MODE_700D_EN FREEDV_MODE_EN_DEFAULT
+#endif
+#if !defined(FREEDV_MODE_2400A_EN)
+        #define FREEDV_MODE_2400A_EN FREEDV_MODE_EN_DEFAULT
+#endif
+#if !defined(FREEDV_MODE_2400B_EN)
+        #define FREEDV_MODE_2400B_EN FREEDV_MODE_EN_DEFAULT
+#endif
+#if !defined(FREEDV_MODE_800XA_EN)
+        #define FREEDV_MODE_800XA_EN FREEDV_MODE_EN_DEFAULT
+#endif
+
+
+
+#define FDV_MODE_ACTIVE(mode_name, var)  ((mode_name##_EN) == 0 ? 0: (var) == mode_name)
+
 /* operator control of 700D state machine */
       
 #define FREEDV_SYNC_UNSYNC 0                 /* force sync state machine to lose sync, and search for new sync */
@@ -126,12 +168,14 @@ void freedv_set_snr_squelch_thresh	(struct freedv *freedv, float snr_squelch_thr
 void freedv_set_clip	                (struct freedv *freedv, int val);
 void freedv_set_total_bit_errors    	(struct freedv *freedv, int val);
 void freedv_set_total_bits              (struct freedv *freedv, int val);
+void freedv_set_total_bit_errors_coded  (struct freedv *freedv, int val);
+void freedv_set_total_bits_coded        (struct freedv *freedv, int val);
 void freedv_set_callback_error_pattern  (struct freedv *freedv, freedv_calback_error_pattern cb, void *state);
 void freedv_set_varicode_code_num       (struct freedv *freedv, int val);
 void freedv_set_data_header             (struct freedv *freedv, unsigned char *header);
 int  freedv_set_alt_modem_samp_rate     (struct freedv *freedv, int samp_rate);
 void freedv_set_carrier_ampl            (struct freedv *freedv, int c, float ampl);
-void freedv_set_sync                    (struct freedv *freedv, Sync sync_cmd);
+void freedv_set_sync                    (struct freedv *freedv, int sync_cmd);
 void freedv_set_verbose                 (struct freedv *freedv, int verbosity);
 void freedv_set_tx_bpf                  (struct freedv *freedv, int val);
 void freedv_set_ext_vco                 (struct freedv *f, int val);

--- a/mchf-eclipse/drivers/freedv/interldpc.c
+++ b/mchf-eclipse/drivers/freedv/interldpc.c
@@ -28,11 +28,12 @@
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
 #include <math.h>
 
 #include "interldpc.h"
-#include "codec2_ofdm.h"
+#include "ofdm_internal.h"
 #include "mpdecode_core.h"
 #include "gp_interleaver.h"
 #include "HRA_112_112.h"
@@ -119,7 +120,7 @@ void interleaver_sync_state_machine(struct OFDM *ofdm,
     int coded_bits_per_frame = ldpc->coded_bits_per_frame;
     int data_bits_per_frame = ldpc->data_bits_per_frame;
     float llr[coded_bits_per_frame];
-    char out_char[coded_bits_per_frame];
+    uint8_t out_char[coded_bits_per_frame];
     State next_sync_state_interleaver;
 
     next_sync_state_interleaver = ofdm->sync_state_interleaver;
@@ -190,7 +191,7 @@ int count_uncoded_errors(struct LDPC *ldpc, struct OFDM_CONFIG *config, int Nerr
     return Terrs;
 }
 
-int count_errors(int tx_bits[], char rx_bits[], int n) {
+int count_errors(uint8_t tx_bits[], uint8_t rx_bits[], int n) {
     int i;
     int Nerrs = 0;
 

--- a/mchf-eclipse/drivers/freedv/interldpc.h
+++ b/mchf-eclipse/drivers/freedv/interldpc.h
@@ -47,7 +47,7 @@ void interleaver_sync_state_machine(struct OFDM *ofdm, struct LDPC *ldpc, struct
                                     float EsNo, int interleave_frames,
                                     int *inter, int *parityCheckCount, int *Nerrs_coded);
 int count_uncoded_errors(struct LDPC *ldpc, struct OFDM_CONFIG *config, int Nerrs_raw[], int interleave_frames, COMP codeword_symbols_de[]);
-int count_errors(int tx_bits[], char rx_bits[], int n);
+int count_errors(uint8_t tx_bits[], uint8_t rx_bits[], int n);
 void ofdm_ldpc_interleave_tx(struct OFDM *ofdm, struct LDPC *ldpc, complex float tx_sams[], uint8_t tx_bits[], uint8_t txt_bits[], int interleave_frames, struct OFDM_CONFIG *config);
 void build_modulated_uw(struct OFDM *ofdm, complex float tx_symbols[], uint8_t txt_bits[], struct OFDM_CONFIG *config);
 

--- a/mchf-eclipse/drivers/freedv/mpdecode_core.c
+++ b/mchf-eclipse/drivers/freedv/mpdecode_core.c
@@ -491,7 +491,7 @@ return(result);
 
 /* Convenience function to call LDPC decoder from C programs */
 
-int run_ldpc_decoder(struct LDPC *ldpc, char out_char[], float input[], int *parityCheckCount) {
+int run_ldpc_decoder(struct LDPC *ldpc, uint8_t out_char[], float input[], int *parityCheckCount) {
     int         max_iter, dec_type;
     float       q_scale_factor, r_scale_factor;
     int         max_row_weight, max_col_weight;

--- a/mchf-eclipse/drivers/freedv/mpdecode_core.h
+++ b/mchf-eclipse/drivers/freedv/mpdecode_core.h
@@ -34,7 +34,7 @@ struct LDPC {
 
 void encode(struct LDPC *ldpc, unsigned char ibits[], unsigned char pbits[]);
 
-int run_ldpc_decoder(struct LDPC *ldpc, char out_char[], float input[], int *parityCheckCount);
+int run_ldpc_decoder(struct LDPC *ldpc, uint8_t out_char[], float input[], int *parityCheckCount);
 
 void sd_to_llr(float llr[], double sd[], int n);
 void Demod2D(float symbol_likelihood[], COMP r[], COMP S_matrix[], float EsNo, float fading[], float mean_amp, int number_symbols);

--- a/mchf-eclipse/drivers/freedv/ofdm_internal.h
+++ b/mchf-eclipse/drivers/freedv/ofdm_internal.h
@@ -51,6 +51,18 @@ extern "C"
 #define cmplx(value) (COSF(value) + SINF(value) * I)
 #define cmplxconj(value) (COSF(value) + SINF(value) * -I)
 
+typedef enum {
+    search,
+    trial,
+    synced
+} State;
+
+typedef enum {
+    unsync,             /* force sync state machine to lose sync, and search for new sync */
+    autosync,           /* falls out of sync automatically */
+    manualsync          /* fall out of sync only under operator control */
+} Sync;
+
 /*
  * Contains user configuration for OFDM modem
  */
@@ -81,8 +93,8 @@ struct OFDM {
     float *rx_amp;
     float *aphase_est_pilot_log;
 
-    int *tx_uw;
-    
+    uint8_t *tx_uw;
+
     State sync_state;
     State last_sync_state;
     State sync_state_interleaver;
@@ -90,7 +102,7 @@ struct OFDM {
 
     Sync sync_mode;
 
-    struct quisk_cfFilter * ofdm_tx_bpf;
+    struct quisk_cfFilter *ofdm_tx_bpf;
     
     complex float foff_metric;
     
@@ -128,11 +140,11 @@ struct OFDM {
 complex float qpsk_mod(int *);
 void qpsk_demod(complex float, int *);
 void ofdm_txframe(struct OFDM *, complex float *, complex float []);
-void ofdm_assemble_modem_frame(uint8_t [], uint8_t [], uint8_t []);
+void ofdm_assemble_modem_frame(struct OFDM *, uint8_t [], uint8_t [], uint8_t []);
 void ofdm_assemble_modem_frame_symbols(complex float [], COMP [], uint8_t []);
-void ofdm_disassemble_modem_frame(struct OFDM *, int [], COMP [], float [], short []);
+void ofdm_disassemble_modem_frame(struct OFDM *, uint8_t [], COMP [], float [], short []);
 void ofdm_rand(uint16_t [], int);
-void ofdm_generate_payload_data_bits(int payload_data_bits[], int data_bits_per_frame);
+void ofdm_generate_payload_data_bits(uint8_t payload_data_bits[], int data_bits_per_frame);
 
 #ifdef __cplusplus
 }

--- a/mchf-eclipse/drivers/freedv/quantise.c
+++ b/mchf-eclipse/drivers/freedv/quantise.c
@@ -131,8 +131,8 @@ long quantise(const float * cb, float vec[], float w[], int k, int m, float *se)
    for(j=0; j<m; j++) {
 	e = 0.0;
 	for(i=0; i<k; i++) {
-	    diff = (cb[j*k+i]-vec[i]) * w[i];
-	    e += diff*diff;
+	    diff = cb[j*k+i]-vec[i];
+	    e += powf(diff*w[i],2.0);
 	}
 	if (e < beste) {
 	    beste = e;

--- a/mchf-eclipse/drivers/freedv/sine.c
+++ b/mchf-eclipse/drivers/freedv/sine.c
@@ -507,7 +507,7 @@ float est_voicing_mbe(
 
         /* Determine error between estimated harmonic and original */
 
-        offset = FFT_ENC/2 - l*Wo*FFT_ENC/TWO_PI + 0.5;
+// Redundant!        offset = FFT_ENC/2 - l*Wo*FFT_ENC/TWO_PI + 0.5;
         for(m=al; m<bl; m++) {
 	    Ew.real = Sw[m].real - Am.real*W[offset+m].real;
 	    Ew.imag = Sw[m].imag - Am.imag*W[offset+m].real;


### PR DESCRIPTION
- Now make takes care of generating dependency files, so that a change
in a header triggers rebuilding all files using it.
- Only FreeDV 1600 (all processors) and 700D (F7 and H7) are enabled, this
  shrinks our binaries radically.