### PR TITLE
Improved Macro Keyer labels and DigiTX Buffer refactoring

### DIFF
--- a/mchf-eclipse/drivers/audio/cw/uhsdr_digi_buffer.c
+++ b/mchf-eclipse/drivers/audio/cw/uhsdr_digi_buffer.c
@@ -45,11 +45,28 @@ digi_buff_consumer_t DigiModes_Set_BufferConsumer( digi_buff_consumer_t consumer
     return prev_consumer;
 }
 
+/**
+ * Amount of available characters in tx transmit buffer
+ * @return number of available characters in buffer or 0 if empty
+ */
 uint8_t DigiModes_TxBufferHasData()
 {
     int32_t len = digimodes_tx_buffer_head - digimodes_tx_tail;
     return len < 0 ? ( len + DIGIMODES_TX_BUFFER_SIZE ) : len;
 }
+
+/**
+ * Amount of available characters in tx transmit buffer for a specific customer (RTTY, UI, etc.)
+ * @param consumer who wants to read (must match active consumer)
+ * @return number of available characters in buffer or 0 if empty or not for active consumer
+ */
+uint8_t DigiModes_TxBufferHasDataFor(digi_buff_consumer_t consumer)
+{
+    assert((consumer & RTTY) || (consumer & BPSK) || (consumer & CW) || (consumer & UI));
+
+    return (consumer == active_consumer) ? DigiModes_TxBufferHasData() : 0;
+}
+
 
 bool DigiModes_TxBufferRemove( uint8_t* c_ptr, digi_buff_consumer_t consumer )
 {

--- a/mchf-eclipse/drivers/audio/cw/uhsdr_digi_buffer.h
+++ b/mchf-eclipse/drivers/audio/cw/uhsdr_digi_buffer.h
@@ -29,6 +29,7 @@ extern "C" {
 #endif
 
 uint8_t DigiModes_TxBufferHasData();
+uint8_t DigiModes_TxBufferHasDataFor(digi_buff_consumer_t consumer);
 
 /*
  * The Digi buffer has multi consumers, some of them trying to get an entry

--- a/mchf-eclipse/drivers/audio/psk.c
+++ b/mchf-eclipse/drivers/audio/psk.c
@@ -734,25 +734,27 @@ int16_t Psk_Modulator_GenSample()
                         Psk_Modulator_SetState(PSK_MOD_ACTIVE);
                     }
                 }
-                else if (DigiModes_TxBufferHasData())
+                else if (DigiModes_TxBufferHasData(BPSK))
                 {
-                    DigiModes_TxBufferRemove( &psk_state.tx_char, BPSK );
-                    Psk_Modulator_SetState(PSK_MOD_ACTIVE);
-                    if (psk_state.tx_char == 0x04) // EOT, stop tranmission
+                    if (DigiModes_TxBufferRemove( &psk_state.tx_char, BPSK ))
                     {
-                        // we send from buffer, and nothing more is in the buffer
-                        // request sending the trailing sequence
-                        Psk_Modulator_SetState(PSK_MOD_POSTAMBLE);
-                    }
-                    else
-                    {
-                        // if all zeros have been sent, look for new
-                        // input from input buffer
-                        psk_state.tx_bits = Bpsk_FindCharReversed(psk_state.tx_char);
-                        // reset counter for spacing zeros
-                        psk_state.tx_zeros = 0;
-                        // reset counter for trailing postamble (which conclude a transmission)
-                        psk_state.tx_ones = 0;
+                        Psk_Modulator_SetState(PSK_MOD_ACTIVE);
+                        if (psk_state.tx_char == 0x04) // EOT, stop tranmission
+                        {
+                            // we send from buffer, and nothing more is in the buffer
+                            // request sending the trailing sequence
+                            Psk_Modulator_SetState(PSK_MOD_POSTAMBLE);
+                        }
+                        else
+                        {
+                            // if all zeros have been sent, look for new
+                            // input from input buffer
+                            psk_state.tx_bits = Bpsk_FindCharReversed(psk_state.tx_char);
+                            // reset counter for spacing zeros
+                            psk_state.tx_zeros = 0;
+                            // reset counter for trailing postamble (which conclude a transmission)
+                            psk_state.tx_ones = 0;
+                        }
                     }
                 }
 

--- a/mchf-eclipse/drivers/audio/rtty.c
+++ b/mchf-eclipse/drivers/audio/rtty.c
@@ -802,21 +802,29 @@ int16_t Rtty_Modulator_GenSample()
 		{
 			// load the character and add the stop bits;
 			bool bitsFilled = false;
-            uint8_t current_ascii;
+
 			while ( bitsFilled == false
-			        && DigiModes_TxBufferRemove( &current_ascii, RTTY ) )
+			        &&  DigiModes_TxBufferHasDataFor(RTTY))
 			{
-			    if (current_ascii == 0x04 ) //EOT
+
+			    uint8_t current_ascii;
+
+			    // as the character might have been removed from the buffer,
+			    // we do a final check when removing the character
+			    if (DigiModes_TxBufferRemove( &current_ascii, RTTY ))
 			    {
-			        RadioManagement_Request_TxOff();
-			    }
-			    else
-			    {
-			        uint8_t current_baudot = Ascii2Baudot[current_ascii & 0x7f];
-			        if (current_baudot > 0)
-			        { // we have valid baudot code
-			            Rtty_Modulator_Code2Bits(current_baudot);
-			            bitsFilled = true;
+			        if (current_ascii == 0x04 ) //EOT
+			        {
+			            RadioManagement_Request_TxOff();
+			        }
+			        else
+			        {
+			            uint8_t current_baudot = Ascii2Baudot[current_ascii & 0x7f];
+			            if (current_baudot > 0)
+			            { // we have valid baudot code
+			                Rtty_Modulator_Code2Bits(current_baudot);
+			                bitsFilled = true;
+			            }
 			        }
 			    }
 			}

--- a/mchf-eclipse/drivers/ui/ui_configuration.c
+++ b/mchf-eclipse/drivers/ui/ui_configuration.c
@@ -789,27 +789,6 @@ static void __attribute__ ((noinline)) UiConfiguration_ReadConfigEntries(bool lo
     }
 }
 
-void UiConfiguration_UpdateMacroCap(void)
-{
-	for (int i = 0; i < KEYER_BUTTONS; i++)
-	{
-		if (*ts.keyer_mode.macro[i] != '\0')
-		{
-			// Make button label from start of the macro
-		    uint8_t* pmacro = (uint8_t *)ts.keyer_mode.macro[i];
-			int c = 0;
-			while(*pmacro != ' ' && *pmacro != '\0' && c < KEYER_CAP_LEN)
-			{
-				ts.keyer_mode.cap[i][c++] = *pmacro++;
-			}
-			ts.keyer_mode.cap[i][c] = '\0';
-		}
-		else
-		{
-			strcpy((char *) ts.keyer_mode.cap[i], "BTN");
-		}
-	}
-}
 /**
  * Calculate based on current firmware version and stored configuration values, which parameters were not present in the stored configuration and
  * do need to be initialized / reset to the default value.
@@ -943,7 +922,6 @@ void UiConfiguration_LoadEepromValues(bool load_freq_mode_defaults, bool load_ee
     UiReadSettingEEPROM_Filter(load_eeprom_defaults);
 
     ConfigStorage_CopySerial2Array(EEPROM_KEYER_MEMORY_ADDRESS, (uint8_t *)ts.keyer_mode.macro, sizeof(ts.keyer_mode.macro));
-    UiConfiguration_UpdateMacroCap();
 
     // post configuration loading actions below
     df.tuning_step  = tune_steps[df.selected_idx];

--- a/mchf-eclipse/drivers/ui/ui_configuration.h
+++ b/mchf-eclipse/drivers/ui/ui_configuration.h
@@ -47,7 +47,6 @@ const ConfigEntryDescriptor* UiConfiguration_GetEntry(uint16_t id);
 
 void        UiConfiguration_LoadEepromValues(bool load_freq_mode_defaults, bool load_eeprom_defaults);
 uint16_t    UiConfiguration_SaveEepromValues(void);
-void		UiConfiguration_UpdateMacroCap(void);
 
 // Configuration Value Definitions Follow
 //


### PR DESCRIPTION
- Aligned access to tx buffer: all character removal from digi tx buffer during transmit now checks for buffer being assigned to mode
- Now non-printable characters like ENTER show up as underscore. Empty macros are indicated
by yellow 'empty'.
Removed Macro Label code from ui_configuration, labels and colors are (re-)generated
on demand now.

