### PR TITLE
Fix for DSP switch is stuck at a specific mode

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.h
+++ b/mchf-eclipse/drivers/audio/audio_driver.h
@@ -495,15 +495,19 @@ extern uint32_t fm_tone_burst_freq[FM_TONE_BURST_MAX+1];
 #define	DSP_NOTCH_MU_DEFAULT		10//25		// default convergence setting for the notch
 #endif
 
-#define DSP_SWITCH_OFF				0
-#define DSP_SWITCH_NR				1
-#define DSP_SWITCH_NOTCH			2
-#define DSP_SWITCH_NR_AND_NOTCH		3
-#define DSP_SWITCH_NOTCH_MANUAL		4
-#define DSP_SWITCH_PEAK_FILTER		5
-#define DSP_SWITCH_BASS				98
-#define DSP_SWITCH_TREBLE			99
-#define DSP_SWITCH_MAX				6 // bass & treble not used here
+typedef enum
+{
+    DSP_SWITCH_OFF			=	0,
+    DSP_SWITCH_NR,
+    DSP_SWITCH_NOTCH,
+    DSP_SWITCH_NR_AND_NOTCH,
+    DSP_SWITCH_NOTCH_MANUAL,
+    DSP_SWITCH_PEAK_FILTER,
+    DSP_SWITCH_MAX,				// bass & treble not used here
+    DSP_SWITCH_BASS          =   98,
+    DSP_SWITCH_TREBLE        =   99,
+} dsp_mode_t;
+
 #define DSP_SWITCH_MODEMASK_ENABLE_MASK             ((1<<DSP_SWITCH_MAX)-1)
 #define DSP_SWITCH_MODEMASK_ENABLE_DEFAULT              ((1<<DSP_SWITCH_MAX)-1)
 #define DSP_SWITCH_MODEMASK_ENABLE_DSPOFF           (1<<DSP_SWITCH_OFF)

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -6058,7 +6058,7 @@ void UiAction_ChangeLowerMeterUp()
  * @param dsp_mode a valid dsp mode id
  * @return true if dsp_mode is currently available, false otherwise
  */
-static bool UiDriver_IsDspModePermitted(uint16_t dsp_mode)
+static bool UiDriver_IsDspModePermitted(dsp_mode_t dsp_mode)
 {
     bool neg_retval = dsp_mode >= DSP_SWITCH_MAX;
 
@@ -6066,10 +6066,10 @@ static bool UiDriver_IsDspModePermitted(uint16_t dsp_mode)
     neg_retval |= ts.dmod_mode == DEMOD_CW && ( dsp_mode == DSP_SWITCH_NR_AND_NOTCH || dsp_mode == DSP_SWITCH_NOTCH);
 
     // prevent NR AND NOTCH, when in AM and decimation rate equals 2 --> high CPU load)
-    neg_retval |= (dsp_mode == DSP_SWITCH_NR_AND_NOTCH) && (ts.dmod_mode == DEMOD_AM) && (ts.filters_p->sample_rate_dec == RX_DECIMATION_RATE_24KHZ);
+    neg_retval |= (dsp_mode == DSP_SWITCH_NR_AND_NOTCH) && (ts.dmod_mode == DEMOD_AM) && (ads.decimated_freq >= 24000);
 
     // prevent using a mode not enabled in the dsp mode selection (i.e. user configured it to be not used, although available)
-    neg_retval |= (ts.dsp.mode_mask&(1<<ts.dsp.mode)) == 0;
+    neg_retval |= (ts.dsp.mode_mask&(1<<dsp_mode)) == 0;
 
     // not forbidden, so return true;
     return neg_retval == false;


### PR DESCRIPTION
If the user disable a DSP mode in the touch environment,
switching to the disabled mode was possible (which was clearly not
intended) but then switching to the next mode was no longer possible
until reboot...