### PR TITLE
fixed typo Debag into Debug

### DIFF
--- a/mchf-eclipse/drivers/ui/ui_configuration.h
+++ b/mchf-eclipse/drivers/ui/ui_configuration.h
@@ -607,7 +607,7 @@ void		UiConfiguration_UpdateMacroCap(void);
 #define EEPROM_TX_IQ_10M_UP_GAIN_BALANCE_TRANS_OFF	424
 #define EEPROM_TX_IQ_10M_UP_PHASE_BALANCE_TRANS_OFF	425
 #define EEPROM_VSWR_PROTECTION_THRESHOLD            426
-#define EEPROM_EXPFLAGS1                            427     // Flags for options in Debag/Expert menu - see variable "expflags1"
+#define EEPROM_EXPFLAGS1                            427     // Flags for options in Debug/Expert menu - see variable "expflags1"
 #define EEPROM_FIRST_UNUSED                         428		// change this if new value ids are introduced, must be correct at any time
 
 #define MAX_VAR_ADDR (EEPROM_FIRST_UNUSED - 1)

--- a/mchf-eclipse/hardware/uhsdr_board.h
+++ b/mchf-eclipse/hardware/uhsdr_board.h
@@ -489,23 +489,23 @@ typedef struct TransceiverState
 #define FLAGS1_REVERSE_X_TOUCHSCREEN	0x4000  // 1 = X direcction of touchscreen is mirrored
 #define FLAGS1_REVERSE_Y_TOUCHSCREEN	0x8000  // 1 = Y direcction of touchscreen is mirrored
 
-    uint16_t    expflags1;              // Used to hold flags for options in Debag/Expert menu, stored in EEPROM location "EEPROM_EXPFLAGS1"
+    uint16_t    expflags1;              // Used to hold flags for options in Debug/Expert menu, stored in EEPROM location "EEPROM_EXPFLAGS1"
 #define EXPFLAGS1_SMOOTH_DYNAMIC_TUNE   0x01    // 1 = Smooth dynamic tune is ON
-// #define EXPFLAGS1_RESERVE_1          0x02    // Reserve flag for options in Debag/Expert menu
-// #define EXPFLAGS1_RESERVE_2          0x04    // Reserve flag for options in Debag/Expert menu
-// #define EXPFLAGS1_RESERVE_3          0x08    // Reserve flag for options in Debag/Expert menu
-// #define EXPFLAGS1_RESERVE_4          0x10    // Reserve flag for options in Debag/Expert menu
-// #define EXPFLAGS1_RESERVE_5          0x20    // Reserve flag for options in Debag/Expert menu
-// #define EXPFLAGS1_RESERVE_6          0x40    // Reserve flag for options in Debag/Expert menu
-// #define EXPFLAGS1_RESERVE_7          0x80    // Reserve flag for options in Debag/Expert menu
-// #define EXPFLAGS1_RESERVE_8          0x100   // Reserve flag for options in Debag/Expert menu
-// #define EXPFLAGS1_RESERVE_9          0x200   // Reserve flag for options in Debag/Expert menu
-// #define EXPFLAGS1_RESERVE_10         0x400   // Reserve flag for options in Debag/Expert menu
-// #define EXPFLAGS1_RESERVE_11         0x800   // Reserve flag for options in Debag/Expert menu
-// #define EXPFLAGS1_RESERVE_12         0x1000  // Reserve flag for options in Debag/Expert menu
-// #define EXPFLAGS1_RESERVE_13         0x2000  // Reserve flag for options in Debag/Expert menu
-// #define EXPFLAGS1_RESERVE_14         0x4000  // Reserve flag for options in Debag/Expert menu
-// #define EXPFLAGS1_RESERVE_15         0x8000  // Reserve flag for options in Debag/Expert menu
+// #define EXPFLAGS1_RESERVE_1          0x02    // Reserve flag for options in Debug/Expert menu
+// #define EXPFLAGS1_RESERVE_2          0x04    // Reserve flag for options in Debug/Expert menu
+// #define EXPFLAGS1_RESERVE_3          0x08    // Reserve flag for options in Debug/Expert menu
+// #define EXPFLAGS1_RESERVE_4          0x10    // Reserve flag for options in Debug/Expert menu
+// #define EXPFLAGS1_RESERVE_5          0x20    // Reserve flag for options in Debug/Expert menu
+// #define EXPFLAGS1_RESERVE_6          0x40    // Reserve flag for options in Debug/Expert menu
+// #define EXPFLAGS1_RESERVE_7          0x80    // Reserve flag for options in Debug/Expert menu
+// #define EXPFLAGS1_RESERVE_8          0x100   // Reserve flag for options in Debug/Expert menu
+// #define EXPFLAGS1_RESERVE_9          0x200   // Reserve flag for options in Debug/Expert menu
+// #define EXPFLAGS1_RESERVE_10         0x400   // Reserve flag for options in Debug/Expert menu
+// #define EXPFLAGS1_RESERVE_11         0x800   // Reserve flag for options in Debug/Expert menu
+// #define EXPFLAGS1_RESERVE_12         0x1000  // Reserve flag for options in Debug/Expert menu
+// #define EXPFLAGS1_RESERVE_13         0x2000  // Reserve flag for options in Debug/Expert menu
+// #define EXPFLAGS1_RESERVE_14         0x4000  // Reserve flag for options in Debug/Expert menu
+// #define EXPFLAGS1_RESERVE_15         0x8000  // Reserve flag for options in Debug/Expert menu
 #define EXPFLAGS1_CONFIG_DEFAULT        0x0000  // Default flags state
 
 #ifdef UI_BRD_MCHF

--- a/mchf-eclipse/src/uhsdr_main.c
+++ b/mchf-eclipse/src/uhsdr_main.c
@@ -314,7 +314,7 @@ void TransceiverStateInit(void)
 
     ts.debug_vswr_protection_threshold = 1; // OFF
 
-    //CONFIG LOADED:ts.expflags1 = 0; // Used to hold flags for options in Debag/Expert menu, stored in EEPROM location "EEPROM_EXPFLAGS1"
+    //CONFIG LOADED:ts.expflags1 = 0; // Used to hold flags for options in Debug/Expert menu, stored in EEPROM location "EEPROM_EXPFLAGS1"
 
     ts.band_effective = NULL; // this is an invalid band number, which will trigger a redisplay of the band name and the effective power
 }


### PR DESCRIPTION
changed the references from "Debag/Expert mmenu" to "Debug/Expert menu" in the comments.
As there is nog code change, I did not bump the version. 