### PR TITLE
Fixed () vs. (void) signature

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_agc.h
+++ b/mchf-eclipse/drivers/audio/audio_agc.h
@@ -40,7 +40,7 @@ extern agc_wdsp_params_t agc_wdsp_conf;
 
 void AudioAgc_RunAgcWdsp(int16_t blockSize, float32_t (*agcbuffer)[AUDIO_BLOCK_SIZE], const bool use_stereo );
 void AudioAgc_SetupAgcWdsp(float32_t sample_rate, bool remove_dc);
-void AudioAgc_AgcWdsp_Init();
+void AudioAgc_AgcWdsp_Init(void);
 
 
 #endif

--- a/mchf-eclipse/drivers/audio/audio_driver.h
+++ b/mchf-eclipse/drivers/audio/audio_driver.h
@@ -645,8 +645,8 @@ extern lLMS leakyLMS;
 // Exports
 void AudioDriver_Init(void);
 void AudioDriver_SetProcessingChain(uint8_t dmod_mode, bool reset_dsp_nr);
-int32_t AudioDriver_GetTranslateFreq();
-void AudioDriver_SetSamPllParameters ();
+int32_t AudioDriver_GetTranslateFreq(void);
+void AudioDriver_SetSamPllParameters (void);
 
 void AudioDriver_I2SCallback(AudioSample_t *audio, IqSample_t *iq, AudioSample_t *audioDst, int16_t size);
 
@@ -657,6 +657,6 @@ void AudioDriver_CalcBandpass(float32_t coeffs[5], float32_t f0, float32_t FS);
 void AudioDriver_SetBiquadCoeffs(float32_t* coeffsTo,const float32_t* coeffsFrom);
 
 void AudioDriver_IQPhaseAdjust(uint16_t txrx_mode, float32_t* i_buffer, float32_t* q_buffer, const uint16_t blockSize);
-void AudioDriver_AgcWdsp_Set();
+void AudioDriver_AgcWdsp_Set(void);
 
 #endif

