### PR TITLE
python2 and python3 compatible handbook generation (fix for #1843)

### DIFF
--- a/mchf-eclipse/support/ui/menu/mk-menu-handbook
+++ b/mchf-eclipse/support/ui/menu/mk-menu-handbook
@@ -2,6 +2,7 @@
 
 # 2017-01-01 HB9ocq - removed WA (escape commas)
 
+PYTHON=${PYTHON:-python}
 
 # automated build only by DF8OE
 if [ "$1" == "auto" ] && [ ! -f ../DF8OE ]; then
@@ -31,13 +32,13 @@ else
 	echo "building menu-handbook..."
 	cp -v uhsdr-logo.png support/ui/menu > /dev/zero
 	(cd support/ui/menu  \
-		&&  python2 ./ui_menu_structure_c2py.py | python -  \
-		&&  python2 ./ui_menu_structure_graph.py > ui_menu_structure_graph.gv  \
+		&&  ${PYTHON} ./ui_menu_structure_c2py.py | ${PYTHON} -  \
+		&&  ${PYTHON} ./ui_menu_structure_graph.py > ui_menu_structure_graph.gv  \
 		&&  dot -Tsvg -oui_menu_structure_graph.svg  ui_menu_structure_graph.gv  \
 		&&  dot -Tpng -oui_menu_structure_graph.png  ui_menu_structure_graph.gv \
 	)
 	(cd support/ui/menu  \
-		&&  python2 ./ui_menu_structure_mdtable.py > ui_menu_structure_mdtable.md \
+		&&  ${PYTHON} ./ui_menu_structure_mdtable.py > ui_menu_structure_mdtable.md \
 	)
 	(echo $(stat -c%y drivers/ui/menu/ui_menu_structure.c) > support/ui/menu/menu-handbook-build.timestamp)
 	echo "menu-handbook build completed."

--- a/mchf-eclipse/support/ui/menu/ui_menu_structure_c2py.py
+++ b/mchf-eclipse/support/ui/menu/ui_menu_structure_c2py.py
@@ -34,7 +34,7 @@ INPUT_C_SRC = MCHF_BASEDIR + r"drivers/ui/menu/ui_menu_structure.c"
 MAJ = subprocess.check_output('cat ' + MCHF_VERSIONFILE + ' | cut -d " " -f 2 | grep "TRX4M" | egrep -e "^[^#]" | grep "MAJOR" | cut -d "\\"" -f 2 | tr -d $"\n"', shell = True)
 MIN = subprocess.check_output('cat ' + MCHF_VERSIONFILE + ' | cut -d " " -f 2 | grep "TRX4M" | egrep -e "^[^#]" | grep "MINOR" | cut -d "\\"" -f 2 | tr -d $"\n"', shell = True)
 REL = subprocess.check_output('cat ' + MCHF_VERSIONFILE + ' | cut -d " " -f 2 | grep "TRX4M" | egrep -e "^[^#]" | grep "RELEASE" | cut -d "\\"" -f 2 | tr -d $"\n"', shell = True)
-BUILD_ID = MAJ + "." + MIN + "." + REL
+BUILD_ID = MAJ.decode() + "." + MIN.decode() + "." + REL.decode()
 
 # reading version from mchf.bin
 #BUILD_ID = subprocess.check_output('grep -aPo "(?<=fwv-)[^fwt]+" ../../../mchf.bin | cut -d "" -f 1 | tr -d $"\n"', shell = True)


### PR DESCRIPTION
Any python should work now (tested with python2 and python3)
Default is just to call python, but with
`PYTHON=python2 make handbook-ui-menu-clean handbook-ui-menu`
or
`PYTHON=python3 make handbook-ui-menu-clean handbook-ui-menu`
you can make it call whatever python you want.