### PR TITLE
Limit TX to frequencies supported by PA

### DIFF
--- a/mchf-eclipse/drivers/ui/radio_management.c
+++ b/mchf-eclipse/drivers/ui/radio_management.c
@@ -735,7 +735,11 @@ void RadioManagement_MuteTemporarilyRxAudio()
 Oscillator_ResultCodes_t RadioManagement_ValidateFrequencyForTX(uint32_t dial_freq)
 {
     // we check with the si570 code if the frequency is tunable, we do not tune to it.
-    return osc->prepareNextFrequency(RadioManagement_Dial2TuneFrequency(dial_freq, TRX_MODE_TX), df.temp_factor);
+    bool osc_ok = osc->prepareNextFrequency(RadioManagement_Dial2TuneFrequency(dial_freq, TRX_MODE_TX), df.temp_factor);
+    // we also check if our PA is able to support this frequency
+    bool pa_ok = dial_freq >= mchf_pa.min_freq && dial_freq <= mchf_pa.max_freq;
+
+    return pa_ok && osc_ok;
 }
 
 /**


### PR DESCRIPTION
Right now only MCHF PA is defined, which has 1.8 Mhz to 32Mhz range 