### PR TITLE
Fix TX PA range not obeyed

### DIFF
--- a/mchf-eclipse/drivers/ui/radio_management.c
+++ b/mchf-eclipse/drivers/ui/radio_management.c
@@ -735,11 +735,13 @@ void RadioManagement_MuteTemporarilyRxAudio()
 Oscillator_ResultCodes_t RadioManagement_ValidateFrequencyForTX(uint32_t dial_freq)
 {
     // we check with the si570 code if the frequency is tunable, we do not tune to it.
-    bool osc_ok = osc->prepareNextFrequency(RadioManagement_Dial2TuneFrequency(dial_freq, TRX_MODE_TX), df.temp_factor);
-    // we also check if our PA is able to support this frequency
+	Oscillator_ResultCodes_t osc_res = osc->prepareNextFrequency(RadioManagement_Dial2TuneFrequency(dial_freq, TRX_MODE_TX), df.temp_factor);
+    bool osc_ok = osc_res == OSC_OK || osc_res == OSC_TUNE_LIMITED;
+	
+	// we also check if our PA is able to support this frequency
     bool pa_ok = dial_freq >= mchf_pa.min_freq && dial_freq <= mchf_pa.max_freq;
 
-    return pa_ok && osc_ok;
+    return pa_ok && osc_ok ? osc_res: OSC_TUNE_IMPOSSIBLE;
 }
 
 /**


### PR DESCRIPTION
The code was plain wrong, unfortunately the compiler did not detect the improper use of wrong data types without casts...