### PR TITLE
FreeDV Update, TX no output power warning and some refactorings

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_agc.c
+++ b/mchf-eclipse/drivers/audio/audio_agc.c
@@ -226,7 +226,7 @@ loadWcpAGC(a);
         agc_wdsp.initialised = true;
     }
     //    var_gain = 32.0;  // slope of the AGC --> this is 10 * 10^(slope / 20) --> for 10dB slope, this is 30.0
-    agc_wdsp.var_gain = powf (10.0, (float32_t)agc_wdsp_conf.slope / 20.0 / 10.0); // 10^(slope / 200)
+    agc_wdsp.var_gain = pow10f((float32_t)agc_wdsp_conf.slope / 20.0 / 10.0); // 10^(slope / 200)
 
     //    hangtime = 0.250;                // hangtime
     agc_wdsp.hangtime = (float32_t)agc_wdsp_conf.hang_time / 1000.0;
@@ -282,7 +282,7 @@ loadWcpAGC(a);
     //  max_gain = out_target / var_gain * powf (10.0, (thresh + noise_offset) / 20.0));
     agc_wdsp.tau_hang_decay = (float32_t)agc_wdsp_conf.tau_hang_decay / 1000.0;
     agc_wdsp.tau_decay = (float32_t)agc_wdsp_conf.tau_decay[agc_wdsp_conf.mode] / 1000.0;
-    agc_wdsp.max_gain = powf (10.0, (float32_t)agc_wdsp_conf.thresh / 20.0);
+    agc_wdsp.max_gain = pow10f ((float32_t)agc_wdsp_conf.thresh / 20.0);
     agc_wdsp.fixed_gain = agc_wdsp.max_gain / 10.0;
     // attack_buff_size is 48 for sample rate == 12000 and
     // 96 for sample rate == 24000
@@ -315,7 +315,7 @@ loadWcpAGC(a);
     if (agc_wdsp.max_input > agc_wdsp.min_volts)
     {
         float32_t convert
-        = powf (10.0, (float32_t)agc_wdsp_conf.hang_thresh / 20.0);
+        = pow10f ((float32_t)agc_wdsp_conf.hang_thresh / 20.0);
         float32_t tmpB = (convert - agc_wdsp.min_volts) / (agc_wdsp.max_input - agc_wdsp.min_volts);
         if(tmpB < 1e-8)
         {
@@ -328,7 +328,7 @@ loadWcpAGC(a);
         agc_wdsp.hang_thresh = 1.0;
     }
 
-    float32_t tmpC = powf (10.0, (agc_wdsp.hang_thresh - 1.0) / 0.125);
+    float32_t tmpC = pow10f ((agc_wdsp.hang_thresh - 1.0) / 0.125);
     agc_wdsp.hang_level = (agc_wdsp.max_input * tmpC + (agc_wdsp.out_target /
             (agc_wdsp.var_gain * agc_wdsp.max_gain)) * (1.0 - tmpC)) * 0.637;
 

--- a/mchf-eclipse/drivers/audio/audio_management.c
+++ b/mchf-eclipse/drivers/audio/audio_management.c
@@ -15,7 +15,7 @@
 void AudioManagement_CalcALCDecay()
 {
     // calculate ALC decay (release) time constant - this needs to be moved to its own function (and the one in "ui_menu.c")
-    ads.alc_decay = powf(10,-((((float32_t)ts.alc_decay_var)+35.0)/10.0));
+    ads.alc_decay = pow10f(-((((float32_t)ts.alc_decay_var)+35.0)/10.0));
 }
 
 // make sure the frequencies below match the order of iq_freq_enum_t !

--- a/mchf-eclipse/drivers/audio/freedv_uhsdr.h
+++ b/mchf-eclipse/drivers/audio/freedv_uhsdr.h
@@ -92,6 +92,7 @@ typedef struct {
 
     uint8_t squelch_snr_thresh;
     uint8_t mode;
+    bool    mute_if_squelched;
 } freedv_conf_t;
 
 extern freedv_conf_t freedv_conf;

--- a/mchf-eclipse/drivers/freedv/codec2.c
+++ b/mchf-eclipse/drivers/freedv/codec2.c
@@ -2090,7 +2090,7 @@ float codec2_energy_700c(struct CODEC2 *c2, const unsigned char * bits)
     if (indexes[3] == 0)
     	mean -= 10;
 
-    return powf(10.0, mean/10.0);
+    return POW10F(mean/10.0);
 }
 
 #ifndef CORTEX_M4
@@ -2113,7 +2113,7 @@ float codec2_energy_450(struct CODEC2 *c2, const unsigned char * bits)
     if (indexes[3] == 0)
     	mean -= 10;
 
