### PR TITLE
mistake corrected in hex2dfu - do not preserve use of tobinstr() pyth…

### DIFF
--- a/mchf-eclipse/support/hex2dfu/hex2dfu.py
+++ b/mchf-eclipse/support/hex2dfu/hex2dfu.py
@@ -66,6 +66,10 @@ def save_dfu(ih):
     #
     image_data = ih.tobinarray()
 
+    if len(image_data) != len(bytes(image_data)):
+        # catch and correct python2.7 issue using this hack
+        image_data = ih.tobinstr()
+
     data = struct.pack(
         "<II",
         ih.minaddr(),       # dwElementAddress

--- a/mchf-eclipse/support/hex2dfu/hex2dfu.py
+++ b/mchf-eclipse/support/hex2dfu/hex2dfu.py
@@ -64,13 +64,13 @@ def save_dfu(ih):
 
     # Image element
     #
-    image_data = ih.tobinstr()
+    image_data = ih.tobinarray()
 
     data = struct.pack(
         "<II",
         ih.minaddr(),       # dwElementAddress
         len(image_data)     # dwElementSize
-    ) + bytes(image_data,"utf-8")          # Data
+    ) + bytes(image_data)   # Data
 
     # Target prefix
     #


### PR DESCRIPTION
…on2-ism - use tobinarray()
with this done, 2.11.78 and python3 produces
```
$ du -sh fw-*
420K    fw-mchf.bin
420K    fw-mchf.dfu
2.7M    fw-mchf.elf
832K    fw-mchf.map
```
the difference between the dfu file and the bin is 309 bytes.