### PR TITLE
AudioNr fix for silence after using FreeDV and NR (#1749)

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_nr.h
+++ b/mchf-eclipse/drivers/audio/audio_nr.h
@@ -113,6 +113,7 @@ audio_nr_params_t nr_params;
 
 void NR_Init();
 
+void AudioNr_Prepare();
 void AudioNr_HandleNoiseReduction();
 void AudioNr_ActivateAutoNotch(uint8_t notch1_bin, bool notch1_active);
 

--- a/mchf-eclipse/drivers/ui/radio_management.c
+++ b/mchf-eclipse/drivers/ui/radio_management.c
@@ -1081,6 +1081,9 @@ void RadioManagement_SetDemodMode(uint8_t new_mode)
     else if (ts.dmod_mode == DEMOD_DIGI)
     {
             RadioManagement_ChangeCodec(ts.digital_mode,0);
+            // FIXME:  Maybe we should better handle the
+            // mode switching centrally for all modes
+            AudioNr_Prepare(); // prepare AudioNr for use after FreeDV using the same buffer
     }
 
     if (new_mode == DEMOD_FM && ts.dmod_mode != DEMOD_FM)


### PR DESCRIPTION
I could reproduce the issue only with NR on. In this case previous FreeDV
use left residue values which map to float "NaN", which then breaks one of
the audio filter state which then produces only NaN which translates
to silence...