### PR TITLE
 Separated Wattmeter and Bandfilter Control, User-selectable Band Definitions

### DIFF
--- a/mchf-eclipse/drivers/ui/menu/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu.c
@@ -725,11 +725,11 @@ bool __attribute__ ((noinline)) UiDriverMenuBandPowerAdjust(int var, MenuProcess
     return tchange;
 }
 
-bool __attribute__ ((noinline))  UiDriverMenuBandRevCouplingAdjust(int var, MenuProcessingMode_t mode, uint8_t filter_band, char* options, uint32_t* clr_ptr)
+bool __attribute__ ((noinline))  UiDriverMenuBandRevCouplingAdjust(int var, MenuProcessingMode_t mode, uint8_t coupling_band, char* options, uint32_t* clr_ptr)
 {
     bool tchange = false;
-    volatile uint8_t *adj_ptr = &swrm.coupling_calc[filter_band];
-    if(ts.filter_band == filter_band)	 	// is this band selected?
+    volatile uint8_t *adj_ptr = &swrm.coupling_calc[coupling_band];
+    if(ts.coupling_band == coupling_band)	 	// is this band selected?
     {
         tchange = UiDriverMenuItemChangeUInt8(var, mode, adj_ptr,
                                               SWR_COUPLING_MIN,
@@ -738,7 +738,7 @@ bool __attribute__ ((noinline))  UiDriverMenuBandRevCouplingAdjust(int var, Menu
                                               1
                                              );
     }
-    if((ts.txrx_mode != TRX_MODE_TX) || (ts.filter_band != filter_band))	// Orange if not in TX mode or NOT on this band
+    if((ts.txrx_mode != TRX_MODE_TX) || (ts.coupling_band != coupling_band))	// Orange if not in TX mode or NOT on this band
         *clr_ptr = Orange;
     sprintf(options, "  %u", *adj_ptr);
     return tchange;

--- a/mchf-eclipse/drivers/ui/menu/ui_menu.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu.c
@@ -701,7 +701,8 @@ bool __attribute__ ((noinline)) UiDriverMenuBandPowerAdjust(int var, MenuProcess
      volatile uint8_t* adj_ptr = &ts.pwr_adj[pa_level == PA_LEVEL_FULL?ADJ_FULL_POWER:ADJ_REF_PWR][band_mode];
 
     bool tchange = false;
-    if((band_mode == RadioManagement_GetBand(df.tune_old)) && (ts.power_level == pa_level))
+    const BandInfo* band = RadioManagement_GetBand(df.tune_old);
+    if((band_mode == band->band_mode) && (ts.power_level == pa_level))
     {
         tchange = UiDriverMenuItemChangeUInt8(var, mode, adj_ptr,
                                               TX_POWER_FACTOR_MIN,
@@ -712,7 +713,7 @@ bool __attribute__ ((noinline)) UiDriverMenuBandPowerAdjust(int var, MenuProcess
 
         if(tchange)	 		// did something change?
         {
-            RadioManagement_SetPowerLevel(band_mode, pa_level);	// yes, update the power factor
+            RadioManagement_SetPowerLevel(band, pa_level);	// yes, update the power factor
         }
     }
     else
@@ -4175,6 +4176,16 @@ void UiMenu_UpdateItem(uint16_t select, MenuProcessingMode_t mode, int pos, int 
         snprintf(options,32,"     %s",digimodes[ts.digital_mode].label);
         clr = digimodes[ts.digital_mode].enabled?White:Red;
         break;
+    case MENU_DEBUG_BANDEF_SELECT:
+        var_change = UiDriverMenuItemChangeUInt8(var, mode, &bandinfo_idx,0,BAND_INFO_SET_NUM-1,0,1);
+        if (var_change)
+        {
+            bandInfo = bandInfos[bandinfo_idx].bands;
+            UiDriver_UpdateDisplayAfterParamChange();
+        }
+        snprintf(options,32,"     %s",bandInfos[bandinfo_idx].name);
+        break;
+
     case CONFIG_CAT_PTT_RTS:
         var_change = UiDriverMenuItemChangeEnableOnOffBool(var, mode, &ts.enable_ptt_rts,0,options,&clr);
         break;

--- a/mchf-eclipse/drivers/ui/menu/ui_menu_internal.h
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu_internal.h
@@ -316,6 +316,7 @@ enum
     CONFIG_SMETER_ATTACK,
     CONFIG_SMETER_DECAY,
     MENU_DEBUG_SMOOTH_DYN_TUNE,
+    MENU_DEBUG_BANDEF_SELECT,
     MAX_RADIO_CONFIG_ITEM   // Number of radio configuration menu items - This must ALWAYS remain as the LAST item!
 };
 

--- a/mchf-eclipse/drivers/ui/menu/ui_menu_structure.c
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu_structure.c
@@ -464,6 +464,7 @@ const MenuDescriptor debugGroup[] =
     { MENU_DEBUG, MENU_ITEM, MENU_DEBUG_FREEDV_MODE, NULL, "FreeDV Mode", UiMenuDesc("Change active FreeDV mode. Please note, you have to reboot to activate new mode") },
     { MENU_DEBUG, MENU_ITEM, MENU_DEBUG_FREEDV_SQL_THRESHOLD, NULL, "FreeDV Squelch threshold", UiMenuDesc("If not OFF, FreeDV will squelch if detected SNR is below set value.") },
     { MENU_DEBUG, MENU_ITEM, MENU_DEBUG_SMOOTH_DYN_TUNE, NULL, "Smooth dynamic tune", UiMenuDesc("Activate smooth dynamic tune.") },
+    { MENU_DEBUG, MENU_ITEM, MENU_DEBUG_BANDEF_SELECT, NULL, "Band Definition", UiMenuDesc("Select which band definition to use for ham bands (Original UHSDR or IARU Region 1 - 3") },
 
 	{ MENU_DEBUG, MENU_STOP, 0, NULL, NULL, UiMenuDesc("") }
 };

--- a/mchf-eclipse/drivers/ui/radio_management.c
+++ b/mchf-eclipse/drivers/ui/radio_management.c
@@ -82,28 +82,137 @@ DialFrequency               df;
 // Bands definition
 //
 //
-//
-const BandInfo bandInfo[] =
+// We first define all individual band definitions
+static const BandInfo bi_2200m_all =   { .tune = 135700,       .size = 2100,       .name = "2200m", BAND_MODE_2200};
+static const BandInfo bi_630m_all =    { .tune = 472000,       .size = 7000,       .name = "630m",  BAND_MODE_630};
+static const BandInfo bi_160m_all =    { .tune = 1810000,      .size = 190000,     .name = "160m",  BAND_MODE_160};
+static const BandInfo bi_80m_r1 =      { .tune = 3500000,      .size = 300000,     .name = "80m",   BAND_MODE_80};
+static const BandInfo bi_80m_r2 =      { .tune = 3500000,      .size = 500000,     .name = "80m",   BAND_MODE_80};
+static const BandInfo bi_80m_r3 =      { .tune = 3500000,      .size = 400000,     .name = "80m",   BAND_MODE_80};
+static const BandInfo bi_60m_gen =     { .tune = 5250000,      .size = 200000,     .name = "60m",   BAND_MODE_60};
+static const BandInfo bi_40m_r1 =      { .tune = 7000000,      .size = 200000,     .name = "40m",   BAND_MODE_40};
+static const BandInfo bi_40m_r2_3 =    { .tune = 7000000,      .size = 300000,     .name = "40m",   BAND_MODE_40};
+static const BandInfo bi_30m_all =     { .tune = 10100000,     .size = 50000,      .name = "30m",   BAND_MODE_30};
+static const BandInfo bi_20m_all =     { .tune = 14000000,     .size = 350000,     .name = "20m",   BAND_MODE_20};
+static const BandInfo bi_17m_all =     { .tune = 18068000,     .size = 100000,     .name = "17m",   BAND_MODE_17};
+static const BandInfo bi_15m_all =     { .tune = 21000000,     .size = 450000,     .name = "15m",   BAND_MODE_15};
+static const BandInfo bi_12m_all =     { .tune = 24890000,     .size = 100000,     .name = "12m",   BAND_MODE_12};
+static const BandInfo bi_10m_all =     { .tune = 28000000,     .size = 1700000,    .name = "10m",   BAND_MODE_10};
+static const BandInfo bi_6m_r2_3 =     { .tune = 50000000,     .size = 4000000,    .name = "6m",    BAND_MODE_6};
+static const BandInfo bi_4m_gen =      { .tune = 70000000,     .size = 500000,     .name = "4m",    BAND_MODE_4};
+static const BandInfo bi_2m_r1 =       { .tune = 144000000,    .size = 2000000,    .name = "2m",    BAND_MODE_2};
+static const BandInfo bi_2m_r2_3 =     { .tune = 144000000,    .size = 4000000,    .name = "2m",    BAND_MODE_2};
+static const BandInfo bi_70cm_r1 =     { .tune = 430000000,    .size = 10000000,   .name = "70cm",  BAND_MODE_70};
+static const BandInfo bi_70cm_r2_3 =   { .tune = 430000000,    .size = 20000000,   .name = "70cm",  BAND_MODE_70};
+static const BandInfo bi_23cm_all =    { .tune = 1240000000,   .size = 60000000,   .name = "23cm",  BAND_MODE_23};
+static const BandInfo bi_gen_all =     { .tune = 0,            .size = 0,          .name = "Gen",   BAND_MODE_GEN};
+
+// now we combine from the above defined bands the set of bands for each region
+// to be backwards compatible we provide the original set of bands which are
+// the maximum band size from the 3 different IARU regions
+// IMPORTANT: Right now the order of bands in the list is fixed to the order of BAND_MODE_xxx (low to high)
+// TODO: Make this list ordered by frequency
+static const BandInfo bandInfo_combined[MAX_BAND_NUM] =
 {
-    { .tune = 3500000, .size = 500000, .name = "80m"} , // Region 2
-    { .tune = 5250000, .size = 200000, .name = "60m"} , // should cover all regions
-    { .tune = 7000000, .size = 300000, .name = "40m"} , // Region 2
-    { .tune = 10100000, .size = 50000, .name = "30m"} ,
-    { .tune = 14000000, .size = 350000, .name = "20m"} ,
-    { .tune = 18068000, .size = 100000, .name = "17m"} ,
-    { .tune = 21000000, .size = 450000, .name = "15m"} ,
-    { .tune = 24890000, .size = 100000, .name = "12m"} ,
-    { .tune = 28000000, .size = 1700000, .name = "10m"} ,
-    { .tune = 50000000, .size = 2000000, .name = "6m"} , // Region 2
-    { .tune = 70000000, .size = 500000, .name = "4m"} ,
-    { .tune = 144000000, .size = 2000000, .name = "2m"} , // Region 1
-    { .tune = 430000000, .size = 10000000, .name = "70cm"} , // Region 1
-    { .tune = 1240000000, .size = 60000000, .name = "23cm"} , // Region 1
-    { .tune = 135.7000, .size = 2.1000, .name = "2200m"} , // Region 1
-    { .tune = 472000, .size = 7000, .name = "630m"} , // Region 1
-    { .tune = 1810000, .size = 190000, .name = "160m"} ,
-    { .tune = 0, .size = 0, .name = "Gen"} ,
+    bi_80m_r2,
+    bi_60m_gen,
+    bi_40m_r2_3,
+    bi_30m_all,
+    bi_20m_all,
+    bi_17m_all,
+    bi_15m_all,
+    bi_12m_all,
+    bi_10m_all,
+    bi_6m_r2_3,
+    bi_4m_gen,
+    bi_2m_r2_3,
+    bi_70cm_r2_3,
+    bi_23cm_all,
+    bi_2200m_all,
+    bi_630m_all,
+    bi_160m_all,
+    bi_gen_all,
 };
+
+static const BandInfo bandInfo_region1[MAX_BAND_NUM] =
+{
+        bi_80m_r1,
+        bi_60m_gen, // should cover all regions
+        bi_40m_r1,
+        bi_30m_all,
+        bi_20m_all,
+        bi_17m_all,
+        bi_15m_all,
+        bi_12m_all,
+        bi_10m_all,
+        bi_6m_r2_3,
+        bi_4m_gen,
+        bi_2m_r1,
+        bi_70cm_r1,
+        bi_23cm_all,
+        bi_2200m_all,
+        bi_630m_all,
+        bi_160m_all,
+        bi_gen_all,
+};
+
+static const BandInfo bandInfo_region2[MAX_BAND_NUM] =
+{
+        bi_80m_r2,
+        bi_60m_gen, // should cover all regions
+        bi_40m_r2_3,
+        bi_30m_all,
+        bi_20m_all,
+        bi_17m_all,
+        bi_15m_all,
+        bi_12m_all,
+        bi_10m_all,
+        bi_6m_r2_3,
+        bi_4m_gen,
+        bi_2m_r2_3,
+        bi_70cm_r2_3,
+        bi_23cm_all,
+        bi_2200m_all,
+        bi_630m_all,
+        bi_160m_all,
+        bi_gen_all,
+};
+
+static const BandInfo bandInfo_region3[MAX_BAND_NUM] =
+{
+        bi_80m_r3,
+        bi_60m_gen, // should cover all regions
+        bi_40m_r2_3,
+        bi_30m_all,
+        bi_20m_all,
+        bi_17m_all,
+        bi_15m_all,
+        bi_12m_all,
+        bi_10m_all,
+        bi_6m_r2_3,
+        bi_4m_gen,
+        bi_2m_r2_3,
+        bi_70cm_r2_3,
+        bi_23cm_all,
+        bi_2200m_all,
+        bi_630m_all,
+        bi_160m_all,
+        bi_gen_all,
+};
+
+// finally we list all of them in a table and give them names for the menu
+const BandInfoSet bandInfos[] =
+{
+        { bandInfo_combined, "R1+2+3" },
+        { bandInfo_region1,  "Region 1" },
+        { bandInfo_region2,  "Region 2" },
+        { bandInfo_region3,  "Region 3" },
+};
+
+const int BAND_INFO_SET_NUM = sizeof(bandInfos)/sizeof(BandInfoSet);
+
+const BandInfo *bandInfo = bandInfos[0].bands;
+uint8_t bandinfo_idx; // default init with 0 is fine
 
 // this structure MUST match the order of entries in power_level_t !
 static const power_level_desc_t mchf_rf_power_levels[] =
@@ -221,12 +330,12 @@ float32_t RadioManagement_CalculatePowerFactorScale(float32_t powerMw)
  * @param band
  * @return true if the power factor value differs from previous
  */
-static bool RadioManagement_SetBandPowerFactor(band_mode_t band, int32_t power)
+static bool RadioManagement_SetBandPowerFactor(const BandInfo* band, int32_t power)
 {
     float32_t   pf_bandvalue;    // used as a holder for percentage of power output scaling
 
     // FIXME: This code needs fixing, the hack for TX Outside should at least reduce power factor for lower bands
-    if (band >= MAX_BANDS)
+    if (RadioManagement_IsGenericBand(band)) // we are outside a TX band
     {
         // TX outside bands **very dirty hack**
         //  FIXME: calculate based on 2 frequency points close the selected frequency, should be inter-/extrapolated
@@ -243,7 +352,7 @@ static bool RadioManagement_SetBandPowerFactor(band_mode_t band, int32_t power)
     }
     else
     {
-        pf_bandvalue = ts.pwr_adj[power == 0?ADJ_FULL_POWER:ADJ_REF_PWR][band];
+        pf_bandvalue = ts.pwr_adj[power == 0?ADJ_FULL_POWER:ADJ_REF_PWR][band->band_mode];
     }
 
     pf_bandvalue /= RadioManagement_IsPowerFactorReduce(df.tune_old)? 400: 100;
@@ -289,16 +398,16 @@ bool RadioManagement_UsesTxSidetone()
  * @param power_level The requested power level (as PA_LEVEL constants). Invalid values are not accepted
  * @returns true if power level has been changed, false otherwise
  */
-bool RadioManagement_SetPowerLevel(band_mode_t band, power_level_t power_level)
+bool RadioManagement_SetPowerLevel(const BandInfo* band, power_level_t power_level)
 {
     bool retval = false;
     bool power_modified = false;
 
     int32_t power = power_level < mchf_power_levelsInfo.count ? mchf_power_levelsInfo.levels[power_level].mW : -1;
 
-    if (power != -1)
+    if (power != -1 && band != NULL)
     {
-        if (band >= MAX_BANDS)
+        if (RadioManagement_IsGenericBand(band))
         {
             if(ts.flags1 & FLAGS1_TX_OUTSIDE_BANDS)
             {
@@ -837,8 +946,7 @@ void RadioManagement_SwitchTxRx(uint8_t txrx_mode, bool tune_mode)
         // there might have been a band change between the modes, make sure to have the power settings fitting the mode
         if (txrx_mode_final == TRX_MODE_TX)
         {
-            uint8_t tx_band = RadioManagement_GetBand(tune_new);
-            RadioManagement_SetPowerLevel(tx_band,ts.power_level);
+            RadioManagement_SetPowerLevel(RadioManagement_GetBand(tune_new),ts.power_level);
         }
 
         AudioManagement_SetSidetoneForDemodMode(ts.dmod_mode,txrx_mode_final == TRX_MODE_RX?false:tune_mode);
@@ -919,7 +1027,7 @@ bool RadioManagement_CalculateCWSidebandMode()
     {
     case CW_SB_AUTO:                     // For "auto" modes determine if we are above or below threshold frequency
         // if (RadioManagement_SSB_AutoSideBand(df.tune_new) == DEMOD_USB)   // is the current frequency above the USB threshold?
-        retval = (df.tune_new <= USB_FREQ_THRESHOLD && RadioManagement_GetBand(df.tune_new) != BAND_MODE_60);
+        retval = (df.tune_new <= USB_FREQ_THRESHOLD && RadioManagement_GetBand(df.tune_new)->band_mode != BAND_MODE_60);
         // is the current frequency below the USB threshold AND is it not 60m? -> LSB
         break;
     case CW_SB_LSB:
@@ -1134,7 +1242,7 @@ bool RadioManagement_FreqIsInBand(const BandInfo* bandinfo, const uint32_t freq)
  * @param freq in Hz
  * @return the ham band or BAND_MODE_GEN if not a known ham band
  */
-uint8_t RadioManagement_GetBand(uint32_t freq)
+const BandInfo* RadioManagement_GetBand(uint32_t freq)
 {
     static band_mode_t band_scan_old = BAND_MODE_GEN;
     band_mode_t   band_scan;
@@ -1142,7 +1250,7 @@ uint8_t RadioManagement_GetBand(uint32_t freq)
     band_scan = BAND_MODE_GEN;
 
     // first try the previously selected band, and see if it is an match
-    if (band_scan_old != BAND_MODE_GEN && freq >= bandInfo[band_scan_old].tune && freq <= (bandInfo[band_scan_old].tune + bandInfo[band_scan_old].size))
+    if (band_scan_old != BAND_MODE_GEN && RadioManagement_FreqIsInBand(&bandInfo[band_scan_old], freq))
     {
         band_scan = band_scan_old;
     }
@@ -1159,13 +1267,13 @@ uint8_t RadioManagement_GetBand(uint32_t freq)
     }
 
 
-    return band_scan;       // return with the band
+    return &bandInfo[band_scan];       // return with the band
 }
 
 uint32_t RadioManagement_SSB_AutoSideBand(uint32_t freq) {
     uint32_t retval;
 
-    if((ts.lsb_usb_auto_select == AUTO_LSB_USB_60M) && ((freq < USB_FREQ_THRESHOLD) && (RadioManagement_GetBand(freq) != BAND_MODE_60)))       // are we <10 MHz and NOT on 60 meters?
+    if((ts.lsb_usb_auto_select == AUTO_LSB_USB_60M) && ((freq < USB_FREQ_THRESHOLD) && (RadioManagement_GetBand(freq)->band_mode != BAND_MODE_60)))       // are we <10 MHz and NOT on 60 meters?
     {
         retval = DEMOD_LSB;
     }
@@ -1552,8 +1660,7 @@ bool RadioManagement_UpdatePowerAndVSWR()
                 swrm.high_vswr_detected = true;
 
                 // change output power to "PA_LEVEL_0_5W" when VSWR protection is active
-                uint8_t tx_band = RadioManagement_GetBand ( df.tune_new);
-                RadioManagement_SetPowerLevel ( tx_band, PA_LEVEL_0_5W );
+                RadioManagement_SetPowerLevel ( RadioManagement_GetBand ( df.tune_new), PA_LEVEL_0_5W );
             }
         }
 

--- a/mchf-eclipse/drivers/ui/radio_management.h
+++ b/mchf-eclipse/drivers/ui/radio_management.h
@@ -297,7 +297,6 @@ bool RadioManagement_FreqIsInBand(const BandInfo* bandinfo, const uint32_t freq)
 bool RadioManagement_SetPowerLevel(band_mode_t band, power_level_t power_level);
 bool RadioManagement_Tune(bool tune);
 bool RadioManagement_UpdatePowerAndVSWR();
-void RadioManagement_SetHWFiltersForFrequency(ulong freq);
 void RadioManagement_ChangeCodec(uint32_t codec, bool enableCodec);
 bool RadioManagement_ChangeFrequency(bool force_update, uint32_t dial_freq,uint8_t txrx_mode);
 void RadioManagement_HandlePttOnOff();

--- a/mchf-eclipse/drivers/ui/radio_management.h
+++ b/mchf-eclipse/drivers/ui/radio_management.h
@@ -172,9 +172,29 @@ typedef struct BandInfo
     uint32_t tune;
     uint32_t size;
     const char* name;
+    uint32_t band_mode;
 } BandInfo;
 
-extern const BandInfo bandInfo[MAX_BAND_NUM];
+/**
+ *
+ * @param band
+ * @return true if band is the so called generic band (everything which is not ham tx)
+ */
+static inline bool RadioManagement_IsGenericBand(const BandInfo* band)
+{
+    return band->size == 0;
+}
+
+typedef struct
+{
+    const BandInfo* bands;
+    const char* name;
+} BandInfoSet;
+
+extern const BandInfoSet bandInfos[];
+extern const int BAND_INFO_SET_NUM;
+extern uint8_t bandinfo_idx;
+extern const BandInfo *bandInfo;
 
 typedef struct band_regs_s
 {
@@ -292,9 +312,9 @@ inline bool RadioManagement_IsTxDisabledBy(uint8_t whom)
 }
 
 uint32_t RadioManagement_GetRealFreqTranslationMode(uint32_t txrx_mode, uint32_t dmod_mode, uint32_t iq_freq_mode);
-band_mode_t RadioManagement_GetBand(ulong freq);
+const BandInfo* RadioManagement_GetBand(ulong freq);
 bool RadioManagement_FreqIsInBand(const BandInfo* bandinfo, const uint32_t freq);
-bool RadioManagement_SetPowerLevel(band_mode_t band, power_level_t power_level);
+bool RadioManagement_SetPowerLevel(const BandInfo* band, power_level_t power_level);
 bool RadioManagement_Tune(bool tune);
 bool RadioManagement_UpdatePowerAndVSWR();
 void RadioManagement_ChangeCodec(uint32_t codec, bool enableCodec);

--- a/mchf-eclipse/hardware/uhsdr_board.h
+++ b/mchf-eclipse/hardware/uhsdr_board.h
@@ -294,6 +294,8 @@ typedef struct TransceiverState
 
     bool	rx_temp_mute;
     uint8_t	filter_band;		// filter selection band:  1= 80, 2= 60/40, 3=30/20, 4=17/15/12/10 - used for selection of power detector coefficient selection.
+#define FILTER_BAND_UNKNOWN 255 // used to indicate that we don't know how the BPF is set
+    uint8_t coupling_band;      // which tx wattmeter coupling factor value to use
     //
     // Receive/Transmit public flag
     uint8_t 	txrx_mode;

--- a/mchf-eclipse/hardware/uhsdr_board.h
+++ b/mchf-eclipse/hardware/uhsdr_board.h
@@ -240,6 +240,8 @@ typedef struct vfo_reg_s
 //    uint32_t filter_mode;
 } VfoReg;
 
+typedef struct BandInfo BandInfo; // forward declaration of BandInfo data type, we need this to be able to make a pointer to it.
+
 // Transceiver state public structure
 typedef struct TransceiverState
 {
@@ -289,8 +291,8 @@ typedef struct TransceiverState
 
     // Ham band public flag
     // index of bands table in Flash
-    uint8_t 	band; // this band idx does not relate to the real frequency, it is a "just" a memory index.
-    uint8_t     band_effective; // the band the currently selected frequency is in (which may be different from the band memory idx);
+    uint8_t 	        band; // this band idx does not relate to the real frequency, it is a "just" a memory index.
+    const BandInfo*     band_effective; // the band the currently selected frequency is in (which may be different from the band memory idx);
 
     bool	rx_temp_mute;
     uint8_t	filter_band;		// filter selection band:  1= 80, 2= 60/40, 3=30/20, 4=17/15/12/10 - used for selection of power detector coefficient selection.

--- a/mchf-eclipse/src/uhsdr_main.c
+++ b/mchf-eclipse/src/uhsdr_main.c
@@ -141,7 +141,7 @@ void TransceiverStateInit(void)
 
     //CONFIG LOADED: ts.band		  		= BAND_MODE_20;			// band from eeprom
     ts.rx_temp_mute		= false;					// used in muting audio during band change
-    ts.filter_band		= 0;					// used to indicate the bpf filter selection for power detector coefficient selection
+    ts.filter_band		= FILTER_BAND_UNKNOWN;	// used to indicate the bpf filter selection for power detector coefficient selection
     ts.dmod_mode 		= DEMOD_USB;				// demodulator mode
     //CONFIG LOADED: ts.rx_gain[RX_AUDIO_SPKR].value = AUDIO_GAIN_DEFAULT;
     ts.rx_gain[RX_AUDIO_DIG].value		= DIG_GAIN_DEFAULT;

--- a/mchf-eclipse/src/uhsdr_main.c
+++ b/mchf-eclipse/src/uhsdr_main.c
@@ -317,7 +317,7 @@ void TransceiverStateInit(void)
 
     //CONFIG LOADED:ts.expflags1 = 0; // Used to hold flags for options in Debag/Expert menu, stored in EEPROM location "EEPROM_EXPFLAGS1"
 
-    ts.band_effective = 255; // this is an invalid band number, which will trigger a redisplay of the band name and the effective power
+    ts.band_effective = NULL; // this is an invalid band number, which will trigger a redisplay of the band name and the effective power
 }
 
 // #include "Trace.h"


### PR DESCRIPTION
* Separated Wattmeter and Bandfilter Control
Both concepts have frequency dependent calibrations/actions, but not the
same frequency ranges. Makes code a little more easy to understand.
Also fix an issue that the BPF may not be correctly configured after
startup because we (possibly incorrectly) assume the  BPF to be
configured for bandfilter band 0.


* Experimental Support for user selectable band definitions
In the debug menu, there is now an item to select the most appropriate
band definition. In addition to the original definition, which is basically
region 2, we have the 3 IARU regions.
As this is experimental, we don't save the setting yet. But this is of course
planned.