### PR TITLE
De-emphasis & more for WFM demodulation

### DIFF
--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -3265,7 +3265,11 @@ static void AudioDriver_RxProcessor(IqSample_t * const srcCodec, AudioSample_t *
 
     const int32_t iq_freq_mode = ts.iq_freq_mode;
 #ifdef USE_TWO_CHANNEL_AUDIO
-    const bool use_stereo = dmod_mode == DEMOD_WFM || ((dmod_mode == DEMOD_IQ || dmod_mode == DEMOD_SSBSTEREO || (dmod_mode == DEMOD_SAM && ads.sam_sideband == SAM_SIDEBAND_STEREO)) && ts.stereo_enable);
+    #ifdef USE_WFM
+        const bool use_stereo = dmod_mode == DEMOD_WFM || ((dmod_mode == DEMOD_IQ || dmod_mode == DEMOD_SSBSTEREO || (dmod_mode == DEMOD_SAM && ads.sam_sideband == SAM_SIDEBAND_STEREO)) && ts.stereo_enable);
+    #else
+        const bool use_stereo = ((dmod_mode == DEMOD_IQ || dmod_mode == DEMOD_SSBSTEREO || (dmod_mode == DEMOD_SAM && ads.sam_sideband == SAM_SIDEBAND_STEREO)) && ts.stereo_enable);
+    #endif
 #else
     const bool use_stereo = false;
 #endif

--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -3076,7 +3076,7 @@ static void AudioDriver_Demod_WFM(iq_buffer_t* iq_p, uint32_t blockSize)
 
     static float32_t I_old = 0.2;
     static float32_t Q_old = 0.2;
-    static float32_t m_PilotPhaseAdjust = 1.42; // 0.15
+    static float32_t m_PilotPhaseAdjust = 0.0f; // 0.15
     //const float32_t WFM_gain = 0.24;
     static float32_t m_PilotNcoPhase = 0.0;
     static float32_t WFM_fil_out = 0.0;
@@ -3195,7 +3195,7 @@ static void AudioDriver_Demod_WFM(iq_buffer_t* iq_p, uint32_t blockSize)
               {
                 //    4   multiply audio with 2 times (2 x 19kHz) the phase of the pilot tone --> L-R signal !
                   // LminusR = (stereo_factor / 100.0f) * UKW_buffer_0[i] * arm_sin_f32(m_PilotPhase[i] * 2.0f);
-                      LminusR = (1.2f) * UKW_buffer_0[i] * arm_sin_f32(m_PilotPhase[i] * 2.0f);
+                      LminusR = (3.70f) * UKW_buffer_0[i] * arm_sin_f32(m_PilotPhase[i] * 2.0f);
 
                       iq_p->q_buffer[i] = UKW_buffer_0[i]; // MPX-Signal: L+R
                       UKW_buffer_1[i] = LminusR;          // L-R - Signal
@@ -3265,7 +3265,7 @@ static void AudioDriver_RxProcessor(IqSample_t * const srcCodec, AudioSample_t *
 
     const int32_t iq_freq_mode = ts.iq_freq_mode;
 #ifdef USE_TWO_CHANNEL_AUDIO
-    const bool use_stereo = ((dmod_mode == DEMOD_IQ || dmod_mode == DEMOD_SSBSTEREO || (dmod_mode == DEMOD_SAM && ads.sam_sideband == SAM_SIDEBAND_STEREO)) && ts.stereo_enable);
+    const bool use_stereo = dmod_mode == DEMOD_WFM || ((dmod_mode == DEMOD_IQ || dmod_mode == DEMOD_SSBSTEREO || (dmod_mode == DEMOD_SAM && ads.sam_sideband == SAM_SIDEBAND_STEREO)) && ts.stereo_enable);
 #else
     const bool use_stereo = false;
 #endif

--- a/mchf-eclipse/drivers/audio/audio_driver.c
+++ b/mchf-eclipse/drivers/audio/audio_driver.c
@@ -816,7 +816,7 @@ void AudioDriver_SetBiquadCoeffsAllInstances(arm_biquad_casd_df1_inst_f32 biquad
 /**
  * @brief Biquad Filter Init Helper function which applies the filter specific scaling to calculated coefficients
  */
-void AudioDriver_ScaleBiquadCoeffs(float32_t coeffs[5],const float32_t scalingA, const float32_t scalingB)
+void AudioDriver_ScaleBiquadCoeffs(float32_t coeffs[5],const double scalingA, const double scalingB)
 {
     coeffs[A1] = coeffs[A1] / scalingA;
     coeffs[A2] = coeffs[A2] / scalingA;
@@ -829,17 +829,17 @@ void AudioDriver_ScaleBiquadCoeffs(float32_t coeffs[5],const float32_t scalingA,
 /**
  * @brief Biquad Filter Init Helper function to calculate a notch filter aka narrow bandstop filter
  */
-void AudioDriver_CalcBandstop(float32_t coeffs[5], float32_t f0, float32_t FS)
+void AudioDriver_CalcBandstop(float32_t coeffs[5], double f0, double FS)
 {
-     float32_t Q = 10; // larger Q gives narrower notch
-     float32_t w0 = 2 * PI * f0 / FS;
-     float32_t alpha = sinf(w0) / (2 * Q);
+     double Q = 10; // larger Q gives narrower notch
+     double w0 = 2 * PI * f0 / FS;
+     double alpha = sin(w0) / (2 * Q);
 
      coeffs[B0] = 1;
-     coeffs[B1] = - 2 * cosf(w0);
+     coeffs[B1] = - 2 * cos(w0);
      coeffs[B2] = 1;
-     float32_t scaling = 1 + alpha;
-     coeffs[A1] = 2 * cosf(w0); // already negated!
+     double scaling = 1 + alpha;
+     coeffs[A1] = 2 * cos(w0); // already negated!
      coeffs[A2] = alpha - 1; // already negated!
 
      AudioDriver_ScaleBiquadCoeffs(coeffs,scaling, scaling);
@@ -872,7 +872,7 @@ void AudioDriver_CalcLowpass(float32_t coeffs[5], double f0, double FS, double Q
 /**
  * @brief Biquad Filter Init Helper function to calculate a peak filter aka a narrow bandpass filter
  */
-void AudioDriver_CalcPeakFilter(float32_t coeffs[], float32_t f0, float32_t FS, float32_t Q)
+void AudioDriver_CalcPeakFilter(float32_t coeffs[], double f0, double FS, double Q)
 {
     /*       // peak filter = peaking EQ
     f0 = ts.dsp.peak_frequency;
@@ -909,15 +909,15 @@ void AudioDriver_CalcPeakFilter(float32_t coeffs[], float32_t f0, float32_t FS, 
     coeffs[A2] = alpha - 1; // already negated!
      */
     // BPF: constant skirt gain, peak gain = Q
-    float32_t BW = 0.03;
-    float32_t w0 = 2 * PI * f0 / FS;
-    float32_t alpha = sinf (w0) * sinhf( log(2) / 2 * BW * w0 / sinf(w0) ); //
+    double BW = 0.03;
+    double w0 = 2 * PI * f0 / FS;
+    double alpha = sin (w0) * sinh( log(2) / 2 * BW * w0 / sin(w0) ); //
 
     coeffs[B0] = Q * alpha;
     coeffs[B1] = 0;
     coeffs[B2] = - Q * alpha;
-    float32_t scaling = 1 + alpha;
-    coeffs[A1] = 2 * cosf(w0); // already negated!
+    double scaling = 1 + alpha;
+    coeffs[A1] = 2 * cos(w0); // already negated!
     coeffs[A2] = alpha - 1; // already negated!
 
     AudioDriver_ScaleBiquadCoeffs(coeffs,scaling, scaling);
@@ -925,7 +925,7 @@ void AudioDriver_CalcPeakFilter(float32_t coeffs[], float32_t f0, float32_t FS, 
 }
 
 #ifdef USE_WFM
-void AudioDriver_CalcBandpass(float32_t coeffs[], float32_t f0, float32_t FS, float32_t Q)
+void AudioDriver_CalcBandpass(float32_t coeffs[], double f0, double FS, double Q)
 {
     /*
     coeffs[B0] = alpha;
@@ -936,13 +936,13 @@ void AudioDriver_CalcBandpass(float32_t coeffs[], float32_t f0, float32_t FS, fl
     coeffs[A2] = alpha - 1; // already negated!
      */
 
-    float32_t w0 = 2 * PI * f0 / FS;
+    double w0 = 2 * PI * f0 / FS;
     double alpha = sin(w0) / 2.0;
 
     coeffs[B0] =  alpha;
     coeffs[B1] = 0;
     coeffs[B2] = - alpha;
-    float32_t scaling = 1 + alpha;
+    double scaling = 1 + alpha;
     coeffs[A1] = 2 * cos(w0); // already negated!
     coeffs[A2] = alpha - 1; // already negated!
 
@@ -955,26 +955,26 @@ void AudioDriver_CalcBandpass(float32_t coeffs[], float32_t f0, float32_t FS, fl
 /**
  * @brief Biquad Filter Init Helper function to calculate a treble adjustment filter aka high shelf filter
  */
-void AudioDriver_CalcHighShelf(float32_t coeffs[5], float32_t f0, float32_t S, float32_t gain, float32_t FS)
+void AudioDriver_CalcHighShelf(float32_t coeffs[5], double f0, double S, double gain, double FS)
 {
-    float32_t w0 = 2 * PI * f0 / FS;
-    float32_t A = pow10f(gain/40.0); // gain ranges from -20 to 5
-    float32_t alpha = sinf(w0) / 2 * sqrtf( (A + 1/A) * (1/S - 1) + 2 );
-    float32_t cosw0 = cosf(w0);
-    float32_t twoAa = 2 * sqrtf(A) * alpha;
+    double w0 = 2 * PI * f0 / FS;
+    double A = pow10(gain/40.0); // gain ranges from -20 to 5
+    double alpha = sin(w0) / 2 * sqrt( (A + 1/A) * (1/S - 1) + 2 );
+    double cosw0 = cos(w0);
+    double twoAa = 2 * sqrt(A) * alpha;
     // highShelf
     //
     coeffs[B0] = A *        ( (A + 1) + (A - 1) * cosw0 + twoAa );
     coeffs[B1] = - 2 * A *  ( (A - 1) + (A + 1) * cosw0         );
     coeffs[B2] = A *        ( (A + 1) + (A - 1) * cosw0 - twoAa );
-    float32_t scaling =       (A + 1) - (A - 1) * cosw0 + twoAa ;
+    double scaling =       (A + 1) - (A - 1) * cosw0 + twoAa ;
     coeffs[A1] = - 2 *      ( (A - 1) - (A + 1) * cosw0         ); // already negated!
     coeffs[A2] = twoAa      - (A + 1) + (A - 1) * cosw0; // already negated!
 
 
     //    DCgain = 2; //
     //    DCgain = (coeffs[B0] + coeffs[B1] + coeffs[B2]) / (1 - (- coeffs[A1] - coeffs[A2])); // takes into account that coeffs[A1] and coeffs[A2] are already negated!
-    float32_t DCgain = 1.0 * scaling;
+    double DCgain = 1.0 * scaling;
 
     AudioDriver_ScaleBiquadCoeffs(coeffs,scaling, DCgain);
 }
@@ -982,21 +982,21 @@ void AudioDriver_CalcHighShelf(float32_t coeffs[5], float32_t f0, float32_t S, f
 /**
  * @brief Biquad Filter Init Helper function to calculate a bass adjustment filter aka low shelf filter
  */
-void AudioDriver_CalcLowShelf(float32_t coeffs[5], float32_t f0, float32_t S, float32_t gain, float32_t FS)
+void AudioDriver_CalcLowShelf(float32_t coeffs[5], double f0, double S, double gain, double FS)
 {
 
-    float32_t w0 = 2 * PI * f0 / FS;
-    float32_t A = pow10f(gain/40.0); // gain ranges from -20 to 5
+    double w0 = 2 * PI * f0 / FS;
+    double A = pow10(gain/40.0); // gain ranges from -20 to 5
 
-    float32_t alpha = sinf(w0) / 2 * sqrtf( (A + 1/A) * (1/S - 1) + 2 );
-    float32_t cosw0 = cosf(w0);
-    float32_t twoAa = 2 * sqrtf(A) * alpha;
+    double alpha = sin(w0) / 2 * sqrt( (A + 1/A) * (1/S - 1) + 2 );
+    double cosw0 = cos(w0);
+    double twoAa = 2 * sqrt(A) * alpha;
 
     // lowShelf
     coeffs[B0] = A *        ( (A + 1) - (A - 1) * cosw0 + twoAa );
     coeffs[B1] = 2 * A *    ( (A - 1) - (A + 1) * cosw0         );
     coeffs[B2] = A *        ( (A + 1) - (A - 1) * cosw0 - twoAa );
-    float32_t scaling =       (A + 1) + (A - 1) * cosw0 + twoAa ;
+    double scaling =        (A + 1) + (A - 1) * cosw0 + twoAa ;
     coeffs[A1] = 2 *        ( (A - 1) + (A + 1) * cosw0         ); // already negated!
     coeffs[A2] = twoAa      - (A + 1) - (A - 1) * cosw0; // already negated!
 
@@ -1008,7 +1008,7 @@ void AudioDriver_CalcLowShelf(float32_t coeffs[5], float32_t f0, float32_t S, fl
     // I take a divide by a constant instead !
     //    DCgain = (coeffs[B0] + coeffs[B1] + coeffs[B2]) / (1 - (- coeffs[A1] - coeffs[A2])); // takes into account that coeffs[A1] and coeffs[A2] are already negated!
 
-    float32_t DCgain = 1.0 * scaling; //
+    double DCgain = 1.0 * scaling; //
 
 
     AudioDriver_ScaleBiquadCoeffs(coeffs,scaling, DCgain);
@@ -3233,6 +3233,12 @@ static void AudioDriver_Demod_WFM(iq_buffer_t* iq_p, uint32_t blockSize)
          //   6   notch filter 19kHz to eliminate pilot tone from audio
                 //arm_biquad_cascade_df1_f32 (&biquad_WFM_notch_19k_R, float_buffer_R, float_buffer_L, WFM_DEC_SAMPLES);
                 //arm_biquad_cascade_df1_f32 (&biquad_WFM_notch_19k_L, FFT_buffer, iFFT_buffer, WFM_DEC_SAMPLES);
+
+              // this is the biquad filter, a highshelf filter
+              arm_biquad_cascade_df1_f32 (&IIR_biquad_2[0], adb.a_buffer[1],adb.a_buffer[1], blockSizeDec);
+              arm_biquad_cascade_df1_f32 (&IIR_biquad_2[1], adb.a_buffer[0],adb.a_buffer[0], blockSizeDec);
+
+
             }
             else
             {
@@ -3383,11 +3389,10 @@ static void AudioDriver_RxProcessor(IqSample_t * const srcCodec, AudioSample_t *
        //if(1)
 #ifdef USE_WFM
         if(dmod_mode == DEMOD_WFM)
-        {
-            AudioDriver_Demod_WFM(&adb.iq_buf, iqBlockSize); // has to demodulate and pack everything into adb.a_buffer[0], audio_blockSize and adb.a_buffer[1], audio_blockSize
-
-            //arm_fir_decimate_f32(&DECIMATE_DOWN_I, adb.iq_buf.i_buffer, adb.a_buffer[1], iqBlockSize );
-            //arm_fir_decimate_f32(&DECIMATE_DOWN_Q, adb.iq_buf.q_buffer, adb.a_buffer[0], iqBlockSize );
+        {   // audio sample rate has to be 192ksps in order for WFM to deliver nice audio
+            // this does WFM demodulation @192ksps, then does the decimation-by-4, lowpass filtering @15kHz and de-emphasis
+            // and delivers stereo Audio in adb.a_buffer
+            AudioDriver_Demod_WFM(&adb.iq_buf, iqBlockSize);
             signal_active = true;
         }
         else

--- a/mchf-eclipse/drivers/audio/audio_driver.h
+++ b/mchf-eclipse/drivers/audio/audio_driver.h
@@ -651,9 +651,9 @@ void AudioDriver_SetSamPllParameters (void);
 void AudioDriver_I2SCallback(AudioSample_t *audio, IqSample_t *iq, AudioSample_t *audioDst, int16_t size);
 
 
-void AudioDriver_CalcLowShelf(float32_t coeffs[5], float32_t f0, float32_t S, float32_t gain, float32_t FS);
-void AudioDriver_CalcHighShelf(float32_t coeffs[5], float32_t f0, float32_t S, float32_t gain, float32_t FS);
-void AudioDriver_CalcBandpass(float32_t coeffs[5], float32_t f0, float32_t FS, float32_t Q);
+void AudioDriver_CalcLowShelf(float32_t coeffs[5], double f0, double S, double gain, double FS);
+void AudioDriver_CalcHighShelf(float32_t coeffs[5], double f0, double S, double gain, double FS);
+void AudioDriver_CalcBandpass(float32_t coeffs[5], double f0, double FS, double Q);
 void AudioDriver_SetBiquadCoeffs(float32_t* coeffsTo,const float32_t* coeffsFrom);
 
 void AudioDriver_IQPhaseAdjust(uint16_t txrx_mode, float32_t* i_buffer, float32_t* q_buffer, const uint16_t blockSize);

--- a/mchf-eclipse/drivers/ui/radio_management.c
+++ b/mchf-eclipse/drivers/ui/radio_management.c
@@ -1535,6 +1535,18 @@ uint32_t RadioManagement_NextAlternativeDemodMode(uint32_t loc_mode)
             retval = DEMOD_AM;
         }
         break;
+#ifdef USE_WFM
+    case DEMOD_WFM:
+        if(ts.stereo_enable)
+        {
+            ts.stereo_enable = false;
+        }
+        else
+        {
+            ts.stereo_enable = true;
+        }
+        break;
+#endif
     case DEMOD_DIGI:
         ts.digi_lsb = !ts.digi_lsb;
         break;

--- a/mchf-eclipse/drivers/ui/ui_driver.c
+++ b/mchf-eclipse/drivers/ui/ui_driver.c
@@ -1549,7 +1549,7 @@ void UiDriver_DisplayDemodMode()
 		break;
     #ifdef USE_WFM
 	    case DEMOD_WFM:
-	        txt = "WFM";
+            txt = ts.stereo_enable?"STEREO":"MONO";
 	    break;
     #endif
 #endif
@@ -4402,7 +4402,9 @@ static void UiDriver_DisplayModulationType()
 	char txt_empty[]="       ";
 	char txt_SSB[]="SSB";
 	char txt_CW[]="CW";
-
+#ifdef USE_WFM
+	char txt_WFM[]="WFM";
+#endif
 	//const char* txt = digimodes[ts.digital_mode].label;
 	const char* txt;
 	switch(ts.dmod_mode)
@@ -4426,6 +4428,11 @@ static void UiDriver_DisplayModulationType()
 	case DEMOD_CW:
 		txt = txt_CW;
 		break;
+#ifdef USE_WFM
+	case DEMOD_WFM:
+	    txt = txt_WFM;
+	    break;
+#endif
 	default:
 		txt = txt_empty;
 	}

--- a/mchf-eclipse/hardware/uhsdr_board_config.h
+++ b/mchf-eclipse/hardware/uhsdr_board_config.h
@@ -92,7 +92,7 @@
 // only possible on the DDC/DUC RF board
 // and by using 192ksps sample rate for audio processing
 // tested on F7 & H7
-//#define USE_WFM
+#define USE_WFM
 
 // Fast convolution filtering
 // experimental at the moment DD4WH, 2018_08_18

--- a/mchf-eclipse/hardware/uhsdr_board_config.h
+++ b/mchf-eclipse/hardware/uhsdr_board_config.h
@@ -92,7 +92,7 @@
 // only possible on the DDC/DUC RF board
 // and by using 192ksps sample rate for audio processing
 // tested on F7 & H7
-#define USE_WFM
+//#define USE_WFM
 
 // Fast convolution filtering
 // experimental at the moment DD4WH, 2018_08_18


### PR DESCRIPTION
* added de-emphasis, North-American users must change the time constant from 50e-6 to 75e-6
* added 15kHz Butterworth response lowpass filter
* added high shelf filter (user changeable)
* optimized stereo separation and WFM gain level
* toggle demod button to manually switch between FM Stereo and FM Mono 
* on F7, MCU use is now at 60% for MONO and 79% for STEREO demodulation @192ksps sample rate
* small bugfixes for IIR filter coefficient calculations [all calculations now done with double precision, corrected wrong formulae]