-    return powf(10.0, mean/10.0);
+    return POW10F(mean/10.0);
 }
 
 /*---------------------------------------------------------------------------*\

--- a/mchf-eclipse/drivers/freedv/comp_prim.h
+++ b/mchf-eclipse/drivers/freedv/comp_prim.h
@@ -86,7 +86,7 @@ inline static COMP cadd(COMP a, COMP b)
 
 inline static float cabsolute(COMP a)
 {
-    return sqrtf(powf(a.real, 2.0) + powf(a.imag, 2.0));
+    return sqrtf((a.real * a.real) + (a.imag * a.imag) );
 }
 
 /*

--- a/mchf-eclipse/drivers/freedv/defines.h
+++ b/mchf-eclipse/drivers/freedv/defines.h
@@ -112,4 +112,10 @@ extern const struct lsp_codebook newamp1_energy_cb[];
 extern const struct lsp_codebook newamp2vq_cb[];
 extern const struct lsp_codebook newamp2_energy_cb[];
 
+#ifdef __GNUC__
+    #define POW10F(x) pow10f((x))
+#else
+    #define POW10F(x) expf(2.302585092994046f*(x))
+#endif
+
 #endif

--- a/mchf-eclipse/drivers/freedv/fdmdv.c
+++ b/mchf-eclipse/drivers/freedv/fdmdv.c
@@ -1697,8 +1697,9 @@ float calc_snr(int Nc, float sig_est[], float noise_est[])
     int   c;
 
     S = 0.0;
-    for(c=0; c<Nc+1; c++)
-	S += powf(sig_est[c], 2.0);
+    for(c=0; c<Nc+1; c++) {
+        S += sig_est[c] * sig_est[c];
+    }
     SdB = 10.0*log10f(S+1E-12);
 
     /* Average noise mag across all carriers and square to get an
@@ -1710,7 +1711,7 @@ float calc_snr(int Nc, float sig_est[], float noise_est[])
     for(c=0; c<Nc+1; c++)
 	mean += noise_est[c];
     mean /= (Nc+1);
-    N50 = powf(mean, 2.0);
+    N50 = mean * mean;
     N50dB = 10.0*log10f(N50+1E-12);
 
     /* Now multiply by (3000 Hz)/(50 Hz) to find the total noise power
@@ -1972,7 +1973,7 @@ void fdmdv_simulate_channel(float *sig_pwr_av, COMP samples[], int nin, float ta
 
     /* det noise to meet target SNR */
 
-    target_snr_linear = powf(10.0, target_snr/10.0);
+    target_snr_linear = POW10F(target_snr/10.0);
     noise_pwr = *sig_pwr_av/target_snr_linear;       /* noise pwr in a 3000 Hz BW     */
     noise_pwr_1Hz = noise_pwr/3000.0;                  /* noise pwr in a 1 Hz bandwidth */
     noise_pwr_4000Hz = noise_pwr_1Hz*4000.0;           /* noise pwr in a 4000 Hz BW, which

--- a/mchf-eclipse/drivers/freedv/freedv_api.c
+++ b/mchf-eclipse/drivers/freedv/freedv_api.c
@@ -113,7 +113,7 @@ struct freedv *freedv_open(int mode) {
 
 struct freedv *freedv_open_advanced(int mode, struct freedv_advanced *adv) {
     struct freedv *f;
-    int            Nc, codec2_mode, nbit, nbyte;
+    int            Nc, codec2_mode, nbit, nbyte = 0;
 
     if (false == (FDV_MODE_ACTIVE( FREEDV_MODE_1600,mode) || FDV_MODE_ACTIVE( FREEDV_MODE_700,mode) || 
 		FDV_MODE_ACTIVE( FREEDV_MODE_700B,mode) || FDV_MODE_ACTIVE( FREEDV_MODE_2400A,mode) || 

--- a/mchf-eclipse/drivers/freedv/interp.c
+++ b/mchf-eclipse/drivers/freedv/interp.c
@@ -306,7 +306,7 @@ float interp_energy(float prev_e, float next_e)
 
 float interp_energy2(float prev_e, float next_e, float weight)
 {
-    return powf(10.0, (1.0 - weight)*log10f(prev_e) + weight*log10f(next_e));
+    return POW10F((1.0 - weight)*log10f(prev_e) + weight*log10f(next_e));
 
 }
 

--- a/mchf-eclipse/drivers/freedv/mbest.c
+++ b/mchf-eclipse/drivers/freedv/mbest.c
@@ -163,7 +163,7 @@ void mbest_search450(const float  *cb, float vec[], float w[], int k,int shorter
             //Only search first NEWAMP2_K Vectors
             if(i<shorterK){
                 diff = cb[j*k+i]-vec[i];
-                e += powf(diff*w[i],2.0);
+                e += diff*w[i] * diff*w[i];
             }
 	}
 	index[0] = j;

--- a/mchf-eclipse/drivers/freedv/newamp1.c
+++ b/mchf-eclipse/drivers/freedv/newamp1.c
@@ -251,9 +251,9 @@ void post_filter_newamp1(float vec[], float sample_freq_kHz[], int K, float pf_g
     for(k=0; k<K; k++) {
         pre[k] = 20.0*log10f(sample_freq_kHz[k]/0.3);
         vec[k] += pre[k];
-        e_before += powf(10.0, 2.0*vec[k]/20.0);
+        e_before += POW10F(vec[k]/10.0);
         vec[k] *= pf_gain;
-        e_after += powf(10.0, 2.0*vec[k]/20.0);        
+        e_after += POW10F(vec[k]/10.0);
     }
 
     float gain = e_after/e_before;

--- a/mchf-eclipse/drivers/freedv/newamp2.c
+++ b/mchf-eclipse/drivers/freedv/newamp2.c
@@ -230,9 +230,9 @@ void n2_post_filter_newamp2(float vec[], float sample_freq_kHz[], int K, float p
     for(k=0; k<K; k++) {
         pre[k] = 20.0*log10f(sample_freq_kHz[k]/0.3);
         vec[k] += pre[k];
-        e_before += powf(10.0, 2.0*vec[k]/20.0);
+        e_before += POW10F(vec[k]/10.0);
         vec[k] *= pf_gain;
-        e_after += powf(10.0, 2.0*vec[k]/20.0);        
+        e_after += POW10F(vec[k]/10.0);
     }
 
     float gain = e_after/e_before;

--- a/mchf-eclipse/drivers/freedv/postfilter.c
+++ b/mchf-eclipse/drivers/freedv/postfilter.c
@@ -127,11 +127,11 @@ void postfilter(
   */
 
   uv = 0;
-  thresh = powf(10.0, (*bg_est + BG_MARGIN)/20.0);
+  thresh = POW10F((*bg_est + BG_MARGIN)/20.0);
   if (model->voiced)
       for(m=1; m<=model->L; m++)
 	  if (model->A[m] < thresh) {
-	      model->phi[m] = TWO_PI*(float)codec2_rand()/CODEC2_RAND_MAX;
+	      model->phi[m] = (TWO_PI/CODEC2_RAND_MAX)*(float)codec2_rand();
 	      uv++;
 	  }
 

--- a/mchf-eclipse/drivers/freedv/quantise.c
+++ b/mchf-eclipse/drivers/freedv/quantise.c
@@ -132,7 +132,7 @@ long quantise(const float * cb, float vec[], float w[], int k, int m, float *se)
 	e = 0.0;
 	for(i=0; i<k; i++) {
 	    diff = cb[j*k+i]-vec[i];
-	    e += powf(diff*w[i],2.0);
+	    e += (diff*w[i] * diff*w[i]);
 	}
 	if (e < beste) {
 	    beste = e;
@@ -1068,7 +1068,7 @@ float decode_log_Wo(C2CONST *c2const, int index, int bits)
     step = (log10f(Wo_max) - log10f(Wo_min))/Wo_levels;
     Wo   = log10f(Wo_min) + step*(index);
 
-    return powf(10,Wo);
+    return POW10F(Wo);
 }
 
 #if 0
@@ -1810,7 +1810,7 @@ float decode_energy(int index, int bits)
 
     step = (e_max - e_min)/e_levels;
     e    = e_min + step*(index);
-    e    = powf(10.0,e/10.0);
+    e    = POW10F(e/10.0);
 
     return e;
 }
@@ -1963,7 +1963,7 @@ void quantise_WoE(C2CONST *c2const, MODEL *model, float *e, float xq[])
 
   model->L  = PI/model->Wo; /* if we quantise Wo re-compute L */
 
-  *e = powf(10.0, xq[1]/10.0);
+  *e = POW10F(xq[1]/10.0);
 }
 
 /*---------------------------------------------------------------------------*\
@@ -2046,6 +2046,6 @@ void decode_WoE(C2CONST *c2const, MODEL *model, float *e, float xq[], int n1)
 
   model->L  = PI/model->Wo; /* if we quantise Wo re-compute L */
 
-  *e = powf(10.0, xq[1]/10.0);
+  *e = POW10F(xq[1]/10.0);
 }
 

--- a/mchf-eclipse/drivers/ui/ui_configuration.c
+++ b/mchf-eclipse/drivers/ui/ui_configuration.c
@@ -960,9 +960,6 @@ uint16_t UiConfiguration_SaveEepromValues(void)
     }
     else
     {
-        // disable DSP during write because it decreases speed tremendous
-        //  ts.dsp.active &= 0xfa;  // turn off DSP
-
         const uint8_t dmod_mode = ts.dmod_mode;
 
         // TODO: THIS IS UGLY: We are switching to RAM based storage in order to gain speed


### PR DESCRIPTION
 TX with uncalibrated PA now shows error messages

- we warn at startup about missing PA Bias setting
- we warn at TX start if the calculated power factor is zero
  (i.e. no output power will be generated at all)

FreeDV updates

squelched now passes ssb audio if no freedv signal is detected
(i.e. signal is squelched)