### PR TITLE
Fix for #1887 (machine crashes with 2.11.93)

### DIFF
--- a/mchf-eclipse/drivers/ui/radio_management.h
+++ b/mchf-eclipse/drivers/ui/radio_management.h
@@ -201,6 +201,7 @@ typedef struct
 
 extern const BandInfoSet bandInfos[];
 extern const int BAND_INFO_SET_NUM;
+#define BAND_INFO_SET_DEFAULT 0 // first entry is default, this is a "catch all region"
 extern uint8_t bandinfo_idx;
 
 typedef const BandInfo BandInfo_c;

--- a/mchf-eclipse/drivers/ui/ui_configuration.c
+++ b/mchf-eclipse/drivers/ui/ui_configuration.c
@@ -275,7 +275,7 @@ const ConfigEntryDescriptor ConfigEntryInfo[] =
     { ConfigEntry_UInt8, EEPROM_VSWR_PROTECTION_THRESHOLD,&ts.vswr_protection_threshold,1,1,10},
 	{ ConfigEntry_UInt16, EEPROM_EXPFLAGS1,&ts.expflags1,EXPFLAGS1_CONFIG_DEFAULT,0,0xffff},
 	{ ConfigEntry_UInt16, EEPROM_CW_DECODER_FLAGS,&cw_decoder_config.flags,CW_DECODER_FLAGS_DEFAULT,0,0x7fff},
-    { ConfigEntry_UInt8, EEPROM_BAND_REGION,&bandinfo_idx,0,0,0x7f},
+    { ConfigEntry_UInt8, EEPROM_BAND_REGION, &bandinfo_idx, BAND_INFO_SET_DEFAULT, 0, 0x7f}, // we need to validate the range later as we cannot do it here due to C shortcomings
 	
     // the entry below MUST be the last entry, and only at the last position Stop is allowed
     {
@@ -888,6 +888,12 @@ void UiConfiguration_LoadEepromValues(bool load_freq_mode_defaults, bool load_ee
             load_eeprom_defaults);
 
     // restore the bandInfo for a given band info set and band memory index
+    if (bandinfo_idx >= BAND_INFO_SET_NUM)
+    {
+        // if the stored band index is not available, we need to handle this
+        // we cannot do this during reading as C does not allow us to use a const int as initializer constant
+        bandinfo_idx = BAND_INFO_SET_DEFAULT; // reset to default
+    }
     bandInfo = bandInfos[bandinfo_idx].bands;
     ts.band = RadioManagement_GetBandInfo(band_mem_idx);
 


### PR DESCRIPTION
Added additional range checking for band index as it absolutely must be
in range, but original code was not always doing this properly.