### PR TITLE
VSWR foldback protection only when min power available

### DIFF
--- a/mchf-eclipse/drivers/ui/radio_management.c
+++ b/mchf-eclipse/drivers/ui/radio_management.c
@@ -38,6 +38,7 @@
 
 #include "ui_configuration.h"
 #include "ui_menu.h"  // for CONFIG_160M_FULL_POWER_ADJUST and Co.
+#include "ui_driver.h" // for SWR_MIN_CALC_POWER
 
 #include "config_storage.h"
 
@@ -1713,7 +1714,8 @@ bool RadioManagement_UpdatePowerAndVSWR()
 
         swrm.vswr = (1+sqrtf(swrm.rev_pwr/swrm.fwd_pwr))/(1-sqrtf(swrm.rev_pwr/swrm.fwd_pwr));
 
-        if ( ts.vswr_protection_threshold > 1 )
+		// Perform VSWR protection iff threshold is > 1 AND enough forward power exists for a valid calculation
+        if ( ts.vswr_protection_threshold > 1 && swrm.fwd_pwr >= SWR_MIN_CALC_POWER)
         {
             if ( swrm.vswr > ts.vswr_protection_threshold )
             {


### PR DESCRIPTION
While testing SSB transmit on the MCHF I kept having VSWR protection kick in (blinking TX).  This would not happen during tune or if I used a 100% duty cycle mode like FM.  After troubleshooting I realized this only happened when the transmit power level dropped.  The UI code set precedent for not computing SWR (for display purposes) if a minimum forward power was not met.  I took this concept and applied it to the VSWR foldback protection code.   I tested this on an MCHF under the same conditions as before and had no issue with VSWR protection kicking in.