### PR TITLE
Fix for RTTY macro not working properly (#1852)

### DIFF
--- a/mchf-eclipse/drivers/audio/rtty.c
+++ b/mchf-eclipse/drivers/audio/rtty.c
@@ -803,8 +803,8 @@ int16_t Rtty_Modulator_GenSample()
 			// load the character and add the stop bits;
 			bool bitsFilled = false;
             uint8_t current_ascii;
-			while ( DigiModes_TxBufferRemove( &current_ascii, RTTY )
-			        && bitsFilled == false )
+			while ( bitsFilled == false
+			        && DigiModes_TxBufferRemove( &current_ascii, RTTY ) )
 			{
 			    if (current_ascii == 0x04 ) //EOT
 			    {


### PR DESCRIPTION
We must not take one more character out of tx buffer it is not used. Moving bitsFilled == filled before the buffer read solves this problem.