### PR TITLE
Fix for #1858 RTTY 2 ASCII gets some things wrong

### DIFF
--- a/mchf-eclipse/drivers/audio/rtty.c
+++ b/mchf-eclipse/drivers/audio/rtty.c
@@ -614,10 +614,20 @@ static bool RttyDecoder_waitForStartBit(float32_t sample) {
 }
 
 
+// character tables borrowed from fldigi / rtty.cxx
+static const char RTTYLetters[] = {
+	'\0',	'E',	'\n',	'A',	' ',	'S',	'I',	'U',
+	'\r',	'D',	'R',	'J',	'N',	'F',	'C',	'K',
+	'T',	'Z',	'L',	'W',	'H',	'Y',	'P',	'Q',
+	'O',	'B',	'G',	' ',	'M',	'X',	'V',	' '
+};
 
-static const char RTTYLetters[] = "<E\nA SIU\nDRJNFCKTZLWHYPQOBG^MXV^";
-static const char RTTYSymbols[] = "<3\n- ,87\n$4#,.:(5+)2.60197.^./=^";
-
+static const char RTTYSymbols[32] = {
+	'\0',	'3',	'\n',	'-',	' ',	'\a',	'8',	'7',
+	'\r',	'$',	'4',	'\'',	',',	'!',	':',	'(',
+	'5',	'"',	')',	'2',	'#',	'6',	'0',	'1',
+	'9',	'?',	'&',	' ',	'.',	'/',	';',	' '
+};
 
 void Rtty_Demodulator_ProcessSample(float32_t sample)
 {


### PR DESCRIPTION
The tables we have been using had obviously issues. Now we use the same tables as fldigi for RTTY to ASCII. Which should be checked against our ASCII 2 Baudot.