### PR TITLE
Python3 change for uhsdr.py

### DIFF
--- a/mchf-eclipse/support/python/uhsdr.py
+++ b/mchf-eclipse/support/python/uhsdr.py
@@ -104,7 +104,7 @@ class catCommands:
         cmd = bytearray([ 0x00, 0x00 , 0x00, 0x00, CatCmd.UHSDR_ID])
         ok,res = self.execute(cmd,5)
 
-        return res == bytearray("UHSDR")
+        return res == bytearray("UHSDR", 'utf-8')
    
 
     def writeEEPROM(self, addr, value16bit):


### PR DESCRIPTION
Had to change uhsdr.py so that the bytearray cast would work. I think this is a necessary Python3 change. I have tested this for backup and restore and it seems to work for me. Thank you for all your work!

If something about this falls outside the normal workflow feel free to remedy as you see fit.

-mike/w1mt