--- a/mchf-eclipse/drivers/audio/audio_filter.h
+++ b/mchf-eclipse/drivers/audio/audio_filter.h
@@ -156,8 +156,8 @@ uint8_t  AudioFilter_NextApplicableFilterPath(const uint16_t query, const uint16
 bool     AudioFilter_IsApplicableFilterPath(const uint16_t query, const uint16_t filter_mode, const uint8_t filter_path);
 void     AudioFilter_GetNamesOfFilterPath(uint16_t filter_path,const char** filter_names);
 uint16_t AudioFilter_GetFilterModeFromDemodMode(uint8_t dmod_mode);
-uint8_t  AudioFilter_NextApplicableFilter();
-void     AudioFilter_SetDefaultMemories();
+uint8_t  AudioFilter_NextApplicableFilter(void);
+void     AudioFilter_SetDefaultMemories(void);
 
 
 typedef struct

--- a/mchf-eclipse/drivers/audio/audio_management.h
+++ b/mchf-eclipse/drivers/audio/audio_management.h
@@ -19,20 +19,20 @@
 
 void    AudioManagement_CalcIqPhaseGainAdjust(float32_t freq);
 
-void    AudioManagement_CalcTxCompLevel();
-void    AudioManagement_CalcNB_AGC();
-void    AudioManagement_CalcAGCVals();
-void    AudioManagement_CalcRFGain();
-void    AudioManagement_CalcALCDecay();
-void    AudioManagement_CalcAGCDecay();
+void    AudioManagement_CalcTxCompLevel(void);
+void    AudioManagement_CalcNB_AGC(void);
+void    AudioManagement_CalcAGCVals(void);
+void    AudioManagement_CalcRFGain(void);
+void    AudioManagement_CalcALCDecay(void);
+void    AudioManagement_CalcAGCDecay(void);
 void    AudioManagement_SetSidetoneForDemodMode(uint8_t dmod_mode, bool tune_mode);
 
-void    AudioManagement_LoadToneBurstMode();
+void    AudioManagement_LoadToneBurstMode(void);
 void    AudioManagement_CalcSubaudibleGenFreq(float32_t freq);        // load/set current FM subaudible tone settings for generation
 void    AudioManagement_CalcSubaudibleDetFreq(float32_t freq);
 
-void    AudioManagement_KeyBeep();
-void    AudioManagement_KeyBeepPrepare();
+void    AudioManagement_KeyBeep(void);
+void    AudioManagement_KeyBeepPrepare(void);
 
 #define IQ_BALANCE_OFF  -128 // Minimum setting for IQ balance
 #define IQ_BALANCE_MAX  127 // Maximum setting for IQ balance

--- a/mchf-eclipse/drivers/audio/audio_nr.h
+++ b/mchf-eclipse/drivers/audio/audio_nr.h
@@ -111,10 +111,10 @@ typedef struct
 audio_nr_params_t nr_params;
 
 
-void NR_Init();
+void NR_Init(void);
 
-void AudioNr_Prepare();
-void AudioNr_HandleNoiseReduction();
+void AudioNr_Prepare(void);
+void AudioNr_HandleNoiseReduction(void);
 void AudioNr_ActivateAutoNotch(uint8_t notch1_bin, bool notch1_active);
 
 
@@ -122,18 +122,18 @@ int NR_in_buffer_peek(NR_Buffer** c_ptr);
 int NR_in_buffer_remove(NR_Buffer** c_ptr);
 /* no room left in the buffer returns 0 */
 int NR_in_buffer_add(NR_Buffer* c);
-void NR_in_buffer_reset();
-int8_t NR_in_has_data();
-int32_t NR_in_has_room();
+void NR_in_buffer_reset(void);
+int8_t NR_in_has_data(void);
+int32_t NR_in_has_room(void);
 
 
 int NR_out_buffer_peek(NR_Buffer** c_ptr);
 int NR_out_buffer_remove(NR_Buffer** c_ptr);
 /* no room left in the buffer returns 0 */
 int NR_out_buffer_add(NR_Buffer* c);
-void NR_out_buffer_reset();
-int8_t NR_out_has_data();
-int32_t NR_out_has_room();
+void NR_out_buffer_reset(void);
+int8_t NR_out_has_data(void);
+int32_t NR_out_has_room(void);
 #endif
 
 #endif

--- a/mchf-eclipse/drivers/audio/codec/codec.h
+++ b/mchf-eclipse/drivers/audio/codec/codec.h
@@ -45,10 +45,10 @@ void     Codec_IQInGainAdj(uint8_t gain);
 void 	 Codec_MuteDAC(bool state);
 
 uint32_t Codec_Reset(uint32_t AudioFreq);
-void     Codec_RestartI2S();
+void     Codec_RestartI2S(void);
 void     Codec_TxSidetoneSetgain(uint8_t mode);
 void     Codec_SwitchMicTxRxMode(uint8_t mode);
 void     Codec_PrepareTx(uint8_t current_txrx_mode);
 
-bool     Codec_ReadyForIrqCall();
+bool     Codec_ReadyForIrqCall(void);
 #endif

--- a/mchf-eclipse/drivers/audio/codec/uhsdr_hw_i2s.h
+++ b/mchf-eclipse/drivers/audio/codec/uhsdr_hw_i2s.h
@@ -17,10 +17,10 @@
 
 #include "uhsdr_board_config.h"
 
-void UhsdrHwI2s_Codec_StartDMA();
-void UhsdrHwI2s_Codec_StopDMA();
+void UhsdrHwI2s_Codec_StartDMA(void);
+void UhsdrHwI2s_Codec_StopDMA(void);
 
-void UhsdrHwI2s_Codec_ClearTxDmaBuffer();
+void UhsdrHwI2s_Codec_ClearTxDmaBuffer(void);
 
 #endif
 

--- a/mchf-eclipse/drivers/audio/cw/cw_decoder.h
+++ b/mchf-eclipse/drivers/audio/cw/cw_decoder.h
@@ -41,8 +41,8 @@ extern cw_config_t cw_decoder_config;
 
 
 void CwDecode_RxProcessor(float32_t * const src, int16_t blockSize);
-void CwDecode_Filter_Set();
-//void CW_Decoder_WPM_display_erase();
+void CwDecode_Filter_Set(void);
+//void CW_Decoder_WPM_display_erase(void);
 void CwDecoder_WpmDisplayUpdate(bool force_update);
 void CwDecoder_WpmDisplayClearOrPrepare(bool prepare);
 

--- a/mchf-eclipse/drivers/audio/cw/cw_gen.h
+++ b/mchf-eclipse/drivers/audio/cw/cw_gen.h
@@ -16,17 +16,17 @@
 
 #include "arm_math.h"
 
-void    CwGen_Init();
+void    CwGen_Init(void);
 
-void    CwGen_PrepareTx();
-void    CwGen_SetSpeed();
+void    CwGen_PrepareTx(void);
+void    CwGen_SetSpeed(void);
 
 bool    CwGen_Process( float32_t *i_buffer, float32_t *q_buffer, uint32_t size );
 
 // As showed tests calling them (CwGen_DahIRQ & CwGen_DitIRQ) is matter only for Ultimatic mode.
 // After change code to work in this mode w/o them, these extra dependencies with low-level layers could be removed.
-void    CwGen_DahIRQ();
-void    CwGen_DitIRQ();
+void    CwGen_DahIRQ(void);
+void    CwGen_DitIRQ(void);
 
 uint8_t CwGen_CharacterIdFunc( uint32_t );
 

--- a/mchf-eclipse/drivers/audio/cw/uhsdr_digi_buffer.h
+++ b/mchf-eclipse/drivers/audio/cw/uhsdr_digi_buffer.h
@@ -28,7 +28,7 @@ typedef enum
 extern "C" {
 #endif
 
-uint8_t DigiModes_TxBufferHasData();
+uint8_t DigiModes_TxBufferHasData(void);
 uint8_t DigiModes_TxBufferHasDataFor(digi_buff_consumer_t consumer);
 
 /*
@@ -39,7 +39,7 @@ uint8_t DigiModes_TxBufferHasDataFor(digi_buff_consumer_t consumer);
  * @return - previous consumer
  */
 digi_buff_consumer_t DigiModes_Set_BufferConsumer( digi_buff_consumer_t consumer );
-void                 DigiModes_Restore_BufferConsumer();
+void                 DigiModes_Restore_BufferConsumer(void);
 
 /*
  * @return - true if element was removed from buffer and available in c_ptr

--- a/mchf-eclipse/drivers/audio/freedv_uhsdr.h
+++ b/mchf-eclipse/drivers/audio/freedv_uhsdr.h
@@ -98,18 +98,18 @@ typedef struct {
 extern freedv_conf_t freedv_conf;
 
 
-void FreeDv_HandleFreeDv();
-void FreeDV_Init();
+void FreeDv_HandleFreeDv(void);
+void FreeDV_Init(void);
 int32_t FreeDV_SetMode(uint8_t fdv_mode, int32_t firstTime);
-void FreeDV_Test();
+void FreeDV_Test(void);
 
-int32_t FreeDV_Iq_Get_FrameLen();
-int32_t FreeDV_Audio_Get_FrameLen();
+int32_t FreeDV_Iq_Get_FrameLen(void);
+int32_t FreeDV_Audio_Get_FrameLen(void);
 
 
-void FreeDv_DisplayClear();
-void FreeDv_DisplayPrepare();
-void FreeDv_DisplayUpdate();
+void FreeDv_DisplayClear(void);
+void FreeDv_DisplayPrepare(void);
+void FreeDv_DisplayUpdate(void);
 
 int32_t FreeDV_Get_Squelch_SNR(freedv_conf_t* freedv_conf_p);
 void FreeDV_Set_Squelch_SNR(freedv_conf_t* freedv_conf_p, int8_t squelch_snr);

--- a/mchf-eclipse/drivers/audio/psk.c
+++ b/mchf-eclipse/drivers/audio/psk.c
@@ -734,7 +734,7 @@ int16_t Psk_Modulator_GenSample()
                         Psk_Modulator_SetState(PSK_MOD_ACTIVE);
                     }
                 }
-                else if (DigiModes_TxBufferHasData(BPSK))
+                else if (DigiModes_TxBufferHasData())
                 {
                     if (DigiModes_TxBufferRemove( &psk_state.tx_char, BPSK ))
                     {

--- a/mchf-eclipse/drivers/audio/psk.h
+++ b/mchf-eclipse/drivers/audio/psk.h
@@ -53,13 +53,13 @@ typedef enum {
     PSK_MOD_INACTIVE
 } psk_modulator_t;
 
-psk_modulator_t Psk_Modulator_GetState();
+psk_modulator_t Psk_Modulator_GetState(void);
 psk_modulator_t Psk_Modulator_SetState(psk_modulator_t newState);
 
 
 void Psk_Modem_Init(uint32_t output_sample_rate);
-void Psk_Modulator_PrepareTx();
+void Psk_Modulator_PrepareTx(void);
 void Psk_Demodulator_ProcessSample(float32_t sample);
-int16_t Psk_Modulator_GenSample();
+int16_t Psk_Modulator_GenSample(void);
 
 #endif

--- a/mchf-eclipse/drivers/audio/rtty.h
+++ b/mchf-eclipse/drivers/audio/rtty.h
@@ -79,6 +79,6 @@ typedef struct
 extern rtty_ctrl_t rtty_ctrl_config;
 void Rtty_Modem_Init(uint32_t output_sample_rate);
 void Rtty_Demodulator_ProcessSample(float32_t sample);
-int16_t Rtty_Modulator_GenSample();
+int16_t Rtty_Modulator_GenSample(void);
 
 #endif

--- a/mchf-eclipse/drivers/audio/tx_processor.h
+++ b/mchf-eclipse/drivers/audio/tx_processor.h
@@ -19,8 +19,8 @@
 #include "uhsdr_types.h"
 #include "audio_driver.h" // for types
 
-void TxProcessor_Init();
+void TxProcessor_Init(void);
 void TxProcessor_Set(uint8_t dmod_mode);
-void TxProcessor_PrepareRun();
+void TxProcessor_PrepareRun(void);
 void TxProcessor_Run(AudioSample_t * const srcCodec, IqSample_t * const dst, AudioSample_t * const audioDst, uint16_t blockSize, bool external_mute);
 #endif

--- a/mchf-eclipse/drivers/cat/cat_driver.h
+++ b/mchf-eclipse/drivers/cat/cat_driver.h
@@ -32,16 +32,16 @@ typedef enum
 
 // Exports
 
-CatInterfaceState CatDriver_GetInterfaceState();
+CatInterfaceState CatDriver_GetInterfaceState(void);
 
 int CatDriver_InterfaceBufferAddData(uint8_t c);
 
-void CatDriver_HandleProtocol();
+void CatDriver_HandleProtocol(void);
 
-bool CatDriver_CloneOutStart();
-bool CatDriver_CloneInStart();
+bool CatDriver_CloneOutStart(void);
+bool CatDriver_CloneInStart(void);
 
-bool CatDriver_CWKeyPressed();
-bool CatDriver_CatPttActive();
+bool CatDriver_CWKeyPressed(void);
+bool CatDriver_CatPttActive(void);
 
 #endif

--- a/mchf-eclipse/drivers/diag/Trace.h
+++ b/mchf-eclipse/drivers/diag/Trace.h
@@ -18,7 +18,7 @@
 // The API is simple, and mimics the standard output calls:
 // - trace_printf()
 // - trace_puts()
-// - trace_putchar();
+// - trace_putchar(void);
 //
 // The implementation is done in
 // - trace_write()

--- a/mchf-eclipse/drivers/freedv/ampexp.h
+++ b/mchf-eclipse/drivers/freedv/ampexp.h
@@ -32,7 +32,7 @@
 
 struct AEXP;
 
-struct AEXP *amp_experiment_create();
+struct AEXP *amp_experiment_create(void);
 void amp_experiment_destroy(struct AEXP *aexp);
 void amp_experiment(struct AEXP *aexp, MODEL *model, char *arg);
 

--- a/mchf-eclipse/drivers/freedv/dump.h
+++ b/mchf-eclipse/drivers/freedv/dump.h
@@ -32,7 +32,7 @@
 #include "codec2_internal.h"
 
 void dump_on(char filename_prefix[]);
-void dump_off();
+void dump_off(void);
 
 void dump_Sn(int m_pitch, float Sn[]);
 void dump_Sw(COMP Sw[]);

--- a/mchf-eclipse/drivers/freedv/modem_probe.h
+++ b/mchf-eclipse/drivers/freedv/modem_probe.h
@@ -36,7 +36,7 @@
 
 /* Internal functions */
 void modem_probe_init_int(char *modname, char *runname);
-void modem_probe_close_int();
+void modem_probe_close_int(void);
 
 void modem_probe_samp_i_int(char * tracename,int samp[],size_t cnt);
 void modem_probe_samp_f_int(char * tracename,float samp[],size_t cnt);
@@ -55,7 +55,7 @@ static inline void modem_probe_init(char *modname,char *runname){
  * Dump traces to a file and clean up
  */
 static inline void modem_probe_close(){
-        modem_probe_close_int();
+        modem_probe_close_int(void);
 }
 
 /*

--- a/mchf-eclipse/drivers/freedv/phaseexp.h
+++ b/mchf-eclipse/drivers/freedv/phaseexp.h
@@ -32,7 +32,7 @@
 
 struct PEXP;
 
-struct PEXP * phase_experiment_create();
+struct PEXP * phase_experiment_create(void);
 void phase_experiment_destroy(struct PEXP *pexp);
 void phase_experiment(struct PEXP *pexp, MODEL *model, char *arg);
 

--- a/mchf-eclipse/drivers/freedv/quantise.h
+++ b/mchf-eclipse/drivers/freedv/quantise.h
@@ -53,7 +53,7 @@
 #define LPCPF_GAMMA 0.5
 #define LPCPF_BETA  0.2
 
-void quantise_init();
+void quantise_init(void);
 float lpc_model_amplitudes(float Sn[], float w[], MODEL *model, int order,
 			   int lsp,float ak[]);
 void aks_to_M2(codec2_fftr_cfg fftr_fwd_cfg, float ak[], int order, MODEL *model,

--- a/mchf-eclipse/drivers/ui/lcd/ui_lcd_hy28.h
+++ b/mchf-eclipse/drivers/ui/lcd/ui_lcd_hy28.h
@@ -104,12 +104,12 @@ typedef struct
 {
     mchf_display_types_t display_type;
     const char* name;
-    uint16_t (*ReadDisplayId)();
+    uint16_t (*ReadDisplayId)(void);
     void (*SetActiveWindow) (uint16_t XLeft, uint16_t XRight, uint16_t YTop, uint16_t YBottom);
     void (*SetCursorA)( unsigned short Xpos, unsigned short Ypos );
-    void (*WriteRAM_Prepare) ();
-    void (*WriteDataSpiStart_Prepare)();
-    void (*WriteIndexSpi_Prepare)();
+    void (*WriteRAM_Prepare) (void);
+    void (*WriteDataSpiStart_Prepare)(void);
+    void (*WriteIndexSpi_Prepare)(void);
     void (*WriteReg)(unsigned short LCD_Reg, unsigned short LCD_RegValue);
     uint16_t (*ReadReg)( uint16_t LCD_Reg);
     void (*DrawStraightLine)(uint16_t x, uint16_t y, uint16_t Length, uint8_t Direction,uint16_t color);
@@ -134,9 +134,9 @@ typedef struct
     const RegisterValueSetInfo_t* reg_info;
     void (*SetActiveWindow) (uint16_t XLeft, uint16_t XRight, uint16_t YTop, uint16_t YBottom);
     void (*SetCursorA)( unsigned short Xpos, unsigned short Ypos );
-    void (*WriteRAM_Prepare) ();
-    void (*WriteDataSpiStart_Prepare)();
-    void (*WriteIndexSpi_Prepare)();
+    void (*WriteRAM_Prepare) (void);
+    void (*WriteDataSpiStart_Prepare)(void);
+    void (*WriteIndexSpi_Prepare)(void);
     void (*WriteReg)(unsigned short LCD_Reg, unsigned short LCD_RegValue);
     uint16_t (*ReadReg)( uint16_t LCD_Reg);
     void (*DrawStraightLine)(uint16_t x, uint16_t y, uint16_t Length, uint8_t Direction,uint16_t color);
@@ -169,12 +169,12 @@ void 	UiLcdHy28_DrawFullRect (ushort Xpos, ushort Ypos, ushort Height, ushort Wi
 void 	UiLcdHy28_DrawColorPoint(ushort x, ushort y, ushort color);
 
 void    UiLcdHy28_BulkPixel_OpenWrite(ushort x, ushort width, ushort y, ushort height);
-void    UiLcdHy28_BulkPixel_CloseWrite();
+void    UiLcdHy28_BulkPixel_CloseWrite(void);
 void 	UiLcdHy28_BulkPixel_Put(uint16_t pixel);
 void    UiLcdHy28_BulkPixel_PutBuffer(uint16_t* pixel_buffer, uint32_t len);
-void    UiLcdHy28_BulkPixel_BufferFlush();
+void    UiLcdHy28_BulkPixel_BufferFlush(void);
 
-uint8_t 	UiLcdHy28_Init();
+uint8_t 	UiLcdHy28_Init(void);
 
 void    UiLcdHy28_BacklightEnable(bool on);
 
@@ -209,9 +209,9 @@ typedef struct
 
 extern mchf_touchscreen_t mchf_touchscreen;
 
-void    UiLcdHy28_TouchscreenDetectPress();
-void 	UiLcdHy28_TouchscreenReadCoordinates();
-bool    UiLcdHy28_TouchscreenHasProcessableCoordinates();
+void    UiLcdHy28_TouchscreenDetectPress(void);
+void 	UiLcdHy28_TouchscreenReadCoordinates(void);
+bool    UiLcdHy28_TouchscreenHasProcessableCoordinates(void);
 void    UiLcdHy28_TouchscreenInit(uint8_t mirror);
 
 

--- a/mchf-eclipse/drivers/ui/lcd/ui_lcd_layouts.h
+++ b/mchf-eclipse/drivers/ui/lcd/ui_lcd_layouts.h
@@ -51,8 +51,8 @@ typedef struct {
 typedef struct
 {
 	UiArea_t region;
-	void (*function_short_press)();
-	void (*function_long_press)();
+	void (*function_short_press)(void);
+	void (*function_long_press)(void);
 } touchaction_descr_t;
 
 typedef struct

--- a/mchf-eclipse/drivers/ui/lcd/ui_spectrum.h
+++ b/mchf-eclipse/drivers/ui/lcd/ui_spectrum.h
@@ -31,12 +31,12 @@ typedef struct
 } SpectrumAreas_t;
 
 
-void UiSpectrum_Init();
-void UiSpectrum_Clear();
-void UiSpectrum_Redraw();
-void UiSpectrum_WaterfallClearData();
+void UiSpectrum_Init(void);
+void UiSpectrum_Clear(void);
+void UiSpectrum_Redraw(void);
+void UiSpectrum_WaterfallClearData(void);
 void UiSpectrum_CalculateDisplayFilterBW(float32_t* width_pixel_, float32_t* left_filter_border_pos_);
-void UiSpectrum_DisplayFilterBW();
+void UiSpectrum_DisplayFilterBW(void);
 
 void UiSpectrum_InitCwSnapDisplay (bool visible);
 void UiSpectrum_ResetSpectrum(void);

--- a/mchf-eclipse/drivers/ui/menu/ui_menu.h
+++ b/mchf-eclipse/drivers/ui/menu/ui_menu.h
@@ -34,10 +34,10 @@ void UiMenu_RenderMenu(MenuProcessingMode_t mode);
 
 void UiMenu_RenderChangeItemValue(int16_t pot_diff);
 void UiMenu_RenderChangeItem(int16_t pot_diff);
-void UiMenu_RenderLastScreen();
-void UiMenu_RenderFirstScreen();
-bool UiMenu_RenderNextScreen(); // returns true if screen was changed, i.e. not last screen
-bool UiMenu_RenderPrevScreen(); // returns true if screen was changed, i.e. not first screen
+void UiMenu_RenderLastScreen(void);
+void UiMenu_RenderFirstScreen(void);
+bool UiMenu_RenderNextScreen(void); // returns true if screen was changed, i.e. not last screen
+bool UiMenu_RenderPrevScreen(void); // returns true if screen was changed, i.e. not first screen
 
 
 enum MENU_INFO_ITEM

--- a/mchf-eclipse/drivers/ui/oscillator/osc_interface.h
+++ b/mchf-eclipse/drivers/ui/oscillator/osc_interface.h
@@ -39,10 +39,10 @@ typedef enum
 typedef struct
 {
 	// startup handling
-	void  (*init)();
+	void  (*init)(void);
 
 	// presence information
-	bool  (*isPresent)();
+	bool  (*isPresent)(void);
 	// startup/runtime reconfiguration
 	void  (*setPPM)(float32_t ppm);
 
@@ -50,11 +50,11 @@ typedef struct
 	// freq is given in Hz, is QSD mixing frequency,
 	// internally multiplied by 4 for Johnson Counter clock counters if needed by circuit
 	Oscillator_ResultCodes_t (*prepareNextFrequency)(ulong freq, int temp_factor);
-	Oscillator_ResultCodes_t (*changeToNextFrequency)();
-	bool 			  (*isNextStepLarge)();
-	bool              (*readyForIrqCall)();
-	uint32_t    (*getMinFrequency)();
-	uint32_t    (*getMaxFrequency)();
+	Oscillator_ResultCodes_t (*changeToNextFrequency)(void);
+	bool 			  (*isNextStepLarge)(void);
+	bool              (*readyForIrqCall)(void);
+	uint32_t    (*getMinFrequency)(void);
+	uint32_t    (*getMaxFrequency)(void);
     const char*  name;
     const Oscillator_Type_t  type;
 
@@ -62,5 +62,5 @@ typedef struct
 
 extern const OscillatorInterface_t *osc;
 
-void Osc_Init();
+void Osc_Init(void);
 #endif

--- a/mchf-eclipse/drivers/ui/oscillator/osc_si5351a.h
+++ b/mchf-eclipse/drivers/ui/oscillator/osc_si5351a.h
@@ -16,7 +16,7 @@
 #define __HW_SI5351A
 #include "osc_interface.h"
 
-void Si5351a_Init();
-bool Si5351a_IsPresent();
+void Si5351a_Init(void);
+bool Si5351a_IsPresent(void);
 
 #endif

--- a/mchf-eclipse/drivers/ui/oscillator/osc_si570.h
+++ b/mchf-eclipse/drivers/ui/oscillator/osc_si570.h
@@ -17,10 +17,10 @@
 
 #include "osc_interface.h"
 
-void 	Si570_Init();
+void 	Si570_Init(void);
 
 // non-critical device information reading
-float32_t   Si570_GetStartupFrequency();
-uint8_t     Si570_GetI2CAddress();
+float32_t   Si570_GetStartupFrequency(void);
+uint8_t     Si570_GetI2CAddress(void);
 
 #endif

--- a/mchf-eclipse/drivers/ui/oscillator/soft_tcxo.h
+++ b/mchf-eclipse/drivers/ui/oscillator/soft_tcxo.h
@@ -46,5 +46,5 @@ typedef struct LoTcxo
 // LO Tcxo
 extern LoTcxo lo;
 
-bool SoftTcxo_HandleLoTemperatureDrift();
-void SoftTcxo_Init();
+bool SoftTcxo_HandleLoTemperatureDrift(void);
+void SoftTcxo_Init(void);

--- a/mchf-eclipse/drivers/ui/radio_management.h
+++ b/mchf-eclipse/drivers/ui/radio_management.h
@@ -222,7 +222,7 @@ typedef enum
 // Working register plus VFO A and VFO B registers.
 extern BandRegs vfo[VFO_MAX];
 
-vfo_name_t get_active_vfo();
+vfo_name_t get_active_vfo(void);
 
 
 // SWR and RF power meter public
@@ -330,11 +330,11 @@ bool RadioManagement_FreqIsInEnabledBand ( uint32_t freq );
 const BandInfo* RadioManagement_GetBandInfo(uint8_t new_band_index);
 bool RadioManagement_SetPowerLevel(const BandInfo* band, power_level_t power_level);
 bool RadioManagement_Tune(bool tune);
-bool RadioManagement_UpdatePowerAndVSWR();
+bool RadioManagement_UpdatePowerAndVSWR(void);
 void RadioManagement_ChangeCodec(uint32_t codec, bool enableCodec);
 bool RadioManagement_ChangeFrequency(bool force_update, uint32_t dial_freq,uint8_t txrx_mode);
-void RadioManagement_HandlePttOnOff();
-void RadioManagement_MuteTemporarilyRxAudio();
+void RadioManagement_HandlePttOnOff(void);
+void RadioManagement_MuteTemporarilyRxAudio(void);
 
 uint32_t RadioManagement_NextNormalDemodMode(uint32_t loc_mode);
 uint32_t RadioManagement_NextAlternativeDemodMode(uint32_t loc_mode);
@@ -344,32 +344,32 @@ bool RadioManagement_IsApplicableDemodMode(uint32_t demod_mode);
 void RadioManagement_SwitchTxRx(uint8_t txrx_mode, bool tune_mode);
 bool RadioManagement_LSBActive(uint16_t dmod_mode);
 bool RadioManagement_USBActive(uint16_t dmod_mode);
-void RadioManagement_SetPaBias();
+void RadioManagement_SetPaBias(void);
 bool RadioManagement_CalculateCWSidebandMode(void);
 void RadioManagement_SetDemodMode(uint8_t new_mode);
-void RadioManagement_HandleRxIQSignalCodecGain();
+void RadioManagement_HandleRxIQSignalCodecGain(void);
 const cw_mode_map_entry_t* RadioManagement_CWConfigValueToModeEntry(uint8_t cw_offset_mode);
 uint8_t RadioManagement_CWModeEntryToConfigValue(const cw_mode_map_entry_t* mode_entry);
 bool RadioManagement_UsesBothSidebands(uint16_t dmod_mode);
 bool RadioManagement_IsPowerFactorReduce(uint32_t freq);
-bool RadioManagement_UsesTxSidetone();
-void RadioManagement_ToggleVfoAB();
+bool RadioManagement_UsesTxSidetone(void);
+void RadioManagement_ToggleVfoAB(void);
 
-bool RadioManagement_FmDevIs5khz();
+bool RadioManagement_FmDevIs5khz(void);
 void RadioManagement_FmDevSet5khz(bool is5khz);
 
-uint32_t RadioManagement_GetTXDialFrequency();
-uint32_t RadioManagement_GetRXDialFrequency();
-int32_t  RadioManagement_GetCWDialOffset();
+uint32_t RadioManagement_GetTXDialFrequency(void);
+uint32_t RadioManagement_GetRXDialFrequency(void);
+int32_t  RadioManagement_GetCWDialOffset(void);
 
-bool     RadioManagement_Transverter_IsEnabled();
+bool     RadioManagement_Transverter_IsEnabled(void);
 uint64_t RadioManagement_Transverter_GetFreq(const uint32_t dial_freq, const uint8_t trx_mode);
 
 
-void RadioManagement_Request_TxOn();
-void RadioManagement_Request_TxOff();
+void RadioManagement_Request_TxOn(void);
+void RadioManagement_Request_TxOff(void);
 
-bool RadioManagement_SwitchTxRx_Possible();
+bool RadioManagement_SwitchTxRx_Possible(void);
 bool RadioManagement_IsTxAtZeroIF(uint8_t dmod_mode, uint8_t digital_mode);
 
 inline void RadioManagement_ToggleVfoMem()

--- a/mchf-eclipse/drivers/ui/ui_driver.h
+++ b/mchf-eclipse/drivers/ui/ui_driver.h
@@ -178,78 +178,78 @@ typedef struct
 // --------------------------------------------------------------------------
 // Exports
 void 	UiDriver_Init(void);
-void 	UiDriver_TaskHandler_MainTasks();
+void 	UiDriver_TaskHandler_MainTasks(void);
 
-void 	UiDriver_CreateTemperatureDisplay();
+void 	UiDriver_CreateTemperatureDisplay(void);
 void 	UiDriver_UpdateFrequency(bool force_update, enum UpdateFrequencyMode_t mode);
 void    UiDriver_FrequencyUpdateLOandDisplay(bool full_update);
-void    UiDriver_RefreshEncoderDisplay();
+void    UiDriver_RefreshEncoderDisplay(void);
 void    UiDriver_DrawFButtonLabel(uint8_t button_num, const char* label, uint32_t label_color) ;
-void 	UiDriver_DisplayFreqStepSize();
+void 	UiDriver_DisplayFreqStepSize(void);
 void 	UiDriver_DisplayDemodMode(void);
 void	UiDriver_LcdBlankingStartTimer(void);
-void    UiDriver_SpectrumChangeLayoutParameters();
+void    UiDriver_SpectrumChangeLayoutParameters(void);
 
 void UiDriver_DebugInfo_DisplayEnable(bool enable);
 
 void UiDriver_ChangeTuningStep(uchar is_up);
-void UiDriver_UpdateDisplayAfterParamChange();
-void UiDriver_UpdateDemodSpecificDisplayAfterParamChange();
+void UiDriver_UpdateDisplayAfterParamChange(void);
+void UiDriver_UpdateDemodSpecificDisplayAfterParamChange(void);
 void UiDriver_SetDemodMode(uint8_t new_mode);
 
-void UiDriver_StartUpScreenInit();
-void UiDriver_StartUpScreenFinish();
+void UiDriver_StartUpScreenInit(void);
+void UiDriver_StartUpScreenFinish(void);
 
 void UiDriver_DoCrossCheck(int16_t cross[]);
-void UiAction_ToggleVfoAB();
+void UiAction_ToggleVfoAB(void);
 void UiDriver_SetSplitMode(bool mode_active);
 
 
 void UiDriver_StartupScreen_LogIfProblem(bool isError, const char* txt);
 
-void UiDriver_BacklightDimHandler();
+void UiDriver_BacklightDimHandler(void);
 
 void UiDriver_TextMsgPutChar(char ch);
 void UiDriver_TextMsgPutSign(const char *s);
-void UiDriver_TextMsgDisplay();
-void UiDriver_TextMsgClear();
-void UiDriver_DisplayFButton_F1MenuExit();
+void UiDriver_TextMsgDisplay(void);
+void UiDriver_TextMsgClear(void);
+void UiDriver_DisplayFButton_F1MenuExit(void);
 
 void UiDriver_SetSpectrumMode(SpectrumMode_t mode);
-SpectrumMode_t UiDriver_GetSpectrumMode();
+SpectrumMode_t UiDriver_GetSpectrumMode(void);
 
 //some exports for layout definitions
-void UiAction_ChangeLowerMeterUp();
-void UiAction_ToggleWaterfallScopeDisplay();
-void UiAction_ChangeSpectrumSize();
-void UiAction_ChangeSpectrumZoomLevelDown();
-void UiAction_ChangeSpectrumZoomLevelUp();
-void UiAction_CheckSpectrumTouchActions();
-void UiAction_ChangeFrequencyToNextKhz();
-void UiAction_ChangeDemodMode();
-void UiAction_ChangePowerLevel();
-void UiAction_ChangeAudioSource();
-void UiAction_ChangeBandDownOrUp();
-void UiAction_ChangeBandUpOrDown();
-void UiAction_ChangeDigitalMode();
-void UiAction_ChangeDynamicTuning();
-void UiAction_ChangeDebugInfoDisplay();
-void UiAction_ChangeRfModPresence();
-void UiAction_ChangeVhfUhfModPresence();
-void UiAction_ChangeFrequencyByTouch();
-void Codec_RestartI2S();
-uint32_t UiDriver_GetActiveDSPFunctions();
+void UiAction_ChangeLowerMeterUp(void);
+void UiAction_ToggleWaterfallScopeDisplay(void);
+void UiAction_ChangeSpectrumSize(void);
+void UiAction_ChangeSpectrumZoomLevelDown(void);
+void UiAction_ChangeSpectrumZoomLevelUp(void);
+void UiAction_CheckSpectrumTouchActions(void);
+void UiAction_ChangeFrequencyToNextKhz(void);
+void UiAction_ChangeDemodMode(void);
+void UiAction_ChangePowerLevel(void);
+void UiAction_ChangeAudioSource(void);
+void UiAction_ChangeBandDownOrUp(void);
+void UiAction_ChangeBandUpOrDown(void);
+void UiAction_ChangeDigitalMode(void);
+void UiAction_ChangeDynamicTuning(void);
+void UiAction_ChangeDebugInfoDisplay(void);
+void UiAction_ChangeRfModPresence(void);
+void UiAction_ChangeVhfUhfModPresence(void);
+void UiAction_ChangeFrequencyByTouch(void);
+void Codec_RestartI2S(void);
+uint32_t UiDriver_GetActiveDSPFunctions(void);
 void UiDriver_UpdateDSPmode(uint8_t new_dsp_mode);
 bool UiDriver_CheckTouchRegion(const UiArea_t* tr_p);
 void UiDriver_Power2String(char* txt, size_t txt_len,uint32_t power_mW);
 
-uint32_t UiDriver_GetNBColor();
+uint32_t UiDriver_GetNBColor(void);
 
-void UiDriver_InitBandSet();
+void UiDriver_InitBandSet(void);
 void UiDriver_SelectBandMemory(uint16_t vfo_sel, uint8_t new_band_index);
 
 
-void UiDriver_Callback_AudioISR();
+void UiDriver_Callback_AudioISR(void);
 
 // Items that are timed using ts.sysclock (operates at 100 Hz)
 //

--- a/mchf-eclipse/drivers/ui/ui_vkeybrd.h
+++ b/mchf-eclipse/drivers/ui/ui_vkeybrd.h
@@ -63,18 +63,18 @@ typedef struct
 enum Vkey_Group_ {Vkey_Group_OneAllowed=0, Vkey_Group_MultipleAllowed};
 
 
-//void UiVk_RedrawDSPVirtualKeys();
+//void UiVk_RedrawDSPVirtualKeys(void);
 bool UiVk_Process_VirtualKeypad(bool LongPress);
-void UiVk_Redraw();
+void UiVk_Redraw(void);
 
-void UiVk_DSPVirtualKeys();
+void UiVk_DSPVirtualKeys(void);
 
-//void UiVk_RedrawBndSelVirtualKeys();
-void UiVk_BndSelVirtualKeys();
+//void UiVk_RedrawBndSelVirtualKeys(void);
+void UiVk_BndSelVirtualKeys(void);
 
-//void UiVk_RedrawBndFreqSetVirtualKeys();
-void UiVk_BndFreqSetVirtualKeys();
+//void UiVk_RedrawBndFreqSetVirtualKeys(void);
+void UiVk_BndFreqSetVirtualKeys(void);
 
-//void UiVk_RedrawModSelVirtualKeys();
-void UiVk_ModSelVirtualKeys();
+//void UiVk_RedrawModSelVirtualKeys(void);
+void UiVk_ModSelVirtualKeys(void);
 #endif /* UI_UI_VKEYBRD_H_ */

--- a/mchf-eclipse/hardware/uhsdr_board.h
+++ b/mchf-eclipse/hardware/uhsdr_board.h
@@ -739,15 +739,15 @@ typedef enum {
 
 
 void Board_SetPaBiasValue(uint16_t bias);
-void Board_HandlePowerDown();
+void Board_HandlePowerDown(void);
 
 void Board_SelectLpfBpf(uint8_t group);
 
-void Board_InitMinimal();
-void Board_InitFull();
-void Board_PostInit();
-void Board_Reboot();
-void Board_Powerdown();
+void Board_InitMinimal(void);
+void Board_InitFull(void);
+void Board_PostInit(void);
+void Board_Reboot(void);
+void Board_Powerdown(void);
 
 void Board_EnableTXSignalPath(bool tx_enable);
 
@@ -758,17 +758,17 @@ void Board_RedLed(ledstate_t state);
 void Board_BlueLed(ledstate_t state);
 #endif
 
-bool Board_PttDahLinePressed();
-bool Board_DitLinePressed();
+bool Board_PttDahLinePressed(void);
+bool Board_DitLinePressed(void);
 
-uint32_t Board_RamSizeGet();
-void Board_RamSizeDetection();
-const char* Board_BootloaderVersion();
+uint32_t Board_RamSizeGet(void);
+void Board_RamSizeDetection(void);
+const char* Board_BootloaderVersion(void);
 
 // in main.c
 void CriticalError(uint32_t error);
 
-bool is_vfo_b();
+bool is_vfo_b(void);
 
 static inline bool is_ssb_tx_filter_enabled() {
 	return (ts.tx_filter != 0);
@@ -794,17 +794,17 @@ static inline bool is_waterfallmode()
     return (ts.flags1 & FLAGS1_WFALL_ENABLED) != 0;
 }
 
-bool is_dsp_nb_active();
-bool is_dsp_nb();
-bool is_dsp_nr();
-bool is_dsp_nr_postagc();
-bool is_dsp_notch();
-bool is_dsp_mnotch();
-bool is_dsp_mpeak();
+bool is_dsp_nb_active(void);
+bool is_dsp_nb(void);
+bool is_dsp_nr(void);
+bool is_dsp_nr_postagc(void);
+bool is_dsp_notch(void);
+bool is_dsp_mnotch(void);
+bool is_dsp_mpeak(void);
 
 
 #ifdef USE_PENDSV_FOR_HIGHPRIO_TASKS
-extern void UiDriver_TaskHandler_HighPrioTasks();
+extern void UiDriver_TaskHandler_HighPrioTasks(void);
 #endif
 
 #endif

--- a/mchf-eclipse/hardware/uhsdr_hmc1023.h
+++ b/mchf-eclipse/hardware/uhsdr_hmc1023.h
@@ -38,8 +38,8 @@ extern HMC1023_t hmc1023;
 
 #ifdef USE_HMC1023
 
-void hmc1023_init();
-void hmc1023_use_spi_settings();
+void hmc1023_init(void);
+void hmc1023_use_spi_settings(bool on);
 void hmc1023_set_coarse(uint8_t coarse);
 void hmc1023_set_fine(uint8_t fine);
 void hmc1023_set_gain(bool on);

--- a/mchf-eclipse/hardware/uhsdr_keypad.h
+++ b/mchf-eclipse/hardware/uhsdr_keypad.h
@@ -45,22 +45,22 @@ enum
     BUTTON_NOP // used for buttons with no function
 };
 
-void        Keypad_KeypadInit();
+void        Keypad_KeypadInit(void);
 
 #ifdef UI_BRD_MCHF
 // this function invoked only on the MCHF with RTC as they have different buttons layout
-void        Keypad_SetLayoutRTC_MCHF();
+void        Keypad_SetLayoutRTC_MCHF(void);
 #endif
 
 bool        Keypad_IsButtonPressed( uint32_t button_num );
-bool        Keypad_IsAnyButtonPressed();
+bool        Keypad_IsAnyButtonPressed(void);
 bool        Keypad_IsKeyPressed( uint32_t key_num );
-bool        Keypad_IsAnyKeyPressed();
+bool        Keypad_IsAnyKeyPressed(void);
 
-void        Keypad_Scan();
+void        Keypad_Scan(void);
 
-uint32_t    Keypad_KeyStates();
-uint32_t    Keypad_ButtonStates();
+uint32_t    Keypad_KeyStates(void);
+uint32_t    Keypad_ButtonStates(void);
 const char* Keypad_GetLabelOfButton( uint32_t id_button );
 
 #endif

--- a/mchf-eclipse/hardware/uhsdr_rtc.h
+++ b/mchf-eclipse/hardware/uhsdr_rtc.h
@@ -18,9 +18,9 @@
 
 #include "rtc.h"
 
-bool Rtc_isEnabled();
-void Rtc_FullReset();
-void Rtc_Start();
+bool Rtc_isEnabled(void);
+void Rtc_FullReset(void);
+void Rtc_Start(void);
 bool Rtc_SetPpm(int16_t ppm);
 void Rtc_GetTime(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTime, uint32_t Format);
 

--- a/mchf-eclipse/src/bootloader/bootloader_main.h
+++ b/mchf-eclipse/src/bootloader/bootloader_main.h
@@ -21,9 +21,9 @@ extern "C" {
 #endif
 
 
-void Bootloader_UsbHostApplication();
-int  Bootloader_Main();
-void Bootloader_CheckAndGoForBootTarget();
+void Bootloader_UsbHostApplication(void);
+int  Bootloader_Main(void);
+void Bootloader_CheckAndGoForBootTarget(void);
 void Bootloader_PrintLine(const char* txt);
 
 enum

--- a/mchf-eclipse/src/bootloader/flash_if.h
+++ b/mchf-eclipse/src/bootloader/flash_if.h
@@ -67,9 +67,9 @@ static inline uint32_t flashIf_userFlashSize()  {  return ((STM32_GetFlashSize()
 
 /* Exported macros -----------------------------------------------------------*/
 /* Exported functions ------------------------------------------------------- */
-void flashIf_FlashUnlock();
-void flashIf_FlashLock();
-FlagStatus flashIf_ReadOutProtectionStatus();
+void flashIf_FlashUnlock(void);
+void flashIf_FlashLock(void);
+FlagStatus flashIf_ReadOutProtectionStatus(void);
 uint32_t flashIf_EraseSectors(uint32_t Address, uint32_t Length);
 HAL_StatusTypeDef flashIf_Program256Bit(uint32_t Address, uint32_t Data[8]);
 

--- a/mchf-eclipse/src/bootloader/uhsdr_boot_hw.h
+++ b/mchf-eclipse/src/bootloader/uhsdr_boot_hw.h
@@ -86,7 +86,7 @@ void mchfBl_PinToggle(Led_TypeDef Led);
 void mchfBl_ButtonInit(Button_TypeDef Button, ButtonMode_TypeDef Button_Mode);
 uint32_t mchfBl_ButtonGetState(Button_TypeDef Button);
 
-void mcHF_PowerOff();
+void mcHF_PowerOff(void);
 
 /*
  * Just toggles the PowerHold Pin, but does not stop execution

--- a/mchf-eclipse/src/uhsdr_main.c
+++ b/mchf-eclipse/src/uhsdr_main.c
@@ -360,7 +360,7 @@ int mchfMain(void)
     // HW init
     Board_InitMinimal();
     // Show logo & HW Info
-    UiDriver_StartUpScreenInit(2000);
+    UiDriver_StartUpScreenInit();
 
     if (ts.display != DISPLAY_NONE)
     {
@@ -425,7 +425,7 @@ int mchfMain(void)
     Canary_Create();
 #endif
 
-    UiDriver_StartUpScreenFinish(2000);
+    UiDriver_StartUpScreenFinish();
 
     // We initialize the requested demodulation mode
     // and update the screen accordingly

--- a/mchf-eclipse/src/uhsdr_main.h
+++ b/mchf-eclipse/src/uhsdr_main.h
@@ -23,7 +23,7 @@ extern "C" {
 #endif
 
 
-int mchfMain();
+int mchfMain(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
In C we must use func(void) as declaration in order to have the compiler complain about
void functions being called with arguments. C++ does not need this.

This is in response to #1871 