### PR TITLE
Fix compiler warnings regarding abs function and float/int arguments.

### DIFF
--- a/mchf-eclipse/drivers/freedv/c2wideband.c
+++ b/mchf-eclipse/drivers/freedv/c2wideband.c
@@ -257,7 +257,7 @@ void correct_rate_K_vec(MODEL *model, float rate_K_vec[], float rate_K_sample_fr
             float cka = K;
             int k;
             for (k = 0; k < K; k++) {
-                float a = abs(rate_K_sample_freqs_kHz[k] - nasty_error_freq);
+                float a = fabsf(rate_K_sample_freqs_kHz[k] - nasty_error_freq);
 
                 if (closest_k == -1 || a < cka) {
                     closest_k = k;
@@ -295,8 +295,8 @@ void correct_rate_K_vec(MODEL *model, float rate_K_vec[], float rate_K_sample_fr
             for (m = 0; m < C2WB_K - 1; m++) {
                 //[tmp st_m] = min(abs(Am_freqs_kHz - rate_K_prev_sample_kHz));
                 //[tmp en_m] = min(abs(Am_freqs_kHz - rate_K_next_sample_kHz));
-                int pa = abs(Am_freqs_kHz[m] - rate_K_prev_sample_kHz);
-                int na = abs(abs(Am_freqs_kHz[m] - rate_K_next_sample_kHz));
+                int pa = abs((int)(Am_freqs_kHz[m] - rate_K_prev_sample_kHz));
+                int na = abs((int)(Am_freqs_kHz[m] - rate_K_next_sample_kHz));
                 if (st == -1 || pa < st) {
                     st = pa;
                     st_m = m;


### PR DESCRIPTION
Just for fun I tried building with `gcc-arm-none-eabi-9-2019-q4-major`.  There were compile warnings in the FreeDV code that were surfaced by `-Wabsolute-value`.  As a fix, if the variable being assigned to was a float I used the `fabsf` function otherwise the float math was cast to `int` before passing to the function.  For the latter two lines of code this is likely a no-op (but at least it tells the reader the behavior is expected).  For the first line of code this may change the output since float->int->float conversion no longer occurs (this can have an impact on decimal precision of the resulting float).  Also on line 299 the abs function was called twice.  Since abs() is idempotent calling it once is sufficent.

I tested this by performing a FreeDV 1600 QSO between the MCHF and a Yaesu991A+Raspberry Pi running the latest FreeDV.  No discernable difference detected between audio and no issues decoding Text Frame.

Note, while the issue was discovered by building with `gcc-arm-none-eabi-9-2019-q4-major` all tests were run with firmware built using `gcc-arm-none-eabi-8-2019-q3-update`.