### PR TITLE
Fix for - CW memory 2nd time #1754

### DIFF
--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -1238,7 +1238,14 @@ void UiAction_ToggleVfoAB()
 
 	uint32_t old_dmod_mode = ts.dmod_mode;
 
+	/**
+	 * @warning - The two functions below call the same function
+	 * -> RadioManagement_SetDemodMode() at the end,
+	 * so some reorganization should be done to better handle switching modes,
+	 * in a more central way...
+	 */
 	RadioManagement_ToggleVfoAB();
+	UiDriver_SetDemodMode( ts.dmod_mode );
 
 	UiDriver_FButton_F4ActiveVFO();
 


### PR DESCRIPTION
There is a kind of inconsistency in switching modes.
UiDriver_SetDemodMode() was not called during VFO changing.
Probably this was the cause of similar issues with other digi modes but not known yet.
It's the easiest way to fix it but as always is not the best one